### PR TITLE
launcher: harden asset paths, DPI, and idle loop

### DIFF
--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -2687,9 +2687,31 @@ bool try_capture(LauncherModel* m, const SDL_Event& ev) {
     return true;
 }
 
+bool is_absolute_path(const std::string& path) {
+    if (path.empty()) return false;
+    if (path[0] == '/' || path[0] == '\\') return true;
+    if (path.size() >= 3 && path[1] == ':' &&
+        ((path[0] >= 'A' && path[0] <= 'Z') || (path[0] >= 'a' && path[0] <= 'z')) &&
+        (path[2] == '/' || path[2] == '\\')) return true;
+    return false;
+}
+
+std::string normalized_path(const char* path) {
+    std::string out = path ? path : "";
+    for (char& ch : out)
+        if (ch == '\\') ch = '/';
+    return out;
+}
+
 std::string asset(const char* rel) {
+    std::string path = normalized_path(rel);
+    if (is_absolute_path(path)) return path;
+
     const char* base = SDL_GetBasePath();
-    return std::string(base ? base : "") + rel;
+    std::string out = normalized_path(base ? base : "");
+    if (!out.empty() && !path.empty() && out.back() != '/')
+        out.push_back('/');
+    return out + path;
 }
 
 } // namespace
@@ -2843,12 +2865,12 @@ extern "C" LngAction launcher_backend_run(LauncherPlatform* p,
         if (smoke_frames > 0 && ++frame > smoke_frames) { m->action = LNG_ACTION_QUIT; break; }
 
         SDL_Event ev;
-        while (SDL_PollEvent(&ev)) {
+        if (SDL_WaitEventTimeout(&ev, 16)) do {
             if (ev.type == SDL_EVENT_QUIT) p->should_quit = true;
             if (ev.type == SDL_EVENT_WINDOW_CLOSE_REQUESTED) p->should_quit = true;
             if (try_capture(m, ev)) continue;
             LNG_ImplSDL_ProcessEvent(&ev);
-        }
+        } while (SDL_PollEvent(&ev));
 
         launcher_platform_refresh_metrics(p);
         if (applied_scale != p->display_scale) {

--- a/src/common/launcher_platform_sdl2.c
+++ b/src/common/launcher_platform_sdl2.c
@@ -23,6 +23,12 @@ bool launcher_platform_open(LauncherPlatform* p, const char* title,
     SDL_zerop(p);
 
     SDL_SetMainReady();   // we built with SDL_MAIN_HANDLED (real main() is entry)
+#if defined(_WIN32)
+    // Match the Windows compatibility override users discovered manually:
+    // let the launcher own DPI scaling instead of being bitmap-scaled by the OS.
+    SDL_SetHint("SDL_WINDOWS_DPI_AWARENESS", "permonitorv2");
+    SDL_SetHint("SDL_WINDOWS_DPI_SCALING", "0");
+#endif
 #ifdef LNG_GLES2
     // The host links ANGLE's libGLESv2/libEGL; SDL must create the context
     // through that same ES library (via EGL), or the directly-linked ANGLE


### PR DESCRIPTION
## Summary
- Normalize launcher asset paths before loading textures/fonts so backslash-separated paths work under Wine/Linux.
- Set SDL2 Windows DPI-awareness hints before window creation to avoid OS bitmap scaling of the launcher UI.
- Wait briefly between idle frames so the launcher does not spin when vsync is ineffective.

## Related reports
- mstan/MegaManX6Recomp#1
- mstan/MegaManX6Recomp#3
- mstan/MegaManX4Recomp#3
- mstan/PokemonStadiumRecomp#19

## Verification
- cmake --build build
- LNG_SMOKE_FRAMES=3 ./build/recomp-ui-launcher.exe
- LNG_SMOKE_FRAMES=3 LNG_FORCE_SCALE=2 ./build/recomp-ui-launcher.exe