### PR TITLE
Improve netplay input and interface selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ password checks, member ordering, and synchronized launch signaling. The UI
 only presents that state and returns a `RecompLauncherCNetplayLaunch` result
 after the host starts the lobby.
 
+Hosts with more than one local network interface may implement the optional
+`local_address_get` callback to enumerate labeled address choices. The launcher
+prefills the first address, preserves the user's selection across refreshes,
+and falls back to the legacy single-address `local_ip` callback when the new
+callback is absent or returns no choices.
+
 The initial waiting-room UI supports two players. Direct clients bind to an
 ephemeral local UDP port, so a direct session requires only the host's exposed
 IP address and port.

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -1352,7 +1352,11 @@ void draw_source_selectables(LauncherModel* m, int p) {
 
 void draw_player_panel(LauncherModel* m, const LauncherTheme& th, int p, float w) {
     char id[24];  snprintf(id, sizeof(id), "player%d", p);
-    char eb[16];  snprintf(eb, sizeof(eb), "PLAYER %d", p + 1);
+    char eb[32];
+    if (p == 0 && m->netplay_supported)
+        snprintf(eb, sizeof(eb), "PLAYER 1 / NETPLAY");
+    else
+        snprintf(eb, sizeof(eb), "PLAYER %d", p + 1);
 
     if (!begin_panel(id, w, false)) { end_panel(); return; }
     ImGui::PushID(p);

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -2415,12 +2415,73 @@ void np_try_launch(LauncherModel* m) {
 void np_refresh_host_ip(LauncherModel* m) {
     const auto* np = np_cb(m);
     if (!np) return;
-    int ok = 0;
-    if (m->netplay_lan_only && np->local_ip)
-        ok = np->local_ip(np->ctx, m->netplay_host_ip, sizeof(m->netplay_host_ip));
-    else if (!m->netplay_lan_only && np->external_ip)
-        ok = np->external_ip(np->ctx, m->netplay_host_ip, sizeof(m->netplay_host_ip));
-    if (!ok) std::snprintf(m->netplay_host_ip, sizeof(m->netplay_host_ip), "Unavailable");
+    m->netplay_local_address_count = 0;
+
+    if (m->netplay_lan_only) {
+        if (np->local_address_get) {
+            for (int index = 0; index < LNG_NETPLAY_MAX_LOCAL_ADDRESSES; ++index) {
+                RecompLauncherCNetplayLocalAddress candidate{};
+                if (!np->local_address_get(np->ctx, index, &candidate)) break;
+                candidate.address[sizeof(candidate.address) - 1] = '\0';
+                candidate.label[sizeof(candidate.label) - 1] = '\0';
+                if (!candidate.address[0]) continue;
+
+                bool duplicate = false;
+                for (int existing = 0; existing < m->netplay_local_address_count; ++existing) {
+                    if (std::strcmp(m->netplay_local_addresses[existing].address,
+                                    candidate.address) == 0) {
+                        duplicate = true;
+                        break;
+                    }
+                }
+                if (!duplicate) {
+                    m->netplay_local_addresses[m->netplay_local_address_count++] = candidate;
+                }
+            }
+        }
+
+        // Older hosts expose one preferred address through local_ip only.
+        if (m->netplay_local_address_count == 0 && np->local_ip) {
+            RecompLauncherCNetplayLocalAddress candidate{};
+            if (np->local_ip(np->ctx, candidate.address, sizeof(candidate.address)) &&
+                candidate.address[0]) {
+                candidate.address[sizeof(candidate.address) - 1] = '\0';
+                std::snprintf(candidate.label, sizeof(candidate.label), "Local network");
+                m->netplay_local_addresses[m->netplay_local_address_count++] = candidate;
+            }
+        }
+
+        if (m->netplay_local_address_count > 0) {
+            int selected = 0;
+            const char* preferred = m->netplay_host_local_ip[0]
+                ? m->netplay_host_local_ip : m->netplay_host_ip;
+            for (int index = 0; index < m->netplay_local_address_count; ++index) {
+                if (std::strcmp(preferred, m->netplay_local_addresses[index].address) == 0) {
+                    selected = index;
+                    break;
+                }
+            }
+            std::snprintf(m->netplay_host_ip, sizeof(m->netplay_host_ip), "%s",
+                          m->netplay_local_addresses[selected].address);
+            std::snprintf(m->netplay_host_local_ip, sizeof(m->netplay_host_local_ip), "%s",
+                          m->netplay_local_addresses[selected].address);
+            return;
+        }
+    } else if (np->external_ip &&
+               np->external_ip(np->ctx, m->netplay_host_ip, sizeof(m->netplay_host_ip))) {
+        m->netplay_host_ip[sizeof(m->netplay_host_ip) - 1] = '\0';
+        return;
+    }
+
+    std::snprintf(m->netplay_host_ip, sizeof(m->netplay_host_ip), "Unavailable");
+}
+
+void np_format_local_address(const RecompLauncherCNetplayLocalAddress& address,
+                             char* out, size_t out_len) {
+    if (address.label[0])
+        std::snprintf(out, out_len, "%s (%s)", address.label, address.address);
+    else
+        std::snprintf(out, out_len, "%s", address.address);
 }
 
 void draw_netplay_player_modal(LauncherModel* m) {
@@ -2572,8 +2633,39 @@ void draw_netplay_host_modal(LauncherModel* m, const LauncherTheme& th) {
         ImGui::PushStyleColor(ImGuiCol_FrameBgActive, col(th.background));
         ImGui::PushStyleColor(ImGuiCol_Text, col(th.text_muted));
         ImGui::SetNextItemWidth(px(300));
-        ImGui::InputText("##host_ip", m->netplay_host_ip, sizeof(m->netplay_host_ip),
-                         ImGuiInputTextFlags_ReadOnly);
+        if (m->netplay_lan_only && m->netplay_local_address_count > 1) {
+            int selected = 0;
+            for (int index = 0; index < m->netplay_local_address_count; ++index) {
+                if (std::strcmp(m->netplay_host_ip,
+                                m->netplay_local_addresses[index].address) == 0) {
+                    selected = index;
+                    break;
+                }
+            }
+            char preview[144];
+            np_format_local_address(m->netplay_local_addresses[selected],
+                                    preview, sizeof(preview));
+            if (ImGui::BeginCombo("##host_ip", preview)) {
+                for (int index = 0; index < m->netplay_local_address_count; ++index) {
+                    char choice[144];
+                    np_format_local_address(m->netplay_local_addresses[index],
+                                            choice, sizeof(choice));
+                    const bool is_selected = index == selected;
+                    if (ImGui::Selectable(choice, is_selected)) {
+                        std::snprintf(m->netplay_host_ip, sizeof(m->netplay_host_ip), "%s",
+                                      m->netplay_local_addresses[index].address);
+                        std::snprintf(m->netplay_host_local_ip,
+                                      sizeof(m->netplay_host_local_ip), "%s",
+                                      m->netplay_local_addresses[index].address);
+                    }
+                    if (is_selected) ImGui::SetItemDefaultFocus();
+                }
+                ImGui::EndCombo();
+            }
+        } else {
+            ImGui::InputText("##host_ip", m->netplay_host_ip, sizeof(m->netplay_host_ip),
+                             ImGuiInputTextFlags_ReadOnly);
+        }
         ImGui::PopStyleColor(4);
         ImGui::EndGroup();
         ImGui::SameLine(0, px(10));

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -25,6 +25,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#define LNG_NETPLAY_MAX_LOCAL_ADDRESSES 8
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -290,6 +292,10 @@ typedef struct {
     char      netplay_host_password[64];
     char      netplay_host_port[16];
     char      netplay_host_ip[64];
+    char      netplay_host_local_ip[64];
+    int       netplay_local_address_count;
+    RecompLauncherCNetplayLocalAddress
+              netplay_local_addresses[LNG_NETPLAY_MAX_LOCAL_ADDRESSES];
     char      netplay_host_endpoint[96];
     bool      netplay_lan_only;
     bool      netplay_direct_modal_open;

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -59,6 +59,13 @@ typedef struct RecompLauncherCNetplayLaunch {
     int      input_delay;
 } RecompLauncherCNetplayLaunch;
 
+typedef struct RecompLauncherCNetplayLocalAddress {
+    /* Numeric address advertised to clients, currently normally IPv4. */
+    char address[64];
+    /* User-facing interface name, for example "Wi-Fi" or "Ethernet". */
+    char label[64];
+} RecompLauncherCNetplayLocalAddress;
+
 typedef struct RecompLauncherCNetplayCallbacks {
     void* ctx;
     /* Configuration and connection state are host-owned and may be persisted. */
@@ -94,6 +101,15 @@ typedef struct RecompLauncherCNetplayCallbacks {
     int  (*launch_pending)(void* ctx);
     void (*clear_launch_pending)(void* ctx);
     int  (*fill_launch)(void* ctx, RecompLauncherCNetplayLaunch* out);
+    /*
+     * Optional multi-interface address discovery. Called with indices starting
+     * at zero until it returns 0. The launcher clears out before each call;
+     * address must be non-empty on success and label may be empty. Append-only
+     * for compatibility with positional callback-table initializers; local_ip
+     * remains the fallback.
+     */
+    int  (*local_address_get)(void* ctx, int index,
+                              RecompLauncherCNetplayLocalAddress* out);
 } RecompLauncherCNetplayCallbacks;
 
 // Plain-C mirror of the launcher's internal settings (bools as int).


### PR DESCRIPTION
## Summary
- label the first controller card as `PLAYER 1 / NETPLAY` for netplay-enabled launchers while preserving `PLAYER 1` elsewhere
- add an optional, append-only callback for labeled local network addresses
- prefill the preferred address and show a selector when multiple interfaces are available
- retain the existing single-address callback as a compatibility fallback

## Validation
- standalone MinGW/Ninja launcher build succeeds
- Metal Warriors integration build and real launcher screenshots verify the label and multi-interface selector