### PR TITLE
Add reusable cross-platform runtime settings overlay

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,13 +39,15 @@ include(CTest)
 if(BUILD_TESTING)
     add_executable(recomp-runtime-ui-test
         tests/runtime_ui_test.c
-        src/common/recomp_runtime_ui.c)
+        src/common/recomp_runtime_ui.c
+        src/common/recomp_runtime_settings.c)
     target_include_directories(recomp-runtime-ui-test PRIVATE src)
-    add_test(NAME recomp-runtime-ui COMMAND recomp-runtime-ui-test)
+    add_test(NAME recomp-runtime-ui COMMAND $<TARGET_FILE:recomp-runtime-ui-test>)
 
     add_executable(recomp-runtime-ui-imgui-test
         tests/runtime_ui_imgui_test.cpp
         src/common/recomp_runtime_ui.c
+        src/common/recomp_runtime_settings.c
         src/common/backends/imgui/runtime_ui_imgui.cpp
         src/third_party/imgui/imgui.cpp
         src/third_party/imgui/imgui_draw.cpp
@@ -53,5 +55,5 @@ if(BUILD_TESTING)
         src/third_party/imgui/imgui_widgets.cpp)
     target_include_directories(recomp-runtime-ui-imgui-test PRIVATE
         src src/common src/third_party/imgui)
-    add_test(NAME recomp-runtime-ui-imgui COMMAND recomp-runtime-ui-imgui-test)
+    add_test(NAME recomp-runtime-ui-imgui COMMAND $<TARGET_FILE:recomp-runtime-ui-imgui-test>)
 endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,3 +34,24 @@ target_link_libraries(recomp-ui-launcher PRIVATE SDL2::SDL2 ${RUI_GL_LIBS})
 
 include(${CMAKE_CURRENT_SOURCE_DIR}/recomp_ui.cmake)
 recomp_target_launcher_ui(recomp-ui-launcher)
+
+include(CTest)
+if(BUILD_TESTING)
+    add_executable(recomp-runtime-ui-test
+        tests/runtime_ui_test.c
+        src/common/recomp_runtime_ui.c)
+    target_include_directories(recomp-runtime-ui-test PRIVATE src)
+    add_test(NAME recomp-runtime-ui COMMAND recomp-runtime-ui-test)
+
+    add_executable(recomp-runtime-ui-imgui-test
+        tests/runtime_ui_imgui_test.cpp
+        src/common/recomp_runtime_ui.c
+        src/common/backends/imgui/runtime_ui_imgui.cpp
+        src/third_party/imgui/imgui.cpp
+        src/third_party/imgui/imgui_draw.cpp
+        src/third_party/imgui/imgui_tables.cpp
+        src/third_party/imgui/imgui_widgets.cpp)
+    target_include_directories(recomp-runtime-ui-imgui-test PRIVATE
+        src src/common src/third_party/imgui)
+    add_test(NAME recomp-runtime-ui-imgui COMMAND recomp-runtime-ui-imgui-test)
+endif()

--- a/README.md
+++ b/README.md
@@ -120,9 +120,9 @@ rollout matrix.
 ```c
 static const RecompRuntimeUiItem rows[] = {
     { "fullscreen", "Display", "Fullscreen", "Choose the window mode.",
-      RECOMP_RUNTIME_UI_CHOICE, 0, 2, 1, modes, 3 },
+      RECOMP_RUNTIME_UI_CHOICE, 0, 2, 1, modes, 3, NULL },
     { "reset", "System", "Reset game", "Reset the emulated machine.",
-      RECOMP_RUNTIME_UI_ACTION, 0, 0, 0, NULL, 0 },
+      RECOMP_RUNTIME_UI_ACTION, 0, 0, 0, NULL, 0, NULL },
 };
 
 RecompRuntimeUiConfig menu = {0};

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # recomp-ui
 
-A shared, **console-agnostic pre-boot launcher** for static-recompilation game
-ports. One Dear ImGui launcher core serves every recomp ecosystem — SNES, PSX,
-N64, Genesis, NES, and beyond — so each game gets a polished settings/ROM/
-controller front-end with **zero UI code of its own**.
+A shared, **console-agnostic launcher and in-game settings UI** for static-
+recompilation game ports. One Dear ImGui launcher core serves every recomp
+ecosystem — SNES, PSX, N64, Genesis, NES, and beyond — while a small runtime
+overlay API lets the same hosts expose live settings after boot.
 
 It is the reusable extraction of the SNES-recomp "launcher_ng" launcher,
 generalized behind a small C ABI. Consume it as a git submodule, hand it your
@@ -91,6 +91,59 @@ The whole contract is [`src/recomp_launcher.h`](src/recomp_launcher.h): a plain-
 settings struct in/out, a game-facts struct, and (optionally) **host callbacks**
 for console-specific verification the launcher re-runs on change — e.g. PSX disc
 identification (`disc_verify`) and memory-card inspection (`memcard_inspect`).
+
+### In-game settings overlay
+
+[`src/recomp_runtime_ui.h`](src/recomp_runtime_ui.h) is the separate runtime
+contract. A game supplies sectioned item descriptors plus callbacks to read,
+apply, persist, and enable its own settings. `recomp-ui` owns hierarchical
+navigation, selection state, help/status text, and drawing.
+
+The runtime model is renderer-independent. For a modern/GPU host, call
+`recomp_runtime_ui_render_imgui()` inside the host's active Dear ImGui frame;
+it uses the same responsive layout and console theme tokens as the launcher,
+without exposing ImGui types through the C ABI. This is the preferred path for
+RT64/N64 and other high-resolution renderers.
+
+`recomp_runtime_ui_render_argb8888()` is a compatibility presentation for
+games that expose a writable CPU framebuffer. It is intentionally compact and
+works well for low-resolution framebuffer consoles, but it is not the visual
+baseline for every platform. Both presentations drive the exact same menu
+state, descriptors, callbacks, and navigation.
+
+The host continues to own the game loop: while
+`recomp_runtime_ui_is_open()` is true it should consume menu input before
+emulated input and decide whether to pause simulation/audio. See
+[`docs/RUNTIME_UI.md`](docs/RUNTIME_UI.md) for the integration boundary and
+rollout matrix.
+
+```c
+static const RecompRuntimeUiItem rows[] = {
+    { "fullscreen", "Display", "Fullscreen", "Choose the window mode.",
+      RECOMP_RUNTIME_UI_CHOICE, 0, 2, 1, modes, 3 },
+    { "reset", "System", "Reset game", "Reset the emulated machine.",
+      RECOMP_RUNTIME_UI_ACTION, 0, 0, 0, NULL, 0 },
+};
+
+RecompRuntimeUiConfig menu = {0};
+menu.title = "My Game";
+menu.subtitle = "SETTINGS";
+menu.items = rows;
+menu.item_count = sizeof(rows) / sizeof(rows[0]);
+menu.callbacks = callbacks;
+menu.theme = "n64"; /* same id used by launcher_profile_apply() */
+RecompRuntimeUi *ui = recomp_runtime_ui_create(&menu);
+```
+
+New integrations should zero-initialize `RecompRuntimeUiConfig`, then assign
+its fields. Set `theme` to the same system id passed to
+`launcher_profile_apply()` (`"snes"`, `"n64"`, `"gba"`, `"genesis"`, ...),
+so pre-boot and in-game UI cannot drift visually.
+
+The API deliberately does not prescribe settings. Backend swaps that require a
+restart can be omitted or exposed as actions; safe live values can be applied
+immediately in `set_value`. This keeps game-specific state and policy in the
+game while making the menu implementation reusable.
 
 ### Optional netplay surface
 

--- a/docs/RUNTIME_UI.md
+++ b/docs/RUNTIME_UI.md
@@ -1,0 +1,76 @@
+# Runtime UI architecture
+
+The in-game menu is cross-platform at the model and design-system layers. It
+does not assume a console, emulator core, game configuration structure, window
+library, or GPU API.
+
+## Ownership
+
+`recomp-ui` owns:
+
+- item/section descriptors and callbacks;
+- navigation, selection, enabled state, status, and persistence requests;
+- the shared `LauncherTheme` design tokens;
+- a modern active-context ImGui presentation;
+- a compact ARGB8888 framebuffer fallback.
+
+The game host owns:
+
+- translating SDL/native events into semantic menu inputs;
+- applying settings to its live renderer, audio, and emulated machine;
+- config-file format and persistence;
+- pause/resume policy and input suppression;
+- beginning/submitting the renderer frame.
+
+That boundary is necessary: recomp-ui cannot safely pause an N64 recomp, reset
+a GBA core, or recreate a Genesis renderer without the host's lifecycle rules.
+
+## Presentation choices
+
+| Host shape | Presentation | Notes |
+|---|---|---|
+| Existing runtime ImGui (for example RT64) | `recomp_runtime_ui_render_imgui` | Preferred; host owns context and draw submission. |
+| GPU host that can add an ImGui frame | `recomp_runtime_ui_render_imgui` | Preferred; use the existing recomp-ui ImGui dependency. |
+| Writable low-resolution CPU framebuffer | `recomp_runtime_ui_render_argb8888` | Compatibility fallback; compact by design. |
+| Different UI toolkit | Implement a presentation over the shared model | Do not duplicate settings behavior or console policy. |
+
+The ImGui presentation is responsive: wide windows show persistent section
+navigation beside the selected page; narrow windows use a drill-in hierarchy.
+Both use the same palette, spacing, radius, and semantic colors as the launcher.
+An N64 host therefore gets the clean graphite/red/blue N64 theme with no CRT
+scanlines; SNES uses its console theme; handheld themes remain flat rather than
+pretending to be a CRT.
+
+## What “every recomp-ui game” requires
+
+Consuming recomp-ui is the anchor, but updating the git submodule alone cannot
+inject an in-game frame into an arbitrary host loop. Universal rollout needs
+one small adapter for each host/runtime family, not one implementation per
+game:
+
+1. create the shared runtime model with that game's supported settings;
+2. route menu input before emulated input;
+3. call the appropriate presentation in the host's render frame;
+4. pause or continue simulation according to that host's policy;
+5. apply and persist values through callbacks.
+
+Games built from the same host template should share that adapter. Per-game
+code should be limited to capabilities, labels/choices, and live-setting
+callbacks. Console detection must never select behavior in the runtime core;
+the system id selects design tokens only.
+
+## Portability rules
+
+- Do not add console-specific keys or settings to `recomp_runtime_ui.c`.
+- Do not make the ARGB8888 fallback the required render path.
+- Do not create or destroy a host's ImGui context in
+  `recomp_runtime_ui_render_imgui`.
+- Use the same choice arrays for pre-boot and runtime settings when both expose
+  a value.
+- The shared `save` callback follows successful value changes. Actions own any
+  persistence they require and do not implicitly rewrite the settings file.
+- Keep input semantic (`ACCEPT`, `BACK`, directions); hosts choose physical
+  buttons and supply their prompt labels.
+- Prefer UTF-8-capable modern presentation; the compact fallback is ASCII-only.
+- A renderer/backend switch that cannot be applied live should remain in the
+  pre-boot launcher until the host provides a safe restart workflow.

--- a/recomp_ui.cmake
+++ b/recomp_ui.cmake
@@ -91,6 +91,7 @@ function(recomp_target_launcher_ui TGT)
         ${RUI_SRC}/common/launcher_debug.c
         ${RUI_SRC}/common/launcher_binds.c
         ${RUI_SRC}/common/launcher_udp_port.c  # host-lobby UDP port probe / auto-pick
+        ${RUI_SRC}/common/recomp_runtime_ui.c # renderer-agnostic in-game overlay
         ${RUI_SRC}/common/launcher_ng_capi.c   # implements recomp_launcher_run_window()
         ${RUI_SRC}/third_party/tinyfiledialogs.c
         # console-specific helpers (src/consoles/<id>/) — always compiled, only
@@ -111,6 +112,7 @@ function(recomp_target_launcher_ui TGT)
         # Dear ImGui backend (the shipping UI) + vendored ImGui core/backends
         # (the latter omitted when a host provides its own — see above)
         ${RUI_SRC}/common/backends/imgui/launcher_imgui.cpp
+        ${RUI_SRC}/common/backends/imgui/runtime_ui_imgui.cpp
         ${_rui_imgui_sources}
     )
 

--- a/recomp_ui.cmake
+++ b/recomp_ui.cmake
@@ -92,6 +92,7 @@ function(recomp_target_launcher_ui TGT)
         ${RUI_SRC}/common/launcher_binds.c
         ${RUI_SRC}/common/launcher_udp_port.c  # host-lobby UDP port probe / auto-pick
         ${RUI_SRC}/common/recomp_runtime_ui.c # renderer-agnostic in-game overlay
+        ${RUI_SRC}/common/recomp_runtime_settings.c # shared cross-ecosystem setting catalog
         ${RUI_SRC}/common/launcher_ng_capi.c   # implements recomp_launcher_run_window()
         ${RUI_SRC}/third_party/tinyfiledialogs.c
         # console-specific helpers (src/consoles/<id>/) — always compiled, only

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -1643,7 +1643,7 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     if (!any_deep_display(m)) {
         // ---- legacy minimal surface (SNES/NES etc.) — aligned label grid -------
         float cw = ImGui::CalcTextSize("Linear filtering").x;   // widest legacy label
-        { float t = ImGui::CalcTextSize("Widescreen 16:9").x; if (t > cw) cw = t; }
+        { float t = ImGui::CalcTextSize("View mode").x; if (t > cw) cw = t; }
         if (m->has_integer_scale) { float t = ImGui::CalcTextSize("Integer scaling").x; if (t > cw) cw = t; }
         cw += px(18.0f);
         row_label("Window scale", th, cw);
@@ -1663,38 +1663,22 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
         row_label("Linear filtering", th, cw);
         bool filter = m->s.linear_filter != 0;
         if (ImGui::Checkbox("##filter", &filter)) launcher_model_toggle_filter(m);
-        if (m->adaptive_view_supported) {
-            row_label("Adaptive view", th, cw);
-            bool adaptive = m->s.adaptive_view != 0;
-            if (ImGui::Checkbox("##adaptive", &adaptive))
-                launcher_model_toggle_adaptive_view(m);
-            experimental_tag(th);
-        }
-        const bool adaptive_fullscreen = m->adaptive_view_supported &&
-                                         m->s.adaptive_view != 0 &&
-                                         m->s.fullscreen != 0;
-        if (m->aspect_mask || m->num_aspect_labels > 0) {   // PSX-style cycle, or a game-supplied vocabulary
-            if (adaptive_fullscreen) ImGui::BeginDisabled();
-            row_label("Aspect ratio", th, cw);
-            if (ImGui::Button(launcher_model_aspect_label(m), ImVec2(px(180), px(30))))
-                launcher_model_cycle_aspect(m);
-            if (m->aspect_experimental) experimental_tag(th);
-            if (adaptive_fullscreen) ImGui::EndDisabled();
-        } else if (m->widescreen_supported) {   // legacy module: only for games that support it
-            if (adaptive_fullscreen) ImGui::BeginDisabled();
-            row_label("Widescreen 16:9", th, cw);
-            bool ws = m->s.widescreen != 0;
-            if (ImGui::Checkbox("##ws", &ws)) launcher_model_toggle_widescreen(m);
+        if (m->aspect_mask || m->num_aspect_labels > 0 ||
+            m->widescreen_supported || m->adaptive_view_supported) {
+            row_label("View mode", th, cw);
+            if (ImGui::Button(launcher_model_view_mode_label(m),
+                              ImVec2(px(180), px(30))))
+                launcher_model_cycle_view_mode(m);
             experimental_tag(th);
             // Genesis-style "extra cells per side" stepper: only when the
             // console opts in (video.widescreen_cells) AND widescreen is on.
             const SystemProfile* wprof = (const SystemProfile*)m->profile;
-            if (wprof && wprof->video.widescreen_cells && m->s.widescreen != 0) {
+            if (wprof && wprof->video.widescreen_cells &&
+                m->s.widescreen != 0 && !m->s.adaptive_view) {
                 row_label("Extra cells / side", th, cw);
                 int d = 0; ws_cells_stepper("wscells", m, &d);
                 if (d) launcher_model_ws_cells_delta(m, d);
             }
-            if (adaptive_fullscreen) ImGui::EndDisabled();
         }
         // HD texture packs (NES module, Mesen hires.txt format): one line —
         //   [x] HD texture pack   …folder tail   [Browse]
@@ -1764,31 +1748,13 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     if (ImGui::Button(launcher_model_fullscreen_label(m), ImVec2(px(120), px(30))))
         launcher_model_cycle_fullscreen(m);
 
-    if (m->adaptive_view_supported) {
-        row_label("Adaptive view", th);
-        bool adaptive = m->s.adaptive_view != 0;
-        if (ImGui::Checkbox("##adaptive", &adaptive))
-            launcher_model_toggle_adaptive_view(m);
+    if (m->aspect_mask || m->num_aspect_labels > 0 ||
+        m->widescreen_supported || m->adaptive_view_supported) {
+        row_label("View mode", th);
+        if (ImGui::Button(launcher_model_view_mode_label(m),
+                          ImVec2(px(180), px(30))))
+            launcher_model_cycle_view_mode(m);
         experimental_tag(th);
-    }
-
-    const bool adaptive_fullscreen = m->adaptive_view_supported &&
-                                     m->s.adaptive_view != 0 &&
-                                     m->s.fullscreen != 0;
-    if (m->aspect_mask || m->num_aspect_labels > 0) {
-        if (adaptive_fullscreen) ImGui::BeginDisabled();
-        row_label("Aspect ratio", th);
-        if (ImGui::Button(launcher_model_aspect_label(m), ImVec2(px(180), px(30))))
-            launcher_model_cycle_aspect(m);
-        if (m->aspect_experimental) experimental_tag(th);
-        if (adaptive_fullscreen) ImGui::EndDisabled();
-    } else if (m->widescreen_supported) {
-        if (adaptive_fullscreen) ImGui::BeginDisabled();
-        row_label("Widescreen 16:9", th);
-        bool ws = m->s.widescreen != 0;
-        if (ImGui::Checkbox("##ws", &ws)) launcher_model_toggle_widescreen(m);
-        experimental_tag(th);
-        if (adaptive_fullscreen) ImGui::EndDisabled();
     }
 
     if (m->has_texture_filter) {

--- a/src/common/backends/imgui/runtime_ui_imgui.cpp
+++ b/src/common/backends/imgui/runtime_ui_imgui.cpp
@@ -1,0 +1,232 @@
+// Modern in-game presentation for the renderer-independent runtime UI model.
+// The host owns the ImGui context/frame/submission. This file only draws.
+
+#include "recomp_runtime_ui_internal.h"
+#include "launcher_theme.h"
+
+#include "imgui.h"
+
+#include <cstdio>
+
+namespace {
+
+ImVec4 col(const LngColor &c, float alpha = 1.0f) {
+    return ImVec4(c.r, c.g, c.b, c.a * alpha);
+}
+
+ImU32 u32(const LngColor &c, float alpha = 1.0f) {
+    return ImGui::ColorConvertFloat4ToU32(col(c, alpha));
+}
+
+void value_text(RecompRuntimeUi *ui, const RecompRuntimeUiItem *item,
+                char *out, size_t out_size) {
+    if (item->type == RECOMP_RUNTIME_UI_ACTION) {
+        std::snprintf(out, out_size, "OPEN");
+        return;
+    }
+    int value = 0;
+    if (!recomp_runtime_ui_current_value(ui, item, &value)) {
+        std::snprintf(out, out_size, "Unavailable");
+    } else if (item->type == RECOMP_RUNTIME_UI_BOOL) {
+        std::snprintf(out, out_size, "%s", value ? "On" : "Off");
+    } else if (item->type == RECOMP_RUNTIME_UI_CHOICE && item->choices &&
+               value >= item->minimum &&
+               static_cast<size_t>(value - item->minimum) < item->choice_count) {
+        std::snprintf(out, out_size, "%s", item->choices[value - item->minimum]);
+    } else {
+        std::snprintf(out, out_size, "%d", value);
+    }
+}
+
+void draw_sections(RecompRuntimeUi *ui, const LauncherTheme &theme,
+                   bool enter_on_click) {
+    for (size_t index = 0; index < ui->section_count; ++index) {
+        ImGui::PushID(static_cast<int>(index));
+        const bool selected = index == ui->section_index;
+        if (ImGui::Selectable(ui->sections[index], selected, 0,
+                              ImVec2(0.0f, theme.row_height))) {
+            ui->section_index = index;
+            if (enter_on_click) recomp_runtime_ui_enter_section(ui, index);
+        }
+        if (ImGui::IsItemHovered()) ui->section_index = index;
+        ImGui::PopID();
+    }
+}
+
+void draw_items(RecompRuntimeUi *ui, const LauncherTheme &theme) {
+    const size_t count = recomp_runtime_ui_section_item_count(
+        ui, ui->section_index);
+    for (size_t index = 0; index < count; ++index) {
+        const RecompRuntimeUiItem *item = recomp_runtime_ui_section_item(
+            ui, ui->section_index, index);
+        if (!item) continue;
+
+        const bool enabled = recomp_runtime_ui_item_enabled(ui, item) != 0;
+        const bool selected = ui->in_section && index == ui->row_index;
+        char value[128];
+        value_text(ui, item, value, sizeof(value));
+
+        ImGui::PushID(static_cast<int>(index));
+        if (!enabled) ImGui::BeginDisabled();
+        const ImVec2 start = ImGui::GetCursorScreenPos();
+        const float row_h = item->description && item->description[0]
+                                ? theme.row_height + theme.spacing_sm
+                                : theme.row_height;
+        if (ImGui::Selectable("##setting", selected, 0, ImVec2(0.0f, row_h))) {
+            ui->row_index = index;
+            ui->in_section = 1;
+            recomp_runtime_ui_adjust_current(ui, 1, 1, 0);
+        }
+        if (ImGui::IsItemHovered()) {
+            ui->row_index = index;
+            ui->in_section = 1;
+        }
+
+        ImDrawList *draw = ImGui::GetWindowDrawList();
+        const ImVec2 end = ImGui::GetItemRectMax();
+        const ImU32 label_color = u32(enabled ? theme.text : theme.text_muted,
+                                      enabled ? 1.0f : 0.65f);
+        draw->AddText(ImVec2(start.x + theme.spacing_md,
+                            start.y + theme.spacing_sm),
+                      label_color, item->label ? item->label : "");
+        const ImVec2 value_size = ImGui::CalcTextSize(value);
+        draw->AddText(ImVec2(end.x - theme.spacing_md - value_size.x,
+                            start.y + theme.spacing_sm),
+                      u32(selected && enabled ? theme.accent2 : theme.text_muted),
+                      value);
+        if (item->description && item->description[0]) {
+            draw->AddText(ImVec2(start.x + theme.spacing_md,
+                                start.y + theme.spacing_sm +
+                                    ImGui::GetTextLineHeight() + 2.0f),
+                          u32(theme.text_muted), item->description);
+        }
+        if (!enabled) ImGui::EndDisabled();
+        ImGui::PopID();
+    }
+}
+
+void push_runtime_style(const LauncherTheme &theme) {
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowRounding, theme.radius_lg);
+    ImGui::PushStyleVar(ImGuiStyleVar_ChildRounding, theme.radius_sm);
+    ImGui::PushStyleVar(ImGuiStyleVar_FrameRounding, theme.radius_sm);
+    ImGui::PushStyleVar(ImGuiStyleVar_WindowPadding,
+                        ImVec2(theme.spacing_lg, theme.spacing_lg));
+    ImGui::PushStyleVar(ImGuiStyleVar_ItemSpacing,
+                        ImVec2(theme.spacing_sm, theme.spacing_sm));
+    ImGui::PushStyleColor(ImGuiCol_WindowBg, col(theme.background, 0.98f));
+    ImGui::PushStyleColor(ImGuiCol_ChildBg, col(theme.panel, 0.96f));
+    ImGui::PushStyleColor(ImGuiCol_Border, col(theme.border));
+    ImGui::PushStyleColor(ImGuiCol_Text, col(theme.text));
+    ImGui::PushStyleColor(ImGuiCol_TextDisabled, col(theme.text_muted));
+    ImGui::PushStyleColor(ImGuiCol_Header, col(theme.control_hovered));
+    ImGui::PushStyleColor(ImGuiCol_HeaderHovered, col(theme.panel_hovered));
+    ImGui::PushStyleColor(ImGuiCol_HeaderActive, col(theme.accent_dim));
+    ImGui::PushStyleColor(ImGuiCol_Button, col(theme.control));
+    ImGui::PushStyleColor(ImGuiCol_ButtonHovered, col(theme.control_hovered));
+    ImGui::PushStyleColor(ImGuiCol_ButtonActive, col(theme.accent_dim));
+}
+
+void pop_runtime_style() {
+    ImGui::PopStyleColor(11);
+    ImGui::PopStyleVar(5);
+}
+
+} // namespace
+
+extern "C" void recomp_runtime_ui_render_imgui(RecompRuntimeUi *ui) {
+    if (!ui || !ui->open || ImGui::GetCurrentContext() == nullptr) return;
+
+    const LauncherTheme theme = launcher_theme_by_name(ui->config.theme);
+    ImGuiIO &io = ImGui::GetIO();
+    const ImVec2 display = io.DisplaySize;
+    if (display.x <= 0.0f || display.y <= 0.0f) return;
+
+    ImGui::GetBackgroundDrawList()->AddRectFilled(
+        ImVec2(0.0f, 0.0f), display, IM_COL32(0, 0, 0, 150));
+
+    const float margin = 24.0f;
+    const float width = display.x - margin * 2.0f < 780.0f
+                            ? display.x - margin * 2.0f
+                            : 780.0f;
+    const float height = display.y - margin * 2.0f < 680.0f
+                             ? display.y - margin * 2.0f
+                             : 680.0f;
+    const bool wide = width >= 640.0f;
+    ImGui::SetNextWindowPos(ImVec2(display.x * 0.5f, display.y * 0.5f),
+                            ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(ImVec2(width, height), ImGuiCond_Always);
+
+    push_runtime_style(theme);
+    const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration |
+                                   ImGuiWindowFlags_NoMove |
+                                   ImGuiWindowFlags_NoSavedSettings;
+    if (ImGui::Begin("##recomp-runtime-ui", nullptr, flags)) {
+        ImGui::PushStyleColor(ImGuiCol_Text, col(theme.accent2));
+        ImGui::TextUnformatted(ui->config.title ? ui->config.title : "Settings");
+        ImGui::PopStyleColor();
+        if (ui->config.subtitle && ui->config.subtitle[0]) {
+            ImGui::SameLine();
+            const float subtitle_w = ImGui::CalcTextSize(ui->config.subtitle).x;
+            ImGui::SetCursorPosX(ImGui::GetWindowWidth() -
+                                 ImGui::GetStyle().WindowPadding.x - subtitle_w);
+            ImGui::TextDisabled("%s", ui->config.subtitle);
+        }
+        ImGui::Separator();
+
+        const float footer_h = ImGui::GetTextLineHeightWithSpacing() +
+                               theme.spacing_lg + 2.0f;
+        const float content_h = ImGui::GetContentRegionAvail().y - footer_h;
+        if (wide) {
+            const float sidebar_w = 190.0f;
+            ImGui::BeginChild("##sections", ImVec2(sidebar_w, content_h), true);
+            draw_sections(ui, theme, false);
+            ImGui::EndChild();
+            ImGui::SameLine();
+            ImGui::BeginChild("##items", ImVec2(0.0f, content_h), true);
+            ImGui::PushStyleColor(ImGuiCol_Text, col(theme.accent2));
+            ImGui::TextUnformatted(ui->sections[ui->section_index]);
+            ImGui::PopStyleColor();
+            ImGui::Separator();
+            draw_items(ui, theme);
+            ImGui::EndChild();
+        } else {
+            ImGui::BeginChild("##content", ImVec2(0.0f, content_h), true);
+            if (ui->in_section) {
+                if (ImGui::SmallButton("< Back"))
+                    recomp_runtime_ui_leave_section(ui);
+                ImGui::SameLine();
+                ImGui::TextUnformatted(ui->sections[ui->section_index]);
+                ImGui::Separator();
+                draw_items(ui, theme);
+            } else {
+                draw_sections(ui, theme, true);
+            }
+            ImGui::EndChild();
+        }
+
+        ImGui::Separator();
+        const char *accept = ui->config.accept_label
+                                 ? ui->config.accept_label : "Select";
+        const char *back = ui->config.back_label
+                               ? ui->config.back_label : "Back";
+        ImGui::TextDisabled("%s  Select    %s  Back    D-pad / Arrows  Navigate",
+                            accept, back);
+        if (ui->status_frames) {
+            ImGui::SameLine();
+            ImGui::PushStyleColor(ImGuiCol_Text, col(theme.accent2));
+            ImGui::TextUnformatted(ui->status);
+            ImGui::PopStyleColor();
+            --ui->status_frames;
+        }
+        ImGui::SameLine();
+        const char *close_label = "Resume";
+        const float close_w = ImGui::CalcTextSize(close_label).x +
+                              theme.spacing_lg * 2.0f;
+        ImGui::SetCursorPosX(ImGui::GetWindowWidth() -
+                             ImGui::GetStyle().WindowPadding.x - close_w);
+        if (ImGui::Button(close_label, ImVec2(close_w, 0.0f)))
+            recomp_runtime_ui_close(ui);
+    }
+    ImGui::End();
+    pop_runtime_style();
+}

--- a/src/common/backends/imgui/runtime_ui_imgui.cpp
+++ b/src/common/backends/imgui/runtime_ui_imgui.cpp
@@ -29,10 +29,19 @@ void value_text(RecompRuntimeUi *ui, const RecompRuntimeUiItem *item,
         std::snprintf(out, out_size, "Unavailable");
     } else if (item->type == RECOMP_RUNTIME_UI_BOOL) {
         std::snprintf(out, out_size, "%s", value ? "On" : "Off");
-    } else if (item->type == RECOMP_RUNTIME_UI_CHOICE && item->choices &&
-               value >= item->minimum &&
-               static_cast<size_t>(value - item->minimum) < item->choice_count) {
-        std::snprintf(out, out_size, "%s", item->choices[value - item->minimum]);
+    } else if (item->type == RECOMP_RUNTIME_UI_CHOICE && item->choices) {
+        size_t index = item->choice_count;
+        if (item->choice_values) {
+            for (size_t i = 0; i < item->choice_count; ++i)
+                if (item->choice_values[i] == value) { index = i; break; }
+        } else if (value >= item->minimum &&
+                   static_cast<size_t>(value - item->minimum) < item->choice_count) {
+            index = static_cast<size_t>(value - item->minimum);
+        }
+        if (index < item->choice_count)
+            std::snprintf(out, out_size, "%s", item->choices[index]);
+        else
+            std::snprintf(out, out_size, "Unavailable");
     } else {
         std::snprintf(out, out_size, "%d", value);
     }

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -493,6 +493,77 @@ void launcher_model_toggle_adaptive_view(LauncherModel* m) {
     m->s.adaptive_view = !m->s.adaptive_view;
 }
 
+static int aspect_choice_count(const LauncherModel* m) {
+    if (m->aspect_labels && m->num_aspect_labels > 0)
+        return m->num_aspect_labels;
+    if (!m->aspect_mask) return 0;
+    int count = 0;
+    for (int i = 0; i < 3; ++i)
+        if (launcher_model_aspect_offered(m, i)) ++count;
+    return count;
+}
+
+static int first_offered_aspect(const LauncherModel* m) {
+    if (m->aspect_labels && m->num_aspect_labels > 0) return 0;
+    for (int i = 0; i < 3; ++i)
+        if (launcher_model_aspect_offered(m, i)) return i;
+    return 0;
+}
+
+static int next_offered_aspect(const LauncherModel* m, int current) {
+    if (m->aspect_labels && m->num_aspect_labels > 0) {
+        int next = current + 1;
+        return next < m->num_aspect_labels ? next : -1;
+    }
+    for (int i = current + 1; i < 3; ++i)
+        if (launcher_model_aspect_offered(m, i)) return i;
+    return -1;
+}
+
+void launcher_model_cycle_view_mode(LauncherModel* m) {
+    if (!m) return;
+    const int fixed_count = aspect_choice_count(m);
+
+    if (m->s.adaptive_view && m->adaptive_view_supported) {
+        m->s.adaptive_view = 0;
+        if (fixed_count) m->s.aspect_index = first_offered_aspect(m);
+        else m->s.widescreen = 0;
+        return;
+    }
+
+    if (fixed_count) {
+        int next = next_offered_aspect(m, m->s.aspect_index);
+        if (next >= 0) {
+            m->s.aspect_index = next;
+            return;
+        }
+        if (m->adaptive_view_supported) {
+            m->s.adaptive_view = 1;
+            return;
+        }
+        m->s.aspect_index = first_offered_aspect(m);
+        return;
+    }
+
+    if (m->widescreen_supported && !m->s.widescreen) {
+        m->s.widescreen = 1;
+        return;
+    }
+    if (m->adaptive_view_supported) {
+        m->s.widescreen = 0;
+        m->s.adaptive_view = 1;
+        return;
+    }
+    m->s.widescreen = 0;
+}
+
+const char* launcher_model_view_mode_label(const LauncherModel* m) {
+    if (!m) return "Native";
+    if (m->adaptive_view_supported && m->s.adaptive_view) return "Adaptive";
+    if (aspect_choice_count(m)) return launcher_model_aspect_label(m);
+    return m->s.widescreen ? "16:9 fixed" : "Native";
+}
+
 void launcher_model_ws_cells_delta(LauncherModel* m, int delta) {
     const SystemProfile* prof = (const SystemProfile*)m->profile;
     if (!prof || !prof->video.widescreen_cells) return;   // gated per console

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -365,6 +365,11 @@ void launcher_model_cycle_scale(LauncherModel* m);   // 1..6 wrap
 void launcher_model_toggle_filter(LauncherModel* m);
 void launcher_model_toggle_widescreen(LauncherModel* m);  // gated
 void launcher_model_toggle_adaptive_view(LauncherModel* m);  // gated; fixed aspect is retained
+/* Unified Native / fixed widescreen / Adaptive control. Compatibility fields
+ * (`widescreen`, `aspect_index`, `adaptive_view`) remain the host ABI, but UI
+ * presents them as one mode instead of unrelated toggles. */
+void launcher_model_cycle_view_mode(LauncherModel* m);
+const char* launcher_model_view_mode_label(const LauncherModel* m);
 
 // ---- widescreen extra cells (SystemProfile.video.widescreen_cells consoles,
 // e.g. Genesis: N extra 8-px background cells rendered per side while

--- a/src/common/recomp_runtime_settings.c
+++ b/src/common/recomp_runtime_settings.c
@@ -1,0 +1,169 @@
+#include "recomp_runtime_ui_internal.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+static const char *const kFullscreenChoices[] = {
+    "Windowed", "Borderless", "Exclusive"
+};
+static const char *const kTextureFilterChoices[] = { "Nearest", "Linear" };
+
+static int has(RecompRuntimeUiStandardFeatures features,
+               RecompRuntimeUiStandardFeatures feature) {
+    return (features & feature) != 0;
+}
+
+static void add_item(RecompRuntimeUiItem *items, size_t *count,
+                     const char *key, const char *section, const char *label,
+                     const char *description, RecompRuntimeUiItemType type,
+                     int minimum, int maximum, int step,
+                     const char *const *choices, size_t choice_count,
+                     const int *choice_values) {
+    RecompRuntimeUiItem *item = &items[(*count)++];
+    memset(item, 0, sizeof(*item));
+    item->key = key;
+    item->section = section;
+    item->label = label;
+    item->description = description;
+    item->type = type;
+    item->minimum = minimum;
+    item->maximum = maximum;
+    item->step = step;
+    item->choices = choices;
+    item->choice_count = choice_count;
+    item->choice_values = choice_values;
+}
+
+RecompRuntimeUi *recomp_runtime_ui_create_standard(
+    const RecompRuntimeUiStandardConfig *standard) {
+    if (!standard) return NULL;
+    size_t standard_count = 0;
+    RecompRuntimeUiStandardFeatures f = standard->features;
+    for (unsigned bit = 0; bit < 64; ++bit)
+        if (f & (UINT64_C(1) << bit)) ++standard_count;
+    size_t total = standard_count + standard->extra_item_count;
+    if (!total) return NULL;
+
+    RecompRuntimeUiItem *items = (RecompRuntimeUiItem *)calloc(total, sizeof(*items));
+    if (!items) return NULL;
+    const char **view_choices = NULL;
+    int *view_values = NULL;
+    size_t view_count = 0;
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_VIEW_MODE)) {
+        unsigned modes = standard->view_modes | RECOMP_RUNTIME_UI_VIEW_MODE_NATIVE;
+        for (unsigned i = 0; i < 3; ++i)
+            if (modes & (1u << i)) ++view_count;
+        view_choices = (const char **)calloc(view_count, sizeof(*view_choices));
+        view_values = (int *)calloc(view_count, sizeof(*view_values));
+        if (!view_choices || !view_values) {
+            free(items); free(view_choices); free(view_values);
+            return NULL;
+        }
+        size_t out = 0;
+        if (modes & RECOMP_RUNTIME_UI_VIEW_MODE_NATIVE) {
+            view_choices[out] = standard->native_view_label
+                                    ? standard->native_view_label : "Native";
+            view_values[out++] = RECOMP_RUNTIME_UI_VIEW_NATIVE;
+        }
+        if (modes & RECOMP_RUNTIME_UI_VIEW_MODE_FIXED_16_9) {
+            view_choices[out] = standard->fixed_view_label
+                                    ? standard->fixed_view_label : "16:9 fixed";
+            view_values[out++] = RECOMP_RUNTIME_UI_VIEW_FIXED_16_9;
+        }
+        if (modes & RECOMP_RUNTIME_UI_VIEW_MODE_ADAPTIVE) {
+            view_choices[out] = standard->adaptive_view_label
+                                    ? standard->adaptive_view_label : "Adaptive";
+            view_values[out++] = RECOMP_RUNTIME_UI_VIEW_ADAPTIVE;
+        }
+    }
+
+    size_t count = 0;
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_FULLSCREEN))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_FULLSCREEN, "Display",
+                 "Fullscreen", "Choose windowed or fullscreen output.",
+                 RECOMP_RUNTIME_UI_CHOICE, 0, 2, 1, kFullscreenChoices, 3, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_WINDOW_SCALE))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_WINDOW_SCALE, "Display",
+                 "Window scale", "Resize the window in native-size steps.",
+                 RECOMP_RUNTIME_UI_INT, 1,
+                 standard->window_scale_max > 0 ? standard->window_scale_max : 8,
+                 1, NULL, 0, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_VIEW_MODE))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_VIEW_MODE, "Display",
+                 "View mode", "Native, fixed widescreen, or live window aspect.",
+                 RECOMP_RUNTIME_UI_CHOICE, 0, 2, 1, view_choices, view_count,
+                 view_values);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_WIDESCREEN_HUD))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_WIDESCREEN_HUD, "Display",
+                 "Edge HUD", "Anchor status groups to widescreen edges.",
+                 RECOMP_RUNTIME_UI_BOOL, 0, 1, 1, NULL, 0, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_INTEGER_SCALE))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_INTEGER_SCALE, "Graphics",
+                 "Integer scaling", "Snap output to whole native-pixel multiples.",
+                 RECOMP_RUNTIME_UI_BOOL, 0, 1, 1, NULL, 0, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_LINEAR_FILTER))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_LINEAR_FILTER, "Graphics",
+                 "Linear filter", "Smooth the final game image.",
+                 RECOMP_RUNTIME_UI_BOOL, 0, 1, 1, NULL, 0, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_TEXTURE_FILTER))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_TEXTURE_FILTER, "Graphics",
+                 "Texture filtering", "Choose nearest or linear sampling.",
+                 RECOMP_RUNTIME_UI_CHOICE, 0, 1, 1, kTextureFilterChoices, 2, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_RESOLUTION_SCALE))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_RESOLUTION_SCALE, "Graphics",
+                 "Resolution scale", "Set the internal rendering resolution.",
+                 RECOMP_RUNTIME_UI_INT, 1,
+                 standard->resolution_scale_max > 0 ? standard->resolution_scale_max : 8,
+                 1, NULL, 0, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_COLOR_CORRECTION))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_COLOR_CORRECTION, "Graphics",
+                 "Color correction", "Use display-aware handheld color correction.",
+                 RECOMP_RUNTIME_UI_BOOL, 0, 1, 1, NULL, 0, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_LCD_GHOSTING))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_LCD_GHOSTING, "Graphics",
+                 "LCD ghosting", "Simulate the original LCD response.",
+                 RECOMP_RUNTIME_UI_BOOL, 0, 1, 1, NULL, 0, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_AUDIO))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_AUDIO, "Audio", "Audio",
+                 "Enable or mute game audio output.", RECOMP_RUNTIME_UI_BOOL,
+                 0, 1, 1, NULL, 0, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_VOLUME))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_VOLUME, "Audio", "Volume",
+                 "Set the in-game mixer volume.", RECOMP_RUNTIME_UI_INT,
+                 0, 100, 5, NULL, 0, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_RESUME))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_RESUME, "System", "Resume game",
+                 "Close settings and return to the game.", RECOMP_RUNTIME_UI_ACTION,
+                 0, 0, 0, NULL, 0, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_SAVE_STATE))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_SAVE_STATE, "System", "Save state",
+                 "Save the current state.", RECOMP_RUNTIME_UI_ACTION,
+                 0, 0, 0, NULL, 0, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_LOAD_STATE))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_LOAD_STATE, "System", "Load state",
+                 "Load the current state slot.", RECOMP_RUNTIME_UI_ACTION,
+                 0, 0, 0, NULL, 0, NULL);
+    if (has(f, RECOMP_RUNTIME_UI_STANDARD_RESET))
+        add_item(items, &count, RECOMP_RUNTIME_UI_KEY_RESET, "System", "Reset game",
+                 "Reset the emulated machine.", RECOMP_RUNTIME_UI_ACTION,
+                 0, 0, 0, NULL, 0, NULL);
+
+    if (standard->extra_items && standard->extra_item_count) {
+        memcpy(items + count, standard->extra_items,
+               standard->extra_item_count * sizeof(*items));
+        count += standard->extra_item_count;
+    }
+
+    RecompRuntimeUiConfig menu = standard->menu;
+    menu.items = items;
+    menu.item_count = count;
+    RecompRuntimeUi *ui = recomp_runtime_ui_create(&menu);
+    if (!ui) {
+        free(items); free(view_choices); free(view_values);
+        return NULL;
+    }
+    ui->owned_items = items;
+    ui->owned_view_choices = view_choices;
+    ui->owned_view_values = view_values;
+    return ui;
+}

--- a/src/common/recomp_runtime_ui.c
+++ b/src/common/recomp_runtime_ui.c
@@ -71,6 +71,9 @@ void recomp_runtime_ui_destroy(RecompRuntimeUi *ui) {
     if (ui->open && ui->config.callbacks.visibility_changed)
         ui->config.callbacks.visibility_changed(ui->config.callbacks.context, 0);
     free(ui->sections);
+    free(ui->owned_items);
+    free(ui->owned_view_choices);
+    free(ui->owned_view_values);
     free(ui);
 }
 
@@ -138,9 +141,15 @@ void recomp_runtime_ui_adjust_current(RecompRuntimeUi *ui, int direction,
                                        : item->maximum - item->minimum + 1;
         if (count <= 0) return;
         int base = value - item->minimum;
+        if (item->choice_values) {
+            base = 0;
+            for (int i = 0; i < count; ++i)
+                if (item->choice_values[i] == value) { base = i; break; }
+        }
         int delta = direction < 0 ? -1 : 1;
         base = (base + delta + count) % count;
-        next = item->minimum + base;
+        next = item->choice_values ? item->choice_values[base]
+                                   : item->minimum + base;
     } else {
         int step = item->step > 0 ? item->step : 1;
         next = value + (direction < 0 ? -step : step);
@@ -362,10 +371,19 @@ static void item_value(RecompRuntimeUi *ui, const RecompRuntimeUiItem *item,
         snprintf(out, out_size, "?");
     } else if (item->type == RECOMP_RUNTIME_UI_BOOL) {
         snprintf(out, out_size, "%s", value ? "On" : "Off");
-    } else if (item->type == RECOMP_RUNTIME_UI_CHOICE && item->choices &&
-               value >= item->minimum &&
-               (size_t)(value - item->minimum) < item->choice_count) {
-        snprintf(out, out_size, "%s", item->choices[value - item->minimum]);
+    } else if (item->type == RECOMP_RUNTIME_UI_CHOICE && item->choices) {
+        size_t index = item->choice_count;
+        if (item->choice_values) {
+            for (size_t i = 0; i < item->choice_count; ++i)
+                if (item->choice_values[i] == value) { index = i; break; }
+        } else if (value >= item->minimum &&
+                   (size_t)(value - item->minimum) < item->choice_count) {
+            index = (size_t)(value - item->minimum);
+        }
+        if (index < item->choice_count)
+            snprintf(out, out_size, "%s", item->choices[index]);
+        else
+            snprintf(out, out_size, "?");
     } else {
         snprintf(out, out_size, "%d", value);
     }
@@ -398,18 +416,29 @@ void recomp_runtime_ui_render_argb8888(RecompRuntimeUi *ui, void *pixels,
     rect(pixels,width,height,pitch,panel_x,panel_y,panel_w,panel_h,panel,238);
     outline(pixels,width,height,pitch,panel_x,panel_y,panel_w,panel_h,
             scale,accent);
+    const char *title = ui->config.title ? ui->config.title : "Settings";
+    const char *subtitle = ui->config.subtitle;
+    const int title_w = text_width(title, scale);
+    const int subtitle_w = text_width(subtitle, scale);
+    const int header_inner_w = panel_w - pad * 2;
+    const int stacked_header = subtitle && subtitle[0] &&
+        title_w + subtitle_w + 4 * scale > header_inner_w;
     draw_text(pixels,width,height,pitch,panel_x+pad,panel_y+pad,scale,accent,
-              ui->config.title ? ui->config.title : "Settings",
-              panel_x+panel_w-pad);
-    if (ui->config.subtitle) {
-        int sw = text_width(ui->config.subtitle, scale);
-        draw_text(pixels,width,height,pitch,panel_x+panel_w-pad-sw,panel_y+pad,
-                  scale,muted,ui->config.subtitle,panel_x+panel_w-pad);
+              title,panel_x+panel_w-pad);
+    if (subtitle && subtitle[0]) {
+        const int subtitle_y = panel_y + pad +
+            (stacked_header ? 10 * scale : 0);
+        int subtitle_x = panel_x + panel_w - pad - subtitle_w;
+        if (subtitle_x < panel_x + pad) subtitle_x = panel_x + pad;
+        draw_text(pixels,width,height,pitch,subtitle_x,
+                  subtitle_y,scale,muted,subtitle,panel_x+panel_w-pad);
     }
-    rect(pixels,width,height,pitch,panel_x+pad,panel_y+24*scale,
+    const int header_extra = stacked_header ? 10 * scale : 0;
+    rect(pixels,width,height,pitch,panel_x+pad,
+         panel_y+24*scale+header_extra,
          panel_w-pad*2,scale,border,255);
 
-    int list_y = panel_y + 32 * scale;
+    int list_y = panel_y + 32 * scale + header_extra;
     int footer_y = panel_y + panel_h - 28 * scale;
     int row_h = 15 * scale;
     int visible = (footer_y - list_y) / row_h;

--- a/src/common/recomp_runtime_ui.c
+++ b/src/common/recomp_runtime_ui.c
@@ -1,0 +1,471 @@
+#include "recomp_runtime_ui_internal.h"
+#include "launcher_theme.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+static int same_text(const char *a, const char *b) {
+    if (!a) a = "";
+    if (!b) b = "";
+    return strcmp(a, b) == 0;
+}
+
+int recomp_runtime_ui_item_enabled(const RecompRuntimeUi *ui,
+                                   const RecompRuntimeUiItem *item) {
+    if (!ui->config.callbacks.is_enabled) return 1;
+    return ui->config.callbacks.is_enabled(ui->config.callbacks.context, item) != 0;
+}
+
+size_t recomp_runtime_ui_section_item_count(const RecompRuntimeUi *ui,
+                                            size_t section) {
+    size_t count = 0;
+    if (!ui || section >= ui->section_count) return 0;
+    for (size_t i = 0; i < ui->config.item_count; ++i)
+        if (same_text(ui->config.items[i].section, ui->sections[section])) ++count;
+    return count;
+}
+
+const RecompRuntimeUiItem *recomp_runtime_ui_section_item(
+    const RecompRuntimeUi *ui, size_t section, size_t row) {
+    size_t found = 0;
+    if (!ui || section >= ui->section_count) return NULL;
+    for (size_t i = 0; i < ui->config.item_count; ++i) {
+        if (!same_text(ui->config.items[i].section, ui->sections[section])) continue;
+        if (found++ == row) return &ui->config.items[i];
+    }
+    return NULL;
+}
+
+static void visibility(RecompRuntimeUi *ui, int open) {
+    if (!ui || ui->open == open) return;
+    ui->open = open;
+    if (!open) ui->in_section = 0;
+    if (ui->config.callbacks.visibility_changed)
+        ui->config.callbacks.visibility_changed(ui->config.callbacks.context, open);
+}
+
+RecompRuntimeUi *recomp_runtime_ui_create(const RecompRuntimeUiConfig *config) {
+    if (!config || !config->items || config->item_count == 0) return NULL;
+    RecompRuntimeUi *ui = (RecompRuntimeUi *)calloc(1, sizeof(*ui));
+    if (!ui) return NULL;
+    ui->config = *config;
+    ui->sections = (const char **)calloc(config->item_count, sizeof(*ui->sections));
+    if (!ui->sections) {
+        free(ui);
+        return NULL;
+    }
+    for (size_t i = 0; i < config->item_count; ++i) {
+        const char *section = config->items[i].section;
+        if (!section || !*section) section = "Settings";
+        int known = 0;
+        for (size_t j = 0; j < ui->section_count; ++j)
+            if (same_text(section, ui->sections[j])) known = 1;
+        if (!known) ui->sections[ui->section_count++] = section;
+    }
+    return ui;
+}
+
+void recomp_runtime_ui_destroy(RecompRuntimeUi *ui) {
+    if (!ui) return;
+    if (ui->open && ui->config.callbacks.visibility_changed)
+        ui->config.callbacks.visibility_changed(ui->config.callbacks.context, 0);
+    free(ui->sections);
+    free(ui);
+}
+
+int recomp_runtime_ui_is_open(const RecompRuntimeUi *ui) {
+    return ui && ui->open;
+}
+
+void recomp_runtime_ui_open(RecompRuntimeUi *ui) {
+    if (!ui) return;
+    ui->in_section = 0;
+    ui->row_index = 0;
+    visibility(ui, 1);
+}
+
+void recomp_runtime_ui_close(RecompRuntimeUi *ui) {
+    visibility(ui, 0);
+}
+
+static size_t wrap_index(size_t current, int delta, size_t count) {
+    if (count == 0) return 0;
+    if (delta < 0) return current == 0 ? count - 1 : current - 1;
+    return current + 1 >= count ? 0 : current + 1;
+}
+
+int recomp_runtime_ui_current_value(RecompRuntimeUi *ui,
+                                    const RecompRuntimeUiItem *item,
+                                    int *value) {
+    if (!ui->config.callbacks.get_value || !value) return 0;
+    return ui->config.callbacks.get_value(ui->config.callbacks.context,
+                                          item, value) != 0;
+}
+
+static void accepted_change(RecompRuntimeUi *ui, const char *status) {
+    snprintf(ui->status, sizeof(ui->status), "%s", status ? status : "Applied");
+    ui->status_frames = 90;
+    if (ui->config.callbacks.save)
+        ui->config.callbacks.save(ui->config.callbacks.context);
+}
+
+static void accepted_action(RecompRuntimeUi *ui) {
+    snprintf(ui->status, sizeof(ui->status), "%s", "Done");
+    ui->status_frames = 90;
+}
+
+void recomp_runtime_ui_adjust_current(RecompRuntimeUi *ui, int direction,
+                                      int activate, int repeat) {
+    const RecompRuntimeUiItem *item = recomp_runtime_ui_section_item(
+        ui, ui->section_index, ui->row_index);
+    if (!item || !recomp_runtime_ui_item_enabled(ui, item)) return;
+    if (item->type == RECOMP_RUNTIME_UI_ACTION) {
+        if (!activate || repeat || !ui->config.callbacks.run_action) return;
+        if (ui->config.callbacks.run_action(ui->config.callbacks.context, item))
+            accepted_action(ui);
+        return;
+    }
+    if (!ui->config.callbacks.set_value) return;
+    int value = 0;
+    if (!recomp_runtime_ui_current_value(ui, item, &value)) return;
+    int next = value;
+    if (item->type == RECOMP_RUNTIME_UI_BOOL) {
+        if (repeat) return;
+        next = !value;
+    } else if (item->type == RECOMP_RUNTIME_UI_CHOICE) {
+        int count = item->choice_count ? (int)item->choice_count
+                                       : item->maximum - item->minimum + 1;
+        if (count <= 0) return;
+        int base = value - item->minimum;
+        int delta = direction < 0 ? -1 : 1;
+        base = (base + delta + count) % count;
+        next = item->minimum + base;
+    } else {
+        int step = item->step > 0 ? item->step : 1;
+        next = value + (direction < 0 ? -step : step);
+        if (next < item->minimum) next = item->minimum;
+        if (next > item->maximum) next = item->maximum;
+    }
+    if (next != value && ui->config.callbacks.set_value(
+            ui->config.callbacks.context, item, next))
+        accepted_change(ui, "Saved");
+}
+
+void recomp_runtime_ui_enter_section(RecompRuntimeUi *ui, size_t section) {
+    if (!ui || section >= ui->section_count) return;
+    ui->section_index = section;
+    ui->row_index = 0;
+    ui->in_section = 1;
+}
+
+void recomp_runtime_ui_leave_section(RecompRuntimeUi *ui) {
+    if (!ui) return;
+    ui->in_section = 0;
+    ui->row_index = 0;
+}
+
+int recomp_runtime_ui_handle_input(RecompRuntimeUi *ui,
+                                   RecompRuntimeUiInput input,
+                                   int pressed, int repeat) {
+    if (!ui) return 0;
+    if (!ui->open) {
+        if (pressed && !repeat && input == RECOMP_RUNTIME_UI_INPUT_TOGGLE) {
+            recomp_runtime_ui_open(ui);
+            return 1;
+        }
+        return 0;
+    }
+    if (!pressed) return 1;
+    if (input == RECOMP_RUNTIME_UI_INPUT_TOGGLE) {
+        if (!repeat) recomp_runtime_ui_close(ui);
+        return 1;
+    }
+    if (input == RECOMP_RUNTIME_UI_INPUT_BACK) {
+        if (!repeat) {
+            if (ui->in_section) {
+                ui->in_section = 0;
+                ui->row_index = 0;
+            } else {
+                recomp_runtime_ui_close(ui);
+            }
+        }
+        return 1;
+    }
+    if (input == RECOMP_RUNTIME_UI_INPUT_UP ||
+        input == RECOMP_RUNTIME_UI_INPUT_DOWN) {
+        int delta = input == RECOMP_RUNTIME_UI_INPUT_UP ? -1 : 1;
+        size_t count = ui->in_section ? recomp_runtime_ui_section_item_count(ui, ui->section_index)
+                                      : ui->section_count;
+        size_t *selection = ui->in_section ? &ui->row_index : &ui->section_index;
+        *selection = wrap_index(*selection, delta, count);
+        return 1;
+    }
+    if (input == RECOMP_RUNTIME_UI_INPUT_ACCEPT) {
+        if (!ui->in_section) {
+            if (!repeat) {
+                recomp_runtime_ui_enter_section(ui, ui->section_index);
+            }
+        } else {
+            recomp_runtime_ui_adjust_current(ui, 1, 1, repeat);
+        }
+        return 1;
+    }
+    if (input == RECOMP_RUNTIME_UI_INPUT_LEFT ||
+        input == RECOMP_RUNTIME_UI_INPUT_RIGHT) {
+        if (ui->in_section)
+            recomp_runtime_ui_adjust_current(ui,
+                           input == RECOMP_RUNTIME_UI_INPUT_LEFT ? -1 : 1,
+                           0, repeat);
+        return 1;
+    }
+    return 1;
+}
+
+#define GLYPH(a,b,c,d,e,f,g) \
+    ((uint64_t)(a) | ((uint64_t)(b) << 5) | ((uint64_t)(c) << 10) | \
+     ((uint64_t)(d) << 15) | ((uint64_t)(e) << 20) | \
+     ((uint64_t)(f) << 25) | ((uint64_t)(g) << 30))
+
+static uint64_t glyph_bits(unsigned char c) {
+    if (c >= 'a' && c <= 'z') c = (unsigned char)(c - 'a' + 'A');
+    switch (c) {
+    case 'A': return GLYPH(14,17,17,31,17,17,17);
+    case 'B': return GLYPH(30,17,17,30,17,17,30);
+    case 'C': return GLYPH(14,17,16,16,16,17,14);
+    case 'D': return GLYPH(30,17,17,17,17,17,30);
+    case 'E': return GLYPH(31,16,16,30,16,16,31);
+    case 'F': return GLYPH(31,16,16,30,16,16,16);
+    case 'G': return GLYPH(14,17,16,23,17,17,15);
+    case 'H': return GLYPH(17,17,17,31,17,17,17);
+    case 'I': return GLYPH(14,4,4,4,4,4,14);
+    case 'J': return GLYPH(7,2,2,2,18,18,12);
+    case 'K': return GLYPH(17,18,20,24,20,18,17);
+    case 'L': return GLYPH(16,16,16,16,16,16,31);
+    case 'M': return GLYPH(17,27,21,21,17,17,17);
+    case 'N': return GLYPH(17,25,21,19,17,17,17);
+    case 'O': return GLYPH(14,17,17,17,17,17,14);
+    case 'P': return GLYPH(30,17,17,30,16,16,16);
+    case 'Q': return GLYPH(14,17,17,17,21,18,13);
+    case 'R': return GLYPH(30,17,17,30,20,18,17);
+    case 'S': return GLYPH(15,16,16,14,1,1,30);
+    case 'T': return GLYPH(31,4,4,4,4,4,4);
+    case 'U': return GLYPH(17,17,17,17,17,17,14);
+    case 'V': return GLYPH(17,17,17,17,17,10,4);
+    case 'W': return GLYPH(17,17,17,21,21,21,10);
+    case 'X': return GLYPH(17,17,10,4,10,17,17);
+    case 'Y': return GLYPH(17,17,10,4,4,4,4);
+    case 'Z': return GLYPH(31,1,2,4,8,16,31);
+    case '0': return GLYPH(14,17,19,21,25,17,14);
+    case '1': return GLYPH(4,12,4,4,4,4,14);
+    case '2': return GLYPH(14,17,1,2,4,8,31);
+    case '3': return GLYPH(30,1,1,14,1,1,30);
+    case '4': return GLYPH(2,6,10,18,31,2,2);
+    case '5': return GLYPH(31,16,16,30,1,1,30);
+    case '6': return GLYPH(14,16,16,30,17,17,14);
+    case '7': return GLYPH(31,1,2,4,8,8,8);
+    case '8': return GLYPH(14,17,17,14,17,17,14);
+    case '9': return GLYPH(14,17,17,15,1,1,14);
+    case '-': return GLYPH(0,0,0,31,0,0,0);
+    case '+': return GLYPH(0,4,4,31,4,4,0);
+    case '/': return GLYPH(1,2,2,4,8,8,16);
+    case ':': return GLYPH(0,4,4,0,4,4,0);
+    case '.': return GLYPH(0,0,0,0,0,6,6);
+    case ',': return GLYPH(0,0,0,0,6,6,4);
+    case '(': return GLYPH(2,4,8,8,8,4,2);
+    case ')': return GLYPH(8,4,2,2,2,4,8);
+    case '[': return GLYPH(14,8,8,8,8,8,14);
+    case ']': return GLYPH(14,2,2,2,2,2,14);
+    case '%': return GLYPH(17,2,4,4,8,16,17);
+    case '<': return GLYPH(2,4,8,16,8,4,2);
+    case '>': return GLYPH(8,4,2,1,2,4,8);
+    case '=': return GLYPH(0,0,31,0,31,0,0);
+    case '_': return GLYPH(0,0,0,0,0,0,31);
+    case '!': return GLYPH(4,4,4,4,4,0,4);
+    case '?': return GLYPH(14,17,1,2,4,0,4);
+    case '#': return GLYPH(10,31,10,10,31,10,0);
+    case '\'': return GLYPH(4,4,2,0,0,0,0);
+    case ' ': return 0;
+    default: return GLYPH(14,17,2,4,4,0,4);
+    }
+}
+
+static uint32_t blend_pixel(uint32_t dst, uint32_t src, unsigned alpha) {
+    unsigned dr = (dst >> 16) & 255, dg = (dst >> 8) & 255, db = dst & 255;
+    unsigned sr = (src >> 16) & 255, sg = (src >> 8) & 255, sb = src & 255;
+    unsigned inv = 255 - alpha;
+    return 0xff000000u |
+           (((sr * alpha + dr * inv) / 255) << 16) |
+           (((sg * alpha + dg * inv) / 255) << 8) |
+           ((sb * alpha + db * inv) / 255);
+}
+
+static void rect(void *pixels, int width, int height, int pitch, int x, int y,
+                 int w, int h, uint32_t color, unsigned alpha) {
+    if (x < 0) { w += x; x = 0; }
+    if (y < 0) { h += y; y = 0; }
+    if (x + w > width) w = width - x;
+    if (y + h > height) h = height - y;
+    if (w <= 0 || h <= 0) return;
+    for (int yy = y; yy < y + h; ++yy) {
+        uint32_t *row = (uint32_t *)((unsigned char *)pixels + yy * pitch);
+        for (int xx = x; xx < x + w; ++xx)
+            row[xx] = alpha == 255 ? (0xff000000u | color)
+                                   : blend_pixel(row[xx], color, alpha);
+    }
+}
+
+static void outline(void *pixels, int width, int height, int pitch, int x, int y,
+                    int w, int h, int thickness, uint32_t color) {
+    rect(pixels,width,height,pitch,x,y,w,thickness,color,255);
+    rect(pixels,width,height,pitch,x,y+h-thickness,w,thickness,color,255);
+    rect(pixels,width,height,pitch,x,y,thickness,h,color,255);
+    rect(pixels,width,height,pitch,x+w-thickness,y,thickness,h,color,255);
+}
+
+static void draw_text(void *pixels, int width, int height, int pitch, int x,
+                      int y, int scale, uint32_t color, const char *text,
+                      int max_x) {
+    if (!text) return;
+    int cursor = x;
+    for (const unsigned char *p = (const unsigned char *)text; *p; ++p) {
+        if (*p >= 0x80) continue;
+        if (cursor + 5 * scale > max_x) break;
+        uint64_t bits = glyph_bits(*p);
+        for (int gy = 0; gy < 7; ++gy) {
+            unsigned row = (unsigned)((bits >> (gy * 5)) & 31);
+            for (int gx = 0; gx < 5; ++gx)
+                if (row & (1u << (4 - gx)))
+                    rect(pixels,width,height,pitch,cursor+gx*scale,y+gy*scale,
+                         scale,scale,color,255);
+        }
+        cursor += 6 * scale;
+    }
+}
+
+static int text_width(const char *text, int scale) {
+    int count = 0;
+    if (!text) return 0;
+    for (const unsigned char *p = (const unsigned char *)text; *p; ++p)
+        if (*p < 0x80) ++count;
+    return count * 6 * scale;
+}
+
+static void item_value(RecompRuntimeUi *ui, const RecompRuntimeUiItem *item,
+                       char *out, size_t out_size) {
+    if (item->type == RECOMP_RUNTIME_UI_ACTION) {
+        snprintf(out, out_size, ">");
+        return;
+    }
+    int value = 0;
+    if (!recomp_runtime_ui_current_value(ui, item, &value)) {
+        snprintf(out, out_size, "?");
+    } else if (item->type == RECOMP_RUNTIME_UI_BOOL) {
+        snprintf(out, out_size, "%s", value ? "On" : "Off");
+    } else if (item->type == RECOMP_RUNTIME_UI_CHOICE && item->choices &&
+               value >= item->minimum &&
+               (size_t)(value - item->minimum) < item->choice_count) {
+        snprintf(out, out_size, "%s", item->choices[value - item->minimum]);
+    } else {
+        snprintf(out, out_size, "%d", value);
+    }
+}
+
+void recomp_runtime_ui_render_argb8888(RecompRuntimeUi *ui, void *pixels,
+                                       int width, int height, int pitch) {
+    if (!ui || !ui->open || !pixels || width <= 0 || height <= 0 ||
+        pitch < width * 4) return;
+    LauncherTheme theme = launcher_theme_by_name(ui->config.theme);
+    int scale = height / 224;
+    if (scale < 1) scale = 1;
+    int margin = 6 * scale;
+    int panel_w = 244 * scale;
+    if (panel_w > width - margin * 2) panel_w = width - margin * 2;
+    int panel_h = height - margin * 2;
+    int panel_x = (width - panel_w) / 2;
+    int panel_y = margin;
+    int pad = 8 * scale;
+    #define RGB8(c) (((uint32_t)((c).r * 255.0f) << 16) | \
+                     ((uint32_t)((c).g * 255.0f) << 8) | \
+                     (uint32_t)((c).b * 255.0f))
+    const uint32_t white = RGB8(theme.text), muted = RGB8(theme.text_muted);
+    const uint32_t accent = RGB8(theme.accent2), panel = RGB8(theme.panel);
+    const uint32_t selected = RGB8(theme.control_hovered);
+    const uint32_t disabled = RGB8(theme.text_muted);
+    const uint32_t border = RGB8(theme.border);
+
+    rect(pixels,width,height,pitch,0,0,width,height,0x000000,130);
+    rect(pixels,width,height,pitch,panel_x,panel_y,panel_w,panel_h,panel,238);
+    outline(pixels,width,height,pitch,panel_x,panel_y,panel_w,panel_h,
+            scale,accent);
+    draw_text(pixels,width,height,pitch,panel_x+pad,panel_y+pad,scale,accent,
+              ui->config.title ? ui->config.title : "Settings",
+              panel_x+panel_w-pad);
+    if (ui->config.subtitle) {
+        int sw = text_width(ui->config.subtitle, scale);
+        draw_text(pixels,width,height,pitch,panel_x+panel_w-pad-sw,panel_y+pad,
+                  scale,muted,ui->config.subtitle,panel_x+panel_w-pad);
+    }
+    rect(pixels,width,height,pitch,panel_x+pad,panel_y+24*scale,
+         panel_w-pad*2,scale,border,255);
+
+    int list_y = panel_y + 32 * scale;
+    int footer_y = panel_y + panel_h - 28 * scale;
+    int row_h = 15 * scale;
+    int visible = (footer_y - list_y) / row_h;
+    if (visible < 1) visible = 1;
+    size_t count = ui->in_section ? recomp_runtime_ui_section_item_count(ui, ui->section_index)
+                                  : ui->section_count;
+    size_t selection = ui->in_section ? ui->row_index : ui->section_index;
+    size_t first = 0;
+    if (selection >= (size_t)visible) first = selection - (size_t)visible + 1;
+    for (int line = 0; line < visible && first + (size_t)line < count; ++line) {
+        size_t index = first + (size_t)line;
+        int y = list_y + line * row_h;
+        if (index == selection)
+            rect(pixels,width,height,pitch,panel_x+pad/2,y-3*scale,
+                 panel_w-pad,row_h,selected,255);
+        if (!ui->in_section) {
+            const char *name = ui->sections[index];
+            draw_text(pixels,width,height,pitch,panel_x+pad,y,scale,
+                      index == selection ? white : muted,name,
+                      panel_x+panel_w-pad-12*scale);
+            draw_text(pixels,width,height,pitch,panel_x+panel_w-pad-5*scale,y,
+                      scale,index == selection ? accent : muted,">",
+                      panel_x+panel_w-pad);
+        } else {
+            const RecompRuntimeUiItem *item = recomp_runtime_ui_section_item(
+                ui, ui->section_index, index);
+            int enabled = recomp_runtime_ui_item_enabled(ui, item);
+            uint32_t color = enabled ? (index == selection ? white : muted)
+                                     : disabled;
+            char value[96];
+            item_value(ui, item, value, sizeof(value));
+            int value_w = text_width(value, scale);
+            draw_text(pixels,width,height,pitch,panel_x+pad,y,scale,color,
+                      item->label,panel_x+panel_w-pad-value_w-8*scale);
+            draw_text(pixels,width,height,pitch,panel_x+panel_w-pad-value_w,y,
+                      scale,index == selection && enabled ? accent : color,
+                      value,panel_x+panel_w-pad);
+        }
+    }
+
+    const char *help = "UP/DOWN SELECT  LEFT/RIGHT CHANGE  ENTER ACCEPT";
+    if (ui->in_section) {
+        const RecompRuntimeUiItem *item = recomp_runtime_ui_section_item(
+            ui, ui->section_index, ui->row_index);
+        if (item && item->description && *item->description) help = item->description;
+    }
+    rect(pixels,width,height,pitch,panel_x+pad,footer_y-4*scale,
+         panel_w-pad*2,scale,border,255);
+    draw_text(pixels,width,height,pitch,panel_x+pad,footer_y+3*scale,scale,
+              muted,help,panel_x+panel_w-pad);
+    if (ui->status_frames) {
+        int status_w = text_width(ui->status, scale);
+        draw_text(pixels,width,height,pitch,panel_x+panel_w-pad-status_w,
+                  panel_y+panel_h-12*scale,scale,accent,ui->status,
+                  panel_x+panel_w-pad);
+        --ui->status_frames;
+    }
+    #undef RGB8
+}

--- a/src/common/recomp_runtime_ui_internal.h
+++ b/src/common/recomp_runtime_ui_internal.h
@@ -1,0 +1,40 @@
+#ifndef RECOMP_RUNTIME_UI_INTERNAL_H
+#define RECOMP_RUNTIME_UI_INTERNAL_H
+
+#include "recomp_runtime_ui.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct RecompRuntimeUi {
+    RecompRuntimeUiConfig config;
+    const char **sections;
+    size_t section_count;
+    size_t section_index;
+    size_t row_index;
+    int open;
+    int in_section;
+    unsigned status_frames;
+    char status[48];
+};
+
+int recomp_runtime_ui_item_enabled(const RecompRuntimeUi *ui,
+                                   const RecompRuntimeUiItem *item);
+size_t recomp_runtime_ui_section_item_count(const RecompRuntimeUi *ui,
+                                            size_t section);
+const RecompRuntimeUiItem *recomp_runtime_ui_section_item(
+    const RecompRuntimeUi *ui, size_t section, size_t row);
+int recomp_runtime_ui_current_value(RecompRuntimeUi *ui,
+                                    const RecompRuntimeUiItem *item,
+                                    int *value);
+void recomp_runtime_ui_adjust_current(RecompRuntimeUi *ui, int direction,
+                                      int activate, int repeat);
+void recomp_runtime_ui_enter_section(RecompRuntimeUi *ui, size_t section);
+void recomp_runtime_ui_leave_section(RecompRuntimeUi *ui);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/common/recomp_runtime_ui_internal.h
+++ b/src/common/recomp_runtime_ui_internal.h
@@ -17,6 +17,9 @@ struct RecompRuntimeUi {
     int in_section;
     unsigned status_frames;
     char status[48];
+    RecompRuntimeUiItem *owned_items;
+    const char **owned_view_choices;
+    int *owned_view_values;
 };
 
 int recomp_runtime_ui_item_enabled(const RecompRuntimeUi *ui,

--- a/src/recomp_runtime_ui.h
+++ b/src/recomp_runtime_ui.h
@@ -27,6 +27,36 @@ typedef enum RecompRuntimeUiInput {
     RECOMP_RUNTIME_UI_INPUT_ACCEPT,
 } RecompRuntimeUiInput;
 
+typedef enum RecompRuntimeUiViewMode {
+    RECOMP_RUNTIME_UI_VIEW_NATIVE = 0,
+    RECOMP_RUNTIME_UI_VIEW_FIXED_16_9 = 1,
+    RECOMP_RUNTIME_UI_VIEW_ADAPTIVE = 2,
+} RecompRuntimeUiViewMode;
+
+enum {
+    RECOMP_RUNTIME_UI_VIEW_MODE_NATIVE = 1u << RECOMP_RUNTIME_UI_VIEW_NATIVE,
+    RECOMP_RUNTIME_UI_VIEW_MODE_FIXED_16_9 = 1u << RECOMP_RUNTIME_UI_VIEW_FIXED_16_9,
+    RECOMP_RUNTIME_UI_VIEW_MODE_ADAPTIVE = 1u << RECOMP_RUNTIME_UI_VIEW_ADAPTIVE,
+};
+
+/* Stable semantic keys used by the standard settings builder and host hooks. */
+#define RECOMP_RUNTIME_UI_KEY_FULLSCREEN       "display.fullscreen"
+#define RECOMP_RUNTIME_UI_KEY_WINDOW_SCALE     "display.window_scale"
+#define RECOMP_RUNTIME_UI_KEY_VIEW_MODE        "display.view_mode"
+#define RECOMP_RUNTIME_UI_KEY_WIDESCREEN_HUD   "display.widescreen_hud"
+#define RECOMP_RUNTIME_UI_KEY_INTEGER_SCALE    "graphics.integer_scale"
+#define RECOMP_RUNTIME_UI_KEY_LINEAR_FILTER    "graphics.linear_filter"
+#define RECOMP_RUNTIME_UI_KEY_TEXTURE_FILTER   "graphics.texture_filter"
+#define RECOMP_RUNTIME_UI_KEY_RESOLUTION_SCALE "graphics.resolution_scale"
+#define RECOMP_RUNTIME_UI_KEY_COLOR_CORRECTION "graphics.color_correction"
+#define RECOMP_RUNTIME_UI_KEY_LCD_GHOSTING     "graphics.lcd_ghosting"
+#define RECOMP_RUNTIME_UI_KEY_AUDIO            "audio.enabled"
+#define RECOMP_RUNTIME_UI_KEY_VOLUME           "audio.volume"
+#define RECOMP_RUNTIME_UI_KEY_RESUME            "system.resume"
+#define RECOMP_RUNTIME_UI_KEY_SAVE_STATE        "system.save_state"
+#define RECOMP_RUNTIME_UI_KEY_LOAD_STATE        "system.load_state"
+#define RECOMP_RUNTIME_UI_KEY_RESET             "system.reset"
+
 typedef struct RecompRuntimeUiItem {
     const char *key;
     const char *section;
@@ -38,6 +68,8 @@ typedef struct RecompRuntimeUiItem {
     int step;
     const char *const *choices;
     size_t choice_count;
+    /* Optional stable values for sparse choices. NULL means minimum + index. */
+    const int *choice_values;
 } RecompRuntimeUiItem;
 
 typedef struct RecompRuntimeUiCallbacks {
@@ -71,12 +103,48 @@ typedef struct RecompRuntimeUiConfig {
     const char *back_label;
 } RecompRuntimeUiConfig;
 
+typedef uint64_t RecompRuntimeUiStandardFeatures;
+enum {
+    RECOMP_RUNTIME_UI_STANDARD_FULLSCREEN       = UINT64_C(1) << 0,
+    RECOMP_RUNTIME_UI_STANDARD_WINDOW_SCALE     = UINT64_C(1) << 1,
+    RECOMP_RUNTIME_UI_STANDARD_VIEW_MODE        = UINT64_C(1) << 2,
+    RECOMP_RUNTIME_UI_STANDARD_WIDESCREEN_HUD   = UINT64_C(1) << 3,
+    RECOMP_RUNTIME_UI_STANDARD_INTEGER_SCALE    = UINT64_C(1) << 4,
+    RECOMP_RUNTIME_UI_STANDARD_LINEAR_FILTER    = UINT64_C(1) << 5,
+    RECOMP_RUNTIME_UI_STANDARD_TEXTURE_FILTER   = UINT64_C(1) << 6,
+    RECOMP_RUNTIME_UI_STANDARD_RESOLUTION_SCALE = UINT64_C(1) << 7,
+    RECOMP_RUNTIME_UI_STANDARD_COLOR_CORRECTION = UINT64_C(1) << 8,
+    RECOMP_RUNTIME_UI_STANDARD_LCD_GHOSTING     = UINT64_C(1) << 9,
+    RECOMP_RUNTIME_UI_STANDARD_AUDIO            = UINT64_C(1) << 10,
+    RECOMP_RUNTIME_UI_STANDARD_VOLUME           = UINT64_C(1) << 11,
+    RECOMP_RUNTIME_UI_STANDARD_RESUME            = UINT64_C(1) << 12,
+    RECOMP_RUNTIME_UI_STANDARD_SAVE_STATE        = UINT64_C(1) << 13,
+    RECOMP_RUNTIME_UI_STANDARD_LOAD_STATE        = UINT64_C(1) << 14,
+    RECOMP_RUNTIME_UI_STANDARD_RESET             = UINT64_C(1) << 15,
+};
+
+typedef struct RecompRuntimeUiStandardConfig {
+    RecompRuntimeUiConfig menu;
+    RecompRuntimeUiStandardFeatures features;
+    unsigned view_modes;
+    const char *native_view_label;   /* default: Native */
+    const char *fixed_view_label;    /* default: 16:9 fixed */
+    const char *adaptive_view_label; /* default: Adaptive */
+    int window_scale_max;            /* default: 8 */
+    int resolution_scale_max;        /* default: 8 */
+    const RecompRuntimeUiItem *extra_items;
+    size_t extra_item_count;
+} RecompRuntimeUiStandardConfig;
+
 /*
  * Creates a host-owned in-game menu. The descriptor and all strings referenced
  * by it must outlive the returned object. The menu does not own or advance the
  * game: the host decides whether an open menu pauses simulation.
  */
 RecompRuntimeUi *recomp_runtime_ui_create(const RecompRuntimeUiConfig *config);
+/* Builds the common cross-ecosystem settings surface, then appends extras. */
+RecompRuntimeUi *recomp_runtime_ui_create_standard(
+    const RecompRuntimeUiStandardConfig *config);
 void recomp_runtime_ui_destroy(RecompRuntimeUi *ui);
 
 int recomp_runtime_ui_is_open(const RecompRuntimeUi *ui);

--- a/src/recomp_runtime_ui.h
+++ b/src/recomp_runtime_ui.h
@@ -1,0 +1,115 @@
+#ifndef RECOMP_RUNTIME_UI_H
+#define RECOMP_RUNTIME_UI_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct RecompRuntimeUi RecompRuntimeUi;
+
+typedef enum RecompRuntimeUiItemType {
+    RECOMP_RUNTIME_UI_BOOL,
+    RECOMP_RUNTIME_UI_INT,
+    RECOMP_RUNTIME_UI_CHOICE,
+    RECOMP_RUNTIME_UI_ACTION,
+} RecompRuntimeUiItemType;
+
+typedef enum RecompRuntimeUiInput {
+    RECOMP_RUNTIME_UI_INPUT_TOGGLE,
+    RECOMP_RUNTIME_UI_INPUT_BACK,
+    RECOMP_RUNTIME_UI_INPUT_UP,
+    RECOMP_RUNTIME_UI_INPUT_DOWN,
+    RECOMP_RUNTIME_UI_INPUT_LEFT,
+    RECOMP_RUNTIME_UI_INPUT_RIGHT,
+    RECOMP_RUNTIME_UI_INPUT_ACCEPT,
+} RecompRuntimeUiInput;
+
+typedef struct RecompRuntimeUiItem {
+    const char *key;
+    const char *section;
+    const char *label;
+    const char *description;
+    RecompRuntimeUiItemType type;
+    int minimum;
+    int maximum;
+    int step;
+    const char *const *choices;
+    size_t choice_count;
+} RecompRuntimeUiItem;
+
+typedef struct RecompRuntimeUiCallbacks {
+    void *context;
+    int (*get_value)(void *context, const RecompRuntimeUiItem *item,
+                     int *value_out);
+    int (*set_value)(void *context, const RecompRuntimeUiItem *item,
+                     int value);
+    int (*run_action)(void *context, const RecompRuntimeUiItem *item);
+    int (*is_enabled)(void *context, const RecompRuntimeUiItem *item);
+    void (*save)(void *context);
+    void (*visibility_changed)(void *context, int open);
+} RecompRuntimeUiCallbacks;
+
+typedef struct RecompRuntimeUiConfig {
+    const char *title;
+    const char *subtitle;
+    const RecompRuntimeUiItem *items;
+    size_t item_count;
+    RecompRuntimeUiCallbacks callbacks;
+
+    /*
+     * Uses the same built-in theme vocabulary as the launcher ("snes",
+     * "n64", "gba", "genesis", ...). NULL selects the neutral default.
+     * Presentation backends consume this value; game logic never needs to.
+     */
+    const char *theme;
+
+    /* Optional platform/input vocabulary for the footer. */
+    const char *accept_label;
+    const char *back_label;
+} RecompRuntimeUiConfig;
+
+/*
+ * Creates a host-owned in-game menu. The descriptor and all strings referenced
+ * by it must outlive the returned object. The menu does not own or advance the
+ * game: the host decides whether an open menu pauses simulation.
+ */
+RecompRuntimeUi *recomp_runtime_ui_create(const RecompRuntimeUiConfig *config);
+void recomp_runtime_ui_destroy(RecompRuntimeUi *ui);
+
+int recomp_runtime_ui_is_open(const RecompRuntimeUi *ui);
+void recomp_runtime_ui_open(RecompRuntimeUi *ui);
+void recomp_runtime_ui_close(RecompRuntimeUi *ui);
+
+/* Returns non-zero when the input belongs to the menu. */
+int recomp_runtime_ui_handle_input(RecompRuntimeUi *ui,
+                                   RecompRuntimeUiInput input,
+                                   int pressed, int repeat);
+
+/*
+ * Composites the menu over a little-endian SDL_PIXELFORMAT_ARGB8888/BGRA frame.
+ * The frame remains owned by the host and may be presented by SDL, OpenGL, or
+ * another backend after this call. No renderer/context dependency is required.
+ */
+void recomp_runtime_ui_render_argb8888(RecompRuntimeUi *ui, void *pixels,
+                                       int width, int height, int pitch_bytes);
+
+/*
+ * Draws the menu into the caller's active Dear ImGui frame. This is the
+ * preferred presentation for GPU-backed and high-resolution hosts (including
+ * RT64). It does not create an ImGui context, begin/end a frame, or submit draw
+ * data; the host keeps ownership of those renderer-specific operations.
+ *
+ * The symbol is available when recomp-ui's ImGui backend is compiled. Keeping
+ * ImGui types out of this C ABI lets C games and hosts with a different ImGui
+ * version consume the same runtime model.
+ */
+void recomp_runtime_ui_render_imgui(RecompRuntimeUi *ui);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/tests/runtime_ui_imgui_test.cpp
+++ b/tests/runtime_ui_imgui_test.cpp
@@ -22,7 +22,7 @@ int main() {
     static const char *const modes[] = { "Standard (4:3)", "16:9", "Adaptive" };
     static const RecompRuntimeUiItem items[] = {
         { "view", "Display", "View mode", "Choose the visible game area.",
-          RECOMP_RUNTIME_UI_CHOICE, 0, 2, 1, modes, 3 },
+          RECOMP_RUNTIME_UI_CHOICE, 0, 2, 1, modes, 3, nullptr },
     };
     int value = 0;
     RecompRuntimeUiConfig config{};

--- a/tests/runtime_ui_imgui_test.cpp
+++ b/tests/runtime_ui_imgui_test.cpp
@@ -1,0 +1,60 @@
+#include "recomp_runtime_ui.h"
+#include "imgui.h"
+
+#include <cassert>
+#include <cstring>
+
+namespace {
+
+int get_value(void *context, const RecompRuntimeUiItem *, int *out) {
+    *out = *static_cast<int *>(context);
+    return 1;
+}
+
+int set_value(void *context, const RecompRuntimeUiItem *, int value) {
+    *static_cast<int *>(context) = value;
+    return 1;
+}
+
+} // namespace
+
+int main() {
+    static const char *const modes[] = { "Standard (4:3)", "16:9", "Adaptive" };
+    static const RecompRuntimeUiItem items[] = {
+        { "view", "Display", "View mode", "Choose the visible game area.",
+          RECOMP_RUNTIME_UI_CHOICE, 0, 2, 1, modes, 3 },
+    };
+    int value = 0;
+    RecompRuntimeUiConfig config{};
+    config.title = "Runtime UI";
+    config.subtitle = "NINTENDO 64";
+    config.items = items;
+    config.item_count = 1;
+    config.theme = "n64";
+    config.callbacks.context = &value;
+    config.callbacks.get_value = get_value;
+    config.callbacks.set_value = set_value;
+
+    RecompRuntimeUi *ui = recomp_runtime_ui_create(&config);
+    assert(ui != nullptr);
+    recomp_runtime_ui_open(ui);
+
+    IMGUI_CHECKVERSION();
+    ImGui::CreateContext();
+    ImGuiIO &io = ImGui::GetIO();
+    io.IniFilename = nullptr;
+    io.DisplaySize = ImVec2(1280.0f, 720.0f);
+    io.DeltaTime = 1.0f / 60.0f;
+    unsigned char *font_pixels = nullptr;
+    int font_w = 0, font_h = 0;
+    io.Fonts->GetTexDataAsRGBA32(&font_pixels, &font_w, &font_h);
+
+    ImGui::NewFrame();
+    recomp_runtime_ui_render_imgui(ui);
+    ImGui::Render();
+    assert(ImGui::GetDrawData()->CmdListsCount > 0);
+
+    ImGui::DestroyContext();
+    recomp_runtime_ui_destroy(ui);
+    return 0;
+}

--- a/tests/runtime_ui_test.c
+++ b/tests/runtime_ui_test.c
@@ -17,6 +17,7 @@ static int get_value(void *context, const RecompRuntimeUiItem *item, int *out) {
     TestState *state = (TestState *)context;
     if (!strcmp(item->key, "enabled")) *out = state->enabled;
     else if (!strcmp(item->key, "level")) *out = state->level;
+    else if (!strcmp(item->key, RECOMP_RUNTIME_UI_KEY_VIEW_MODE)) *out = state->level;
     else return 0;
     return 1;
 }
@@ -25,6 +26,7 @@ static int set_value(void *context, const RecompRuntimeUiItem *item, int value) 
     TestState *state = (TestState *)context;
     if (!strcmp(item->key, "enabled")) state->enabled = value;
     else if (!strcmp(item->key, "level")) state->level = value;
+    else if (!strcmp(item->key, RECOMP_RUNTIME_UI_KEY_VIEW_MODE)) state->level = value;
     else return 0;
     return 1;
 }
@@ -44,11 +46,11 @@ static void visible(void *context, int open) {
 int main(void) {
     static const RecompRuntimeUiItem items[] = {
         { "enabled", "Video", "Enabled", "Toggle the feature.",
-          RECOMP_RUNTIME_UI_BOOL, 0, 1, 1, NULL, 0 },
+          RECOMP_RUNTIME_UI_BOOL, 0, 1, 1, NULL, 0, NULL },
         { "level", "Video", "Level", "Adjust the level.",
-          RECOMP_RUNTIME_UI_INT, 0, 10, 2, NULL, 0 },
+          RECOMP_RUNTIME_UI_INT, 0, 10, 2, NULL, 0, NULL },
         { "reset", "System", "Reset", "Run the action.",
-          RECOMP_RUNTIME_UI_ACTION, 0, 0, 0, NULL, 0 },
+          RECOMP_RUNTIME_UI_ACTION, 0, 0, 0, NULL, 0, NULL },
     };
     TestState state = { 0 };
     RecompRuntimeUiConfig config = {0};
@@ -98,6 +100,25 @@ int main(void) {
     recomp_runtime_ui_close(ui);
     assert(!state.visible);
     recomp_runtime_ui_destroy(ui);
+
+    /* Sparse universal view modes retain their semantic values (0 -> 2). */
+    state.level = RECOMP_RUNTIME_UI_VIEW_NATIVE;
+    RecompRuntimeUiStandardConfig standard = {0};
+    standard.menu.title = "Standard settings";
+    standard.menu.theme = "gba";
+    standard.menu.callbacks = config.callbacks;
+    standard.features = RECOMP_RUNTIME_UI_STANDARD_VIEW_MODE;
+    standard.view_modes = RECOMP_RUNTIME_UI_VIEW_MODE_NATIVE |
+                          RECOMP_RUNTIME_UI_VIEW_MODE_ADAPTIVE;
+    RecompRuntimeUi *standard_ui = recomp_runtime_ui_create_standard(&standard);
+    assert(standard_ui != NULL);
+    recomp_runtime_ui_open(standard_ui);
+    assert(recomp_runtime_ui_handle_input(
+        standard_ui, RECOMP_RUNTIME_UI_INPUT_ACCEPT, 1, 0));
+    assert(recomp_runtime_ui_handle_input(
+        standard_ui, RECOMP_RUNTIME_UI_INPUT_RIGHT, 1, 0));
+    assert(state.level == RECOMP_RUNTIME_UI_VIEW_ADAPTIVE);
+    recomp_runtime_ui_destroy(standard_ui);
     puts("runtime UI tests passed");
     return 0;
 }

--- a/tests/runtime_ui_test.c
+++ b/tests/runtime_ui_test.c
@@ -1,0 +1,103 @@
+#include "recomp_runtime_ui.h"
+
+#include <assert.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+typedef struct TestState {
+    int enabled;
+    int level;
+    int action_count;
+    int save_count;
+    int visible;
+} TestState;
+
+static int get_value(void *context, const RecompRuntimeUiItem *item, int *out) {
+    TestState *state = (TestState *)context;
+    if (!strcmp(item->key, "enabled")) *out = state->enabled;
+    else if (!strcmp(item->key, "level")) *out = state->level;
+    else return 0;
+    return 1;
+}
+
+static int set_value(void *context, const RecompRuntimeUiItem *item, int value) {
+    TestState *state = (TestState *)context;
+    if (!strcmp(item->key, "enabled")) state->enabled = value;
+    else if (!strcmp(item->key, "level")) state->level = value;
+    else return 0;
+    return 1;
+}
+
+static int run_action(void *context, const RecompRuntimeUiItem *item) {
+    TestState *state = (TestState *)context;
+    if (strcmp(item->key, "reset")) return 0;
+    ++state->action_count;
+    return 1;
+}
+
+static void save(void *context) { ++((TestState *)context)->save_count; }
+static void visible(void *context, int open) {
+    ((TestState *)context)->visible = open;
+}
+
+int main(void) {
+    static const RecompRuntimeUiItem items[] = {
+        { "enabled", "Video", "Enabled", "Toggle the feature.",
+          RECOMP_RUNTIME_UI_BOOL, 0, 1, 1, NULL, 0 },
+        { "level", "Video", "Level", "Adjust the level.",
+          RECOMP_RUNTIME_UI_INT, 0, 10, 2, NULL, 0 },
+        { "reset", "System", "Reset", "Run the action.",
+          RECOMP_RUNTIME_UI_ACTION, 0, 0, 0, NULL, 0 },
+    };
+    TestState state = { 0 };
+    RecompRuntimeUiConfig config = {0};
+    config.title = "Runtime UI";
+    config.subtitle = "TEST";
+    config.items = items;
+    config.item_count = sizeof(items) / sizeof(items[0]);
+    config.callbacks = (RecompRuntimeUiCallbacks){
+        &state, get_value, set_value, run_action, NULL, save, visible
+    };
+    config.theme = "n64";
+    RecompRuntimeUi *ui = recomp_runtime_ui_create(&config);
+    assert(ui != NULL);
+    assert(!recomp_runtime_ui_is_open(ui));
+
+    assert(recomp_runtime_ui_handle_input(
+        ui, RECOMP_RUNTIME_UI_INPUT_TOGGLE, 1, 0));
+    assert(recomp_runtime_ui_is_open(ui) && state.visible);
+    assert(recomp_runtime_ui_handle_input(
+        ui, RECOMP_RUNTIME_UI_INPUT_ACCEPT, 1, 0));
+    assert(recomp_runtime_ui_handle_input(
+        ui, RECOMP_RUNTIME_UI_INPUT_ACCEPT, 1, 0));
+    assert(state.enabled == 1 && state.save_count == 1);
+    assert(recomp_runtime_ui_handle_input(
+        ui, RECOMP_RUNTIME_UI_INPUT_DOWN, 1, 0));
+    assert(recomp_runtime_ui_handle_input(
+        ui, RECOMP_RUNTIME_UI_INPUT_RIGHT, 1, 0));
+    assert(state.level == 2 && state.save_count == 2);
+
+    uint32_t frame[256 * 224];
+    memset(frame, 0x7f, sizeof(frame));
+    uint32_t before = frame[0];
+    recomp_runtime_ui_render_argb8888(ui, frame, 256, 224, 256 * 4);
+    assert(frame[0] != before);
+    assert(frame[112 * 256 + 128] != 0x7f7f7f7fU);
+
+    assert(recomp_runtime_ui_handle_input(
+        ui, RECOMP_RUNTIME_UI_INPUT_BACK, 1, 0));
+    assert(recomp_runtime_ui_handle_input(
+        ui, RECOMP_RUNTIME_UI_INPUT_DOWN, 1, 0));
+    assert(recomp_runtime_ui_handle_input(
+        ui, RECOMP_RUNTIME_UI_INPUT_ACCEPT, 1, 0));
+    assert(recomp_runtime_ui_handle_input(
+        ui, RECOMP_RUNTIME_UI_INPUT_ACCEPT, 1, 0));
+    /* Actions own any persistence they need; value persistence is not rerun. */
+    assert(state.action_count == 1 && state.save_count == 2);
+    recomp_runtime_ui_close(ui);
+    assert(!state.visible);
+    recomp_runtime_ui_destroy(ui);
+    puts("runtime UI tests passed");
+    return 0;
+}


### PR DESCRIPTION
## Summary

- add a reusable in-game runtime settings model and public C API
- provide compact ARGB8888 and host Dear ImGui renderers
- build standard settings from explicit host/game capabilities
- share launcher themes and setting semantics instead of duplicating ecosystem UI
- support Native, fixed 16:9, and Adaptive view vocabulary only when an adapter advertises a real implementation
- stack long compact-overlay headers so game titles and platform subtitles cannot overlap
- document host integration and add model plus ImGui smoke tests

Ecosystem runtimes remain responsible for applying settings through their real live APIs. The shared component does not invent unsupported display, filter, or enhancement modes.

## Validation

- recomp-runtime-ui: passed
- recomp-runtime-ui-imgui: passed
- exercised through representative integrations for NES, SNES, GBA, GBC, Sega Genesis, Virtual Boy, and N64
- verified capability filtering on titles that should not expose view modes

## Attribution

The original in-game menu implementation was extracted and adapted from Derrick Gold's DerrickGold/ar-recomp. Both commits retain the Co-authored-by trailer for Derrick Gold <derrick.b.gold@gmail.com>.