### PR TITLE
runtime-ui: add a TEXT item type for string-valued settings

### DIFF
--- a/src/common/backends/imgui/runtime_ui_imgui.cpp
+++ b/src/common/backends/imgui/runtime_ui_imgui.cpp
@@ -25,6 +25,12 @@ void value_text(RecompRuntimeUi *ui, const RecompRuntimeUiItem *item,
         std::snprintf(out, out_size, "OPEN");
         return;
     }
+    if (item->type == RECOMP_RUNTIME_UI_TEXT) {
+        char buf[128];
+        recomp_runtime_ui_current_text(ui, item, buf, sizeof(buf));
+        std::snprintf(out, out_size, "%s", buf[0] ? buf : "(not set)");
+        return;
+    }
     int value = 0;
     if (!recomp_runtime_ui_current_value(ui, item, &value)) {
         std::snprintf(out, out_size, "Unavailable");
@@ -87,8 +93,12 @@ void draw_items(RecompRuntimeUi *ui, const LauncherTheme &theme) {
         const float row_h = item->description && item->description[0]
                                 ? theme.row_height + theme.spacing_sm
                                 : theme.row_height;
+        // INT rows carry -/+ buttons and TEXT rows an edit field, both drawn on
+        // top of the row selectable; without AllowOverlap the selectable would
+        // swallow the clicks meant for them.
         const ImGuiSelectableFlags row_flags =
-            item->type == RECOMP_RUNTIME_UI_INT
+            (item->type == RECOMP_RUNTIME_UI_INT ||
+             item->type == RECOMP_RUNTIME_UI_TEXT)
                 ? ImGuiSelectableFlags_AllowOverlap : 0;
         if (ImGui::Selectable("##setting", selected, row_flags,
                               ImVec2(0.0f, row_h))) {
@@ -111,18 +121,50 @@ void draw_items(RecompRuntimeUi *ui, const LauncherTheme &theme) {
                             start.y + theme.spacing_sm),
                       label_color, item->label ? item->label : "");
         const bool stepped_value = item->type == RECOMP_RUNTIME_UI_INT;
+        const bool editing_this = item->type == RECOMP_RUNTIME_UI_TEXT &&
+                                  ui->editing_text && selected;
         const float step_controls_w = stepped_value ? 96.0f : 0.0f;
-        const ImVec2 value_size = ImGui::CalcTextSize(value);
-        draw->AddText(ImVec2(end.x - theme.spacing_md - value_size.x -
-                                step_controls_w,
-                            start.y + theme.spacing_sm),
-                      u32(selected && enabled ? theme.accent2 : theme.text_muted),
-                      value);
+        if (!editing_this) {
+            const ImVec2 value_size = ImGui::CalcTextSize(value);
+            draw->AddText(ImVec2(end.x - theme.spacing_md - value_size.x -
+                                    step_controls_w,
+                                start.y + theme.spacing_sm),
+                          u32(selected && enabled ? theme.accent2
+                                                  : theme.text_muted),
+                          value);
+        }
         if (item->description && item->description[0]) {
             draw->AddText(ImVec2(start.x + theme.spacing_md,
                                 start.y + theme.spacing_sm +
                                     ImGui::GetTextLineHeight() + 2.0f),
                           u32(theme.text_muted), item->description);
+        }
+        if (editing_this && enabled) {
+            const float field_w = 200.0f;
+            const float field_h = ImGui::GetFrameHeight();
+            ImGui::SetCursorScreenPos(
+                ImVec2(end.x - theme.spacing_md - field_w,
+                       start.y + (row_h - field_h) * 0.5f));
+            ImGui::SetNextItemWidth(field_w);
+            // Nothing is active on the first frame of an edit, which is exactly
+            // when focus should land in the field.
+            if (!ImGui::IsAnyItemActive()) ImGui::SetKeyboardFocusHere();
+            const bool submitted = ImGui::InputText(
+                "##edit", ui->edit_buffer, sizeof(ui->edit_buffer),
+                ImGuiInputTextFlags_EnterReturnsTrue |
+                    ImGuiInputTextFlags_AutoSelectAll);
+            const bool cancelled = ImGui::IsKeyPressed(ImGuiKey_Escape);
+            if (submitted) {
+                recomp_runtime_ui_commit_text(ui, item, ui->edit_buffer);
+                ui->editing_text = 0;
+            } else if (cancelled) {
+                ui->editing_text = 0;
+            } else if (!ImGui::IsItemActive() && ImGui::IsAnyItemActive()) {
+                // Focus moved elsewhere (a click on another row): treat it as
+                // abandoning the edit rather than silently committing.
+                ui->editing_text = 0;
+            }
+            ImGui::SetCursorScreenPos(next);
         }
         if (stepped_value && enabled) {
             const float button_h = ImGui::GetFrameHeight();

--- a/src/common/recomp_runtime_ui.c
+++ b/src/common/recomp_runtime_ui.c
@@ -89,6 +89,9 @@ void recomp_runtime_ui_open(RecompRuntimeUi *ui) {
 }
 
 void recomp_runtime_ui_close(RecompRuntimeUi *ui) {
+    /* Abandon any in-progress edit, so reopening never resumes a stale buffer
+     * and wants_text_input cannot stay stuck on with the menu shut. */
+    if (ui) ui->editing_text = 0;
     visibility(ui, 0);
 }
 
@@ -129,6 +132,14 @@ void recomp_runtime_ui_adjust_current(RecompRuntimeUi *ui, int direction,
             accepted_action(ui);
         return;
     }
+    if (item->type == RECOMP_RUNTIME_UI_TEXT) {
+        /* Activation opens the editor; the backend drives it from there. */
+        if (!activate || repeat) return;
+        recomp_runtime_ui_current_text(ui, item, ui->edit_buffer,
+                                       sizeof(ui->edit_buffer));
+        ui->editing_text = 1;
+        return;
+    }
     if (!ui->config.callbacks.set_value) return;
     int value = 0;
     if (!recomp_runtime_ui_current_value(ui, item, &value)) return;
@@ -159,6 +170,33 @@ void recomp_runtime_ui_adjust_current(RecompRuntimeUi *ui, int direction,
     if (next != value && ui->config.callbacks.set_value(
             ui->config.callbacks.context, item, next))
         accepted_change(ui, "Saved");
+}
+
+void recomp_runtime_ui_current_text(RecompRuntimeUi *ui,
+                                    const RecompRuntimeUiItem *item, char *buf,
+                                    size_t buf_size) {
+    if (!buf || buf_size == 0) return;
+    buf[0] = '\0';
+    if (!ui || !item || !ui->config.callbacks.get_text) return;
+    if (!ui->config.callbacks.get_text(ui->config.callbacks.context, item, buf,
+                                       buf_size))
+        buf[0] = '\0';
+    buf[buf_size - 1] = '\0';
+}
+
+int recomp_runtime_ui_commit_text(RecompRuntimeUi *ui,
+                                  const RecompRuntimeUiItem *item,
+                                  const char *value) {
+    if (!ui || !item || !value || !ui->config.callbacks.set_text) return 0;
+    if (!ui->config.callbacks.set_text(ui->config.callbacks.context, item,
+                                       value))
+        return 0;
+    accepted_change(ui, "Saved");
+    return 1;
+}
+
+int recomp_runtime_ui_wants_text_input(const RecompRuntimeUi *ui) {
+    return (ui && ui->open && ui->editing_text) ? 1 : 0;
 }
 
 void recomp_runtime_ui_enter_section(RecompRuntimeUi *ui, size_t section) {

--- a/src/common/recomp_runtime_ui_internal.h
+++ b/src/common/recomp_runtime_ui_internal.h
@@ -20,6 +20,14 @@ struct RecompRuntimeUi {
     RecompRuntimeUiItem *owned_items;
     const char **owned_view_choices;
     int *owned_view_values;
+    /*
+     * Text-editing state. Owned by the presentation backend (the ImGui one
+     * drives an InputText), because the edit lifecycle -- caret, selection,
+     * commit-on-Enter -- is the widget's business, not the model's. The core
+     * keeps it here only so the host can query wants_text_input.
+     */
+    int editing_text;
+    char edit_buffer[128];
 };
 
 int recomp_runtime_ui_item_enabled(const RecompRuntimeUi *ui,
@@ -35,6 +43,14 @@ void recomp_runtime_ui_adjust_current(RecompRuntimeUi *ui, int direction,
                                       int activate, int repeat);
 void recomp_runtime_ui_enter_section(RecompRuntimeUi *ui, size_t section);
 void recomp_runtime_ui_leave_section(RecompRuntimeUi *ui);
+/* Reads a TEXT item's current value; writes "" when unavailable. */
+void recomp_runtime_ui_current_text(RecompRuntimeUi *ui,
+                                    const RecompRuntimeUiItem *item, char *buf,
+                                    size_t buf_size);
+/* Commits an edited TEXT value; returns non-zero when accepted. */
+int recomp_runtime_ui_commit_text(RecompRuntimeUi *ui,
+                                  const RecompRuntimeUiItem *item,
+                                  const char *value);
 
 #ifdef __cplusplus
 }

--- a/src/recomp_runtime_ui.h
+++ b/src/recomp_runtime_ui.h
@@ -8,6 +8,17 @@
 extern "C" {
 #endif
 
+/*
+ * Feature probe for hosts pinned to a submodule that may predate TEXT items.
+ * A host calling recomp_runtime_ui_wants_text_input() unconditionally would
+ * fail to link against an older pin, so guard on this:
+ *
+ *     #if defined(RECOMP_RUNTIME_UI_HAS_TEXT)
+ *         if (recomp_runtime_ui_wants_text_input(ui)) return true;
+ *     #endif
+ */
+#define RECOMP_RUNTIME_UI_HAS_TEXT 1
+
 typedef struct RecompRuntimeUi RecompRuntimeUi;
 
 typedef enum RecompRuntimeUiItemType {
@@ -15,6 +26,17 @@ typedef enum RecompRuntimeUiItemType {
     RECOMP_RUNTIME_UI_INT,
     RECOMP_RUNTIME_UI_CHOICE,
     RECOMP_RUNTIME_UI_ACTION,
+    /*
+     * Free-form string, edited in place. Uses get_text/set_text instead of
+     * get_value/set_value. Some settings simply are not a number or a choice --
+     * a postal code, a player name, a server address -- and stepping such a
+     * value with -/+ is unusable once its range is more than a few dozen wide.
+     *
+     * While one of these is being edited the host must stop treating arrows /
+     * Return / Escape as menu navigation; see
+     * recomp_runtime_ui_wants_text_input().
+     */
+    RECOMP_RUNTIME_UI_TEXT,
 } RecompRuntimeUiItemType;
 
 typedef enum RecompRuntimeUiInput {
@@ -83,6 +105,16 @@ typedef struct RecompRuntimeUiCallbacks {
     int (*is_enabled)(void *context, const RecompRuntimeUiItem *item);
     void (*save)(void *context);
     void (*visibility_changed)(void *context, int open);
+    /*
+     * RECOMP_RUNTIME_UI_TEXT items only. get_text fills buf with a
+     * NUL-terminated value and returns non-zero; set_text commits an edited
+     * value and returns non-zero if it was accepted (a rejected value leaves
+     * the row showing whatever get_text reports).
+     */
+    int (*get_text)(void *context, const RecompRuntimeUiItem *item, char *buf,
+                    size_t buf_size);
+    int (*set_text)(void *context, const RecompRuntimeUiItem *item,
+                    const char *value);
 } RecompRuntimeUiCallbacks;
 
 typedef struct RecompRuntimeUiConfig {
@@ -156,6 +188,14 @@ void recomp_runtime_ui_close(RecompRuntimeUi *ui);
 int recomp_runtime_ui_handle_input(RecompRuntimeUi *ui,
                                    RecompRuntimeUiInput input,
                                    int pressed, int repeat);
+
+/*
+ * Non-zero while a RECOMP_RUNTIME_UI_TEXT row has keyboard focus. The host must
+ * then stop mapping arrows / Return / Escape to menu navigation and let its
+ * ImGui backend consume them, or typing would move the selection instead of
+ * entering characters. The keys should still be withheld from the game.
+ */
+int recomp_runtime_ui_wants_text_input(const RecompRuntimeUi *ui);
 
 /*
  * Composites the menu over a little-endian SDL_PIXELFORMAT_ARGB8888/BGRA frame.


### PR DESCRIPTION
The item vocabulary is BOOL / INT / CHOICE / ACTION, which cannot express a setting that is genuinely a string.

A postal code is the case that forced it — Boktai's cartridge reads a photodiode as gameplay input, so a gbarecomp game wants the player's location to drive it. None of the existing types work:

- **INT** rows step by `item->step`, so a `0..99999` range needs thousands of clicks. A digit-place selector cuts that to ~20, but
- many postal codes **are not numeric at all** (`SW1A`, `K1A`), so no numeric widget can represent them, and
- **CHOICE** would mean enumerating every postal code on earth.

The same shape applies to a player name or a server address.

### What this adds

- **`RECOMP_RUNTIME_UI_TEXT`**, with `get_text` / `set_text` callbacks alongside `get_value` / `set_value`. `set_text` returns non-zero only if it accepted the value, so a rejected edit leaves the row showing the previous one rather than persisting something malformed.

- **`recomp_runtime_ui_wants_text_input()`** — non-zero while a field has focus. Hosts must consult it: their arrow/Return/Escape mapping would otherwise move the selection out from under the caret while the player types. Cleared on close so it can never latch on with the menu shut.

- **`RECOMP_RUNTIME_UI_HAS_TEXT`** feature macro, so a host pinned to an older submodule can guard the call rather than failing to link.

### Design note

The edit lifecycle — caret, selection, commit-on-Enter, Escape-to-cancel — lives in the ImGui backend, since that is the widget's business; the core keeps only the flag and buffer a host needs to query. Enter commits, Escape cancels, and focus moving to another row abandons rather than silently committing.

### Compatibility

Additive. Existing items and hosts are untouched, and a host that never sets `get_text` simply has no TEXT rows. The consuming side is mstan/gbarecomp#8, which guards on the macro and does **not** require this PR to build.

Exercised through a real host (a gbarecomp game): typing a US ZIP, a UK outward code, whitespace trimming, rejection of a malformed value, and Escape-cancel. I have only run the ImGui backend — `recomp_runtime_ui_render_argb8888` has no TEXT rendering path yet, so a host using that backend would see the row but not an editor. Happy to add it if you want parity before merge.
