### PR TITLE
launcher: drive the first-run BIOS step off SystemProfile instead of hardcoded PlayStation text

### DIFF
--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -5076,6 +5076,31 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
     (void)win;
 }
 
+// First-run wizard BIOS vocabulary. That step is shared by every has_bios
+// console but its strings were hardcoded to the PSX case; these resolve from the
+// active SystemProfile and fall back to the legacy PSX wording, so a profile that
+// has not opted in reads exactly as before.
+const char* bios_label_of(const LauncherModel* m) {
+    if (m->profile && m->profile->bios_label && m->profile->bios_label[0])
+        return m->profile->bios_label;
+    return "PlayStation BIOS";
+}
+const char* bios_note_of(const LauncherModel* m) {
+    if (m->profile && m->profile->bios_note && m->profile->bios_note[0])
+        return m->profile->bios_note;
+    return "Default: bundled OpenBIOS. Optionally browse for your own "
+           "SCPH1001.BIN (exactly 512 KB, dumped from your console).";
+}
+const char* bios_picker_title_of(const LauncherModel* m) {
+    if (m->profile && m->profile->bios_picker_title &&
+        m->profile->bios_picker_title[0])
+        return m->profile->bios_picker_title;
+    return "Select PlayStation BIOS (SCPH1001.BIN)";
+}
+bool bios_is_required(const LauncherModel* m) {
+    return m->profile && m->profile->bios_required != 0;
+}
+
 void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
     if (!m->setup_wizard_open) return;
     launcher_model_poll_prepare_disc(m);
@@ -5094,10 +5119,14 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
     ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + px(480));
     if (m->has_bios) {
         ImGui::TextColored(col(th.text_muted),
-            "%s needs a playable %s before you can launch. This build includes "
-            "a bundled BIOS (OpenBIOS) by default — a retail SCPH1001.BIN dump "
-            "is optional. Pick your %s below (you must legally own these dumps).",
-            game, noun, noun);
+            bios_is_required(m)
+                ? "%s needs a playable %s and a %s before you can launch. Pick "
+                  "both below (you must legally own these dumps)."
+                : "%s needs a playable %s before you can launch. This build "
+                  "includes a bundled BIOS (OpenBIOS) by default — a retail "
+                  "SCPH1001.BIN dump is optional. Pick your %s below (you must "
+                  "legally own these dumps).",
+            game, noun, bios_is_required(m) ? bios_label_of(m) : noun);
     } else {
         ImGui::TextColored(col(th.text_muted),
             "%s needs a playable %s before you can launch. Pick your file below "
@@ -5113,13 +5142,16 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
     /* ---- BIOS (PSX / GBA): empty = bundled; Browse for optional retail ---- */
     if (m->has_bios) {
         const bool has_pick = m->s.bios_path[0] != 0;
-        ImGui::TextUnformatted("1. PlayStation BIOS (optional)");
+        char bios_head[128];
+        snprintf(bios_head, sizeof(bios_head), "1. %s (%s)", bios_label_of(m),
+                 bios_is_required(m) ? "required" : "optional");
+        ImGui::TextUnformatted(bios_head);
         ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + px(480));
-        ImGui::TextColored(col(th.text_muted),
-            "Default: bundled OpenBIOS. Optionally browse for your own "
-            "SCPH1001.BIN (exactly 512 KB, dumped from your console).");
+        ImGui::TextColored(col(th.text_muted), "%s", bios_note_of(m));
         ImGui::PopTextWrapPos();
-        const char* bp = has_pick ? m->s.bios_path : "Bundled BIOS (OpenBIOS)";
+        const char* bp = has_pick ? m->s.bios_path
+                        : (bios_is_required(m) ? "No BIOS selected yet"
+                                               : "Bundled BIOS (OpenBIOS)");
         char belided[220];
         elide_left(bp, px(300), belided, sizeof(belided));
         ImGui::AlignTextToFramePadding();
@@ -5132,7 +5164,7 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
         if (ImGui::Button("Browse BIOS##setup", ImVec2(px(120), px(32)))) {
             char buf[512];
             static const char* kBiosPatterns[] = { "*.bin", "*.rom" };
-            if (launcher_pick_file("Select PlayStation BIOS (SCPH1001.BIN)",
+            if (launcher_pick_file(bios_picker_title_of(m),
                                    kBiosPatterns, 2, "BIOS image (.bin .rom)",
                                    buf, sizeof(buf)))
                 launcher_model_set_bios_path(m, buf);

--- a/src/common/launcher_system_types.h
+++ b/src/common/launcher_system_types.h
@@ -144,6 +144,20 @@ typedef struct SystemProfile {
     // wordmark may be a third-party trademark); an absent file falls back to
     // the text, so this is inert unless a host drops the asset in.
     const char* wordmark_image;
+
+    // BIOS vocabulary for the first-run setup wizard's BIOS step. That step is
+    // shared by every has_bios console, but its strings were hardcoded to the
+    // PSX case, so a GBA game told the player a REQUIRED 16 KB gba_bios.bin was
+    // an OPTIONAL 512 KB SCPH1001.BIN backed by a bundled OpenBIOS that does not
+    // exist for that runtime.
+    //
+    // NULL => the legacy PSX strings, and bios_required zero-fills to 0 => the
+    // legacy "optional, a bundled BIOS covers it" semantics, so existing
+    // positional profile rows are unchanged.
+    const char* bios_label;         // e.g. "Game Boy Advance BIOS"
+    const char* bios_note;          // one line under the label
+    const char* bios_picker_title;  // native file-dialog title
+    int         bios_required;      // 1 => no bundled fallback; must be supplied
 } SystemProfile;                                    // ONE ROW PER CONSOLE
 
 // ---- shared panel composition arrays (NULL-terminated) --------------------------

--- a/src/consoles/gba/gba_profile.h
+++ b/src/consoles/gba/gba_profile.h
@@ -109,6 +109,19 @@ static const SystemProfile kSystemProfileGba = {
     /* screen_kind_count */ LNG_GBA_SCREEN_KIND_COUNT,
     /* rom_filter        */ { kGbaRomPatterns, LNG_GBA_ROM_PATTERN_COUNT,
                               "Game Boy Advance ROM (.gba)" },
+    /* renderer_labels   */ NULL,
+    /* hide_audio_freq   */ 0,
+    /* brand             */ NULL,
+    /* wordmark_image    */ NULL,
+    // The GBA BIOS is REQUIRED, not optional: gbarecomp recompiles and executes
+    // the real BIOS rather than HLE-ing it (PRINCIPLES.md "BIOS is sacred"), and
+    // ships no bundled fallback, so the runtime refuses to launch without one.
+    // It is also 16 KB, not the 512 KB the PSX wording describes.
+    /* bios_label        */ "Game Boy Advance BIOS",
+    /* bios_note         */ "Required. A 16 KB gba_bios.bin dump — this runtime "
+                            "executes the real BIOS and ships no substitute.",
+    /* bios_picker_title */ "Select Game Boy Advance BIOS (gba_bios.bin)",
+    /* bios_required     */ 1,
 };
 
 // ---- name aliases + ABI capability defaults -------------------------------------


### PR DESCRIPTION
The first-run setup wizard's BIOS step is shared by every `has_bios` console — its own comment says `/* ---- BIOS (PSX / GBA): ... */` — but every string in it is the PSX case. A GBA game currently shows:

> **1. PlayStation BIOS (optional)**
> Default: bundled OpenBIOS. Optionally browse for your own SCPH1001.BIN (exactly 512 KB, dumped from your console).

and a file dialog titled `Select PlayStation BIOS (SCPH1001.BIN)`.

Every one of those claims is wrong for GBA. gbarecomp **recompiles and executes the real BIOS** rather than HLE-ing it, ships **no bundled substitute**, and **refuses to launch** without one. So:

| The wizard says | Reality for GBA |
|---|---|
| "PlayStation BIOS" | Game Boy Advance BIOS |
| "(optional)" | **required** — the runtime will not start |
| "bundled OpenBIOS" default | no bundled BIOS exists |
| "SCPH1001.BIN, exactly 512 KB" | `gba_bios.bin`, 16 KB |

It is telling the player that the one asset the launch cannot proceed without is optional, on the first screen they ever see.

## The change

`SystemProfile` gains four fields — `bios_label`, `bios_note`, `bios_picker_title`, `bios_required` — appended at the end so existing positional profile rows zero-fill, following the same convention already used for `screen_kind_names`, `renderer_labels`, `brand` and `wordmark_image`.

The wizard resolves them through small helpers whose fallbacks return **exactly** today's PSX strings, so a profile that has not opted in is byte-for-byte unchanged. `bios_required` is deliberately phrased so that `0` is the legacy "optional, a bundled BIOS covers it" meaning.

The GBA row opts in. Nothing else does.

## Verification

Enumerated every profile:

```
  gba      required=1  label="Game Boy Advance BIOS"
  psx      required=0  label="PlayStation BIOS"
  snes     required=0  label="PlayStation BIOS"
  n64      required=0  label="PlayStation BIOS"
  nes      required=0  label="PlayStation BIOS"
  genesis  required=0  label="PlayStation BIOS"
  gb       required=0  label="PlayStation BIOS"
```

`recomp-ui-launcher` builds clean.

Not visually reviewed — I could not click through the rendered wizard, so the layout of the slightly longer GBA label may want a pass. The strings and the fallback behaviour are what I verified.

Found while designing a first-run *builder* for a GBA title, where this screen is the entry point to the entire flow rather than an occasional dialog.
