### PR TITLE
Remove unresolved conflict markers from recomp_launcher.h (master does not compile)

### DIFF
--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -745,8 +745,6 @@ typedef struct RecompLauncherCGameInfo {
      * discovery, sensor selection, and axis mapping remain host-owned. */
     int has_gyro_controls;
 
-<<<<<<< HEAD
-=======
     /* Add independent checkboxes to Display settings. The host maps their
      * committed Settings values onto renderer configuration. */
     int has_sharp_filter;
@@ -759,7 +757,6 @@ typedef struct RecompLauncherCGameInfo {
     const char* const* display_layout_labels;
     int num_display_layouts;
 
->>>>>>> 7835628ba4ba92d253e228438527507a409bd365
     /* ---- prepare job UX (appended; disc convert / local codegen) ---------
      * prepare_use_selected_rom: 1 = the prepare button uses the already-
      * picked ROM/disc (no second file picker). Cart codegen hosts use this.


### PR DESCRIPTION
`master` does not compile. `b0cadfd` ("Chain setup prepare into rebuild and relaunch") committed three conflict markers into `RecompLauncherCGameInfo`:

```
748: <<<<<<< HEAD
749: =======
762: >>>>>>> 7835628ba4ba92d253e228438527507a409bd365
```

Every translation unit that includes `recomp_launcher.h` fails immediately:

```
src/recomp_launcher.h:748:1: error: version control conflict marker in file
```

That breaks `recomp-ui-launcher` (this repo's own target) and every downstream consumer.

## The resolution is unambiguous

The `HEAD` side of the conflict is **empty**. The incoming side declares four fields — and `launcher_model.c` already reads all four in committed code:

| launcher_model.c | field |
|---|---|
| :164 | `display_layout_labels` |
| :165 | `num_display_layouts` |
| :175 | `has_sharp_filter` |
| :176 | `has_affine_filter` |

So the fields have to exist for the tree to be self-consistent. This keeps the incoming side, deletes the three markers, and changes nothing else. The fields stay exactly where the incoming side put them — before the prepare-job block — so no positional initializer in any profile row shifts.

## Verification

- `recomp-ui-launcher` builds clean.
- A downstream GBA consumer linking via `recomp_target_launcher_ui()` builds clean.

Both failed on the marker before this commit.

Found while pulling latest `master` into a GBA game repo.