### PR TITLE
psx: allow Steam .car disc images in pickers

### DIFF
--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -5649,7 +5649,8 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
     {
         const char* media_help =
             (plat == SETUP_PLAT_PSX)
-                ? "Select the .cue sheet (MODE2/2352), not the .bin track file. "
+                ? "Select the .cue sheet (MODE2/2352) when present. Steam .car "
+                  "disc images can be selected directly. "
                   "The .cue keeps multitrack / audio-track layout correct for "
                   "generate and boot. Cooked .iso dumps are OK — Generate "
                   "converts them to a working .bin/.cue, then verifies the "
@@ -5701,7 +5702,8 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
             draw_verdict_block(m, th, ImGui::GetContentRegionAvail().x);
         if (plat == SETUP_PLAT_PSX && m->rom_present && m->rom_full[0]) {
             const char* ext = strrchr(m->rom_full, '.');
-            if (ext && (lps_streq_ci(ext, ".bin") || lps_streq_ci(ext, ".img"))) {
+            if (ext && (lps_streq_ci(ext, ".bin") || lps_streq_ci(ext, ".img") ||
+                        lps_streq_ci(ext, ".car"))) {
                 ImGui::PushTextWrapPos(wrap_x);
                 ImGui::TextColored(col(th.warn),
                     "You picked a track image (%s). Prefer the matching .cue "
@@ -5763,14 +5765,14 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
             } else {
                 char buf[512];
                 static const char* kDumpPatterns[] = {
-                    "*.cue", "*.iso", "*.bin", "*.img", "*.*" };
+                    "*.cue", "*.iso", "*.bin", "*.img", "*.car", "*.*" };
                 if (launcher_pick_file(
                         plat == SETUP_PLAT_PSX
                             ? "Select disc (.cue preferred; .iso OK)"
                             : "Select raw disc dump to convert",
-                        kDumpPatterns, 5,
+                        kDumpPatterns, 6,
                         plat == SETUP_PLAT_PSX
-                            ? "PlayStation disc (.cue .iso .bin)"
+                            ? "PlayStation disc (.cue .iso .bin .img .car)"
                             : "Disc dump",
                         buf, sizeof(buf)))
                     launcher_model_start_prepare_disc(m, buf);

--- a/src/consoles/psx/psx_profile.h
+++ b/src/consoles/psx/psx_profile.h
@@ -45,10 +45,10 @@ static const char* const kPanelsSettingsPsx[]   = { "video", "audio", "system", 
 
 // ---- ROM (disc) file-picker filter ----------------------------------------------
 // Prefer .cue (multitrack-safe). .iso is accepted and normalized to .bin/.cue
-// by prepare_disc / generate. Bare .bin is last among common dumps so users
-// are nudged away from picking a single track file.
+// by prepare_disc / generate. Steam's .car is a raw disc image and can be
+// selected directly. Bare track images follow the formats with their own TOC.
 static const char* const kPsxDiscPatterns[] = {
-    "*.cue", "*.iso", "*.img", "*.bin", "*.pbp", "*.chd"
+    "*.cue", "*.iso", "*.pbp", "*.chd", "*.img", "*.bin", "*.car"
 };
 #define LNG_PSX_DISC_PATTERN_COUNT \
     ((int)(sizeof(kPsxDiscPatterns) / sizeof(kPsxDiscPatterns[0])))
@@ -97,7 +97,7 @@ static const SystemProfile kSystemProfilePsx = {
     /* screen_kind_names */ NULL,   /* legacy Raw/CRT/Composite/Trinitron set */
     /* screen_kind_count */ 0,
     /* rom_filter        */ { kPsxDiscPatterns, LNG_PSX_DISC_PATTERN_COUNT,
-                              "PlayStation disc (.cue preferred; .iso/.bin/.img/.pbp/.chd)" },
+                              "PlayStation disc (.cue preferred; .iso/.bin/.img/.car/.pbp/.chd)" },
     /* renderer_labels   */ NULL,
     /* hide_audio_freq   */ 0,
     /* brand             */ "brand_psx.tga",

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -718,7 +718,7 @@ typedef struct RecompLauncherCGameInfo {
      *
      * prepare_disc (optional): convert a raw dump into a playable image.
      * Blocking host callback; the UI shows a busy state while it runs.
-     * Return 1 and write the playable .cue/.bin/.iso path into out_disc_path.
+     * Return 1 and write the playable .cue/.bin/.img/.iso/.car path into out_disc_path.
      * prepare_disc_label / prepare_disc_note are button + help text (NULL =>
      * "Convert raw dump…" / default note).
      *


### PR DESCRIPTION
Expose Steam's extension-renamed PlayStation raw disc images in the shared PSX launcher and preparation pickers. Players can select t_data_u.car directly instead of renaming it to .bin.

Context: mstan/TombaRecomp#14