### PR TITLE
launcher: PSX mouse + dual binds, suspend pad nav while capturing, drop Hybrid

### DIFF
--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -1620,17 +1620,18 @@ void panel_tpak_draw(LauncherModel* m, const LauncherTheme* th) {
     }
 }
 
-// PSX-style 3-way pad-mode selector: Hybrid / Analog / D-Pad segmented row.
-// Caller only draws this when pad_mode_supported && pad_mode_selectable (a
-// locked mode draws nothing — there's nothing to pick). The Hybrid segment is
-// itself hidden when !allow_hybrid, matching the original PSX launcher.
+// PSX-style pad-mode selector: Analog / D-Pad segmented row. Caller only draws
+// this when pad_mode_supported && pad_mode_selectable (a locked mode draws
+// nothing — there's nothing to pick). Hybrid is deliberately absent: it is a
+// mod-only mode a trusted game plugin requests at runtime, never a player
+// choice.
 void pad_mode_selector(LauncherModel* m, const LauncherTheme& th, int p, float w) {
     struct Seg { int mode; const char* label; };
     Seg segs[8];
     int n = 0;
     // A console with a custom pad-mode list (ControllerSpec.modes, e.g. Genesis
     // 3-Button/6-Button) drives the segments from that list; otherwise the
-    // legacy PSX-shaped Hybrid/Analog/D-Pad set (Hybrid gated by allow_hybrid).
+    // legacy PSX-shaped Analog/D-Pad set.
     const SystemProfile* prof = (const SystemProfile*)m->profile;
     if (prof && prof->controller.modes && prof->controller.mode_count > 0) {
         int mc = prof->controller.mode_count;
@@ -1638,12 +1639,11 @@ void pad_mode_selector(LauncherModel* m, const LauncherTheme& th, int p, float w
         for (int i = 0; i < mc; ++i)
             segs[n++] = { prof->controller.modes[i].mode, prof->controller.modes[i].label };
     } else {
-        if (m->allow_hybrid) segs[n++] = { 0, "Hybrid" };
         segs[n++] = { 1, "Analog" };
         segs[n++] = { 2, "D-Pad" };
     }
 
-    // Keyboard has no analog sticks — Hybrid/Analog are unavailable (PSX modes).
+    // Keyboard has no analog sticks — Analog is unavailable (PSX modes).
     const bool kb_digital_only =
         m->s.player_src[p] == 1 &&
         !(prof && prof->controller.modes && prof->controller.mode_count > 0);
@@ -1653,8 +1653,8 @@ void pad_mode_selector(LauncherModel* m, const LauncherTheme& th, int p, float w
     for (int i = 0; i < n; ++i) {
         if (i) ImGui::SameLine(0, gap);
         bool sel = m->s.pad_mode[p] == segs[i].mode;
-        // Modes 0 (Hybrid) and 1 (Analog) need sticks; grey out on keyboard.
-        const bool stick_mode = (segs[i].mode == 0 || segs[i].mode == 1);
+        // Analog needs sticks; grey out on keyboard.
+        const bool stick_mode = (segs[i].mode == 1);
         const bool disabled = kb_digital_only && stick_mode;
         ImGui::PushID(i);
         if (disabled) {

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -6474,6 +6474,25 @@ bool try_capture(LauncherModel* m, const SDL_Event& ev) {
         return true;   // swallow all other input (keyboard included) while pad-capturing
     }
 
+    /* Mouse buttons are bindable inputs on stores that keep alternates
+     * (PSX): bind-a-mouse-button is the whole point of the alt slot. The
+     * click that OPENED this capture must not bind itself, so a
+     * button-UP has to be seen first (capture_mouse_armed). */
+    if (m->capturing && !m->capture_pad) {
+        const SystemProfile* mprof = (const SystemProfile*)m->profile;
+        const bool alt_store = mprof && mprof->controller.binds_per_input >= 2;
+        if (ev.type == SDL_EVENT_MOUSE_BUTTON_UP) return true;   /* swallow */
+        if (ev.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
+            if (!alt_store || !m->capture_mouse_armed) return true;
+            int btn = (int)ev.button.button;      /* SDL: 1 L, 2 M, 3 R, 4/5 side */
+            if (btn >= 1 && btn <= 5) {
+                launcher_binds_set_button_slot(m, m->cfg_player + 1, m->capture_btn,
+                                               m->capture_slot, 512 + btn);
+                launcher_model_cancel_capture(m);
+            }
+            return true;
+        }
+    }
     if (ev.type != SDL_EVENT_KEY_DOWN) return true;   // swallow non-key input while capturing
     if (m->capturing) {
         // N64's input.cfg keeps two alternate binds per input, so a keyboard
@@ -6481,7 +6500,10 @@ bool try_capture(LauncherModel* m, const SDL_Event& ev) {
         // Single-bind stores (SNES/PSX/GBA) use the legacy scancode setter
         // (capture_slot is always 0 for them).
         const SystemProfile* prof = (const SystemProfile*)m->profile;
-        if (prof && prof->controller.binds_per_input >= 2)
+        if (prof && prof->controller.binds_per_input >= 2 && prof->id && !strcmp(prof->id, "psx"))
+            launcher_binds_set_button_slot(m, m->cfg_player + 1, m->capture_btn,
+                                           m->capture_slot, (int)LNG_EVSCAN(ev));
+        else if (prof && prof->controller.binds_per_input >= 2)
             launcher_binds_set_field(m, m->cfg_player + 1, m->capture_btn, m->capture_slot,
                                      RUI_N64_FIELD_KEY, (int)LNG_EVSCAN(ev));
         else
@@ -6716,6 +6738,22 @@ extern "C" LngAction launcher_backend_run(LauncherPlatform* p,
             g_pads, LNG_MAX_PADS, m->has_gyro_controls ? 1 : 0);
 
         ImGui_ImplOpenGL3_NewFrame();
+        /* Suspend ImGui's GAMEPAD navigation while a bind capture is open.
+         *
+         * The SDL backend POLLS gamepad state in NewFrame (see
+         * ImGui_ImplSDL3_UpdateGamepads) rather than reading the SDL event
+         * queue, so swallowing pad events in try_capture cannot stop the pad
+         * from driving the menu: press a button to bind it and the focus
+         * jumps instead. Clearing the flag for the frame is the only thing
+         * that actually suppresses it. Keyboard nav stays on so Esc, arrows
+         * and Enter still work while listening. */
+        {
+            ImGuiIO& nav_io = ImGui::GetIO();
+            if (m->capturing || m->hk_capturing || m->camera_capturing)
+                nav_io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableGamepad;
+            else
+                nav_io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
+        }
         LNG_ImplSDL_NewFrame();
         if (force_dpi) {   // Windows has no native point/pixel split — inject it
             ImGuiIO& io = ImGui::GetIO();

--- a/src/common/launcher_binds.c
+++ b/src/common/launcher_binds.c
@@ -167,6 +167,15 @@ static void copy_str(char* d, size_t cap, const char* s) {
 
 static const char* scancode_label(SDL_Scancode sc) {
     if (sc == SDL_SCANCODE_UNKNOWN) return "(unbound)";
+    /* Mouse buttons are bound as pseudo-scancodes ABOVE SDL keyboard space
+     * (512 + SDL button), so SDL_GetScancodeName knows nothing about them
+     * and every mouse bind rendered as "(unbound)" - the bind had actually
+     * been written and persisted, it was purely a display failure. */
+    if ((int)sc > 512 && (int)sc <= 517) {
+        static const char* const kMouseNames[5] =
+            { "Mouse1", "Mouse2", "Mouse3", "Mouse4", "Mouse5" };
+        return kMouseNames[(int)sc - 513];
+    }
     const char* n = SDL_GetScancodeName(sc);
     return (n && n[0]) ? n : "(unbound)";
 }
@@ -191,10 +200,14 @@ static void genesis_pad_label(int kind, int code, int axis_dir, char* out, size_
 static void reload_player_display(LauncherModel* m, int player) {
     if (is_psx_profile(m)) {
         if (player < 1 || player > LNG_MAX_PLAYERS) return;
-        for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b)
+        for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b) {
             copy_str(m->binds[player - 1][b], sizeof(m->binds[player - 1][b]),
-                     scancode_label((SDL_Scancode)rui_psx_binds_get(
-                         keybinds_file_path(), player - 1, b)));
+                     scancode_label((SDL_Scancode)rui_psx_binds_get_slot(
+                         keybinds_file_path(), player - 1, b, 0)));
+            copy_str(m->binds_alt[player - 1][b], sizeof(m->binds_alt[player - 1][b]),
+                     scancode_label((SDL_Scancode)rui_psx_binds_get_slot(
+                         keybinds_file_path(), player - 1, b, 1)));
+        }
         return;
     }
     if (is_nes_profile(m)) {
@@ -482,6 +495,20 @@ void launcher_binds_reset_camera(LauncherModel* m) {
     launcher_binds_refresh_camera(m);
 }
 
+/* Slot-aware setter for stores that keep an alternate bind per input.
+ * PSX keeps two (primary + alt, either may be a mouse pseudo-scancode). */
+void launcher_binds_set_button_slot(LauncherModel* m, int player, int b,
+                                    int slot, int scancode) {
+    if (!m || !is_psx_profile(m)) return;
+    if (player < 1 || player > LNG_MAX_PLAYERS) return;
+    if (b < 0 || b >= LNG_PSX_PAD_BUTTON_COUNT) return;
+    rui_psx_binds_set_slot(keybinds_file_path(), player - 1, b, slot, scancode);
+    char* dst = (slot == 1) ? m->binds_alt[player - 1][b] : m->binds[player - 1][b];
+    size_t cap = (slot == 1) ? sizeof(m->binds_alt[player - 1][b])
+                             : sizeof(m->binds[player - 1][b]);
+    copy_str(dst, cap, scancode_label((SDL_Scancode)scancode));
+}
+
 void launcher_binds_set_button(LauncherModel* m, int player, int b, int scancode) {
     if (is_n64_profile(m)) {
         // Keyboard capture into the N64 store routes through the field API
@@ -490,11 +517,7 @@ void launcher_binds_set_button(LauncherModel* m, int player, int b, int scancode
         return;
     }
     if (is_psx_profile(m)) {
-        if (player < 1 || player > LNG_MAX_PLAYERS) return;
-        if (b < 0 || b >= LNG_PSX_PAD_BUTTON_COUNT) return;
-        rui_psx_binds_set(keybinds_file_path(), player - 1, b, scancode);
-        copy_str(m->binds[player - 1][b], sizeof(m->binds[player - 1][b]),
-                 scancode_label((SDL_Scancode)scancode));
+        launcher_binds_set_button_slot(m, player, b, 0, scancode);
         return;
     }
     if (player < 1 || player > 2) return;

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -110,7 +110,6 @@ void launcher_model_init(LauncherModel* m,
 
         m->pad_mode_supported   = game->pad_mode_supported != 0;
         m->pad_mode_selectable  = game->pad_mode_selectable != 0;
-        m->allow_hybrid         = game->allow_hybrid != 0;
         m->locked_pad_mode      = clampi(game->locked_pad_mode, 0, 2);
         m->lock_device          = game->lock_device != 0;
         m->aspect_mask          = game->aspect_mask;
@@ -277,8 +276,10 @@ void launcher_model_init(LauncherModel* m,
                 for (int i = 0; i < pm_spec->mode_count; ++i)
                     if (pm_spec->modes[i].mode == m->s.pad_mode[p]) { ok = 1; break; }
                 if (!ok) m->s.pad_mode[p] = pm_spec->modes[0].mode;
-            } else if (!m->allow_hybrid && m->s.pad_mode[p] == 0) {
-                m->s.pad_mode[p] = 1;   // snap Hybrid -> Analog
+            } else if (m->s.pad_mode[p] == 0) {
+                /* Hybrid is mod-only and never selectable: migrate any stale
+                 * persisted value. The mod requests it at runtime instead. */
+                m->s.pad_mode[p] = 1;
             }
             /* Keyboard cannot drive Analog/Hybrid — force D-Pad. */
             if (m->s.player_src[p] == 1 &&
@@ -1911,10 +1912,10 @@ void launcher_model_set_pad_mode(LauncherModel* m, int player, int mode) {
             if (spec->modes[i].mode == mode) { m->s.pad_mode[player] = mode; return; }
         return;
     }
-    /* Keyboard has no sticks — Analog/Hybrid are unavailable. */
+    /* Keyboard has no sticks — Analog is unavailable. */
     if (m->s.player_src[player] == 1 && mode != 2) return;
     mode = clampi(mode, 0, 2);
-    if (mode == 0 && !m->allow_hybrid) mode = 1;   // Hybrid hidden -> snap to Analog
+    if (mode == 0) mode = 1;   /* Hybrid is mod-only -> snap to Analog */
     m->s.pad_mode[player] = mode;
 }
 

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -2026,6 +2026,10 @@ void launcher_model_begin_capture_slot(LauncherModel* m, int b, int slot) {
     m->capturing     = true;
     m->capture_btn   = b;
     m->capture_slot  = (slot == 1) ? 1 : 0;
+    /* ImGui activates a button on RELEASE, so the click that opened this
+     * capture is already fully consumed by the time capturing is true.
+     * Arm straight away: the next press is a deliberate new click. */
+    m->capture_mouse_armed = true;
     m->hk_capturing = false;
     m->capturing    = true;
     m->capture_pad  = false;

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -284,7 +284,6 @@ typedef struct {
     // ---- controller pad-mode caps (PlayStation-style analog/digital) ----
     bool     pad_mode_supported;    // false => no selector/art swap; generic pad.tga
     bool     pad_mode_selectable;   // false => selector hidden, mode forced to locked_pad_mode
-    bool     allow_hybrid;          // false => Hybrid option hidden
     int      locked_pad_mode;       // forced mode when !pad_mode_selectable
     bool     lock_device;           // true => hide the player controller cards entirely
 
@@ -615,9 +614,10 @@ void launcher_model_apply_msu1_patch(LauncherModel* m);
 void launcher_model_skip_msu1_patch(LauncherModel* m);
 
 // ---- controllers ----
-// PSX-style pad mode: 0=Hybrid, 1=Analog, 2=D-Pad. Gated: no-op when
-// !pad_mode_selectable (mode is locked); snaps away from Hybrid when
-// !allow_hybrid.
+// PSX-style pad mode: 1=Analog, 2=D-Pad. Gated: no-op when
+// !pad_mode_selectable (mode is locked). Mode 0 (Hybrid) is NOT selectable —
+// it is a mod-only mode requested at runtime by a trusted game plugin — so a
+// stale persisted 0 snaps to Analog.
 void launcher_model_set_pad_mode(LauncherModel* m, int player, int mode);
 void launcher_model_cycle_player_src(LauncherModel* m, int player); // None/Kbd/Pad
 void launcher_model_deadzone_delta(LauncherModel* m, int player, int delta);

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -418,6 +418,10 @@ typedef struct {
     // ControllerSpec sets has_pad_binds (Genesis; the engine stores a gamepad
     // button/axis bind per logical button alongside the keyboard scancode).
     bool      capture_pad;
+    // A mouse button may be BOUND on stores that keep alternates (PSX).
+    // The click that opened the capture must not bind itself, so a
+    // button-UP has to arrive before a DOWN is accepted as a bind.
+    bool      capture_mouse_armed;
     bool      camera_capturing;  // capturing an enabled Voxel camera key
     int       capture_camera;    // LNG_CAMERA_* index
     bool      hk_capturing;      // capturing a system hotkey
@@ -686,6 +690,9 @@ void launcher_model_begin_capture(LauncherModel* m, int b);
 // launcher_model_begin_capture() is slot 0. Only consoles whose bind bridge
 // stores two slots per input (N64) show slot-1 chips.
 void launcher_model_begin_capture_slot(LauncherModel* m, int b, int slot);
+// Write one bind slot (0 primary, 1 alternate) for stores that keep two.
+void launcher_binds_set_button_slot(LauncherModel* m, int player, int b,
+                                    int slot, int scancode);
 // Begin capturing the GAMEPAD bind (button or axis) for button `b` instead of
 // a keyboard scancode. Only meaningful on has_pad_binds consoles (Genesis) —
 // the UI never offers it elsewhere; a stray call is harmless (Esc cancels).

--- a/src/common/launcher_system_types.h
+++ b/src/common/launcher_system_types.h
@@ -40,7 +40,7 @@ typedef struct { const char* label; int code; } ButtonDef;
 // text; `button_count` is how many LEADING entries of ControllerSpec.buttons[]
 // the rebind page shows in that mode (a Genesis 3-button pad has no X/Y/Z/Mode
 // rows). A profile that leaves ControllerSpec.modes NULL keeps the legacy
-// PSX-shaped selector (Hybrid/Analog/D-Pad, gated by allow_hybrid) with the
+// PSX-shaped selector (Analog/D-Pad) with the
 // full button set in every mode — PSX itself is untouched by this concept.
 typedef struct { int mode; const char* label; int button_count; } PadModeDef;
 

--- a/src/consoles/genesis/genesis_profile.h
+++ b/src/consoles/genesis/genesis_profile.h
@@ -127,10 +127,9 @@ static inline void launcher_profile_apply_genesis(RecompLauncherCGameInfo* gi) {
     gi->rom_noun = "ROM";
     // 3-Button/6-Button pad-mode selector (per player, engine PadType values).
     // The custom mode list lives on the SystemProfile row; these ABI flags
-    // just switch the selector on. allow_hybrid is a PSX-only concept.
+    // just switch the selector on.
     gi->pad_mode_supported  = 1;
     gi->pad_mode_selectable = 1;
-    gi->allow_hybrid        = 0;
     // Widescreen defaults ON at the console level (every shipped Genesis
     // recomp exposes the experimental 16:9 path); a per-game host overrides
     // to 0 when its layout isn't widescreen-capable (g_game_layout.ws_capable).

--- a/src/consoles/psx/psx_binds.c
+++ b/src/consoles/psx/psx_binds.c
@@ -49,7 +49,20 @@ static const SDL_Scancode kPsxDefaults[LNG_PSX_PAD_BUTTON_COUNT] = {
 };
 
 static SDL_Scancode s_psx_binds[PSX_BINDS_MAX_PLAYERS][LNG_PSX_PAD_BUTTON_COUNT];
+/* Alternate (secondary) bind per input. Either slot asserts the input.
+ * Persisted in keybinds.ini as a comma-separated second value
+ * ("cross = X, Mouse1"), byte-identical to what psx_keybinds.c writes.
+ * UNKNOWN = no alt bound. */
+static SDL_Scancode s_psx_binds_alt[PSX_BINDS_MAX_PLAYERS][LNG_PSX_PAD_BUTTON_COUNT];
 static int s_psx_binds_init = 0;
+
+/* Mouse-button pseudo-scancodes, mirroring psx_keybinds.c exactly: values
+ * sit above SDL keyboard scancode space so they flow through the same
+ * bind/save/load machinery as ordinary scancodes. INI names Mouse1..5. */
+#define PSX_MOUSE_SC_BASE 512
+#define PSX_MOUSE_SC(btn) ((SDL_Scancode)(PSX_MOUSE_SC_BASE + (btn)))
+#define PSX_IS_MOUSE_SC(sc) \
+    ((int)(sc) > PSX_MOUSE_SC_BASE && (int)(sc) <= PSX_MOUSE_SC_BASE + 5)
 
 // Same scancode<->name normalization psx_keybinds.c/keybinds.c use (SDL name
 // first, then a handful of common aliases) so files round-trip identically
@@ -74,10 +87,21 @@ static SDL_Scancode psx_kb_name_to_scancode(const char* name) {
     if (!strcmp(buf, "escape") || !strcmp(buf, "esc")) return SDL_SCANCODE_ESCAPE;
     if (!strcmp(buf, "backspace")) return SDL_SCANCODE_BACKSPACE;
     if (!strcmp(buf, "none") || !buf[0]) return SDL_SCANCODE_UNKNOWN;
+    /* Mouse buttons (SDL order: 1 left, 2 middle, 3 right, 4/5 side). */
+    if (!strncmp(buf, "mouse", 5) && buf[5] >= '1' && buf[5] <= '5' && !buf[6])
+        return PSX_MOUSE_SC(buf[5] - '0');
+    if (!strcmp(buf, "lmb")) return PSX_MOUSE_SC(1);
+    if (!strcmp(buf, "mmb")) return PSX_MOUSE_SC(2);
+    if (!strcmp(buf, "rmb")) return PSX_MOUSE_SC(3);
     return SDL_SCANCODE_UNKNOWN;
 }
 static const char* psx_kb_scancode_to_name(SDL_Scancode sc) {
     if (sc == SDL_SCANCODE_UNKNOWN) return "None";
+    if (PSX_IS_MOUSE_SC(sc)) {
+        static const char* const kMouseNames[5] =
+            { "Mouse1", "Mouse2", "Mouse3", "Mouse4", "Mouse5" };
+        return kMouseNames[(int)sc - PSX_MOUSE_SC_BASE - 1];
+    }
     const char* n = SDL_GetScancodeName(sc);
     return (n && n[0]) ? n : "None";
 }
@@ -93,8 +117,15 @@ static void psx_kb_write_ini(const char* path) {
         "# Use SDL key names, or \"None\" to leave an input unbound.\n\n");
     for (int p = 0; p < PSX_BINDS_MAX_PLAYERS; ++p) {
         fprintf(f, "[player%d]\n", p + 1);
-        for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b)
-            fprintf(f, "%-9s = %s\n", kPsxKbKeyName[b], psx_kb_scancode_to_name(s_psx_binds[p][b]));
+        for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b) {
+            if (s_psx_binds_alt[p][b] != SDL_SCANCODE_UNKNOWN)
+                fprintf(f, "%-9s = %s, %s\n", kPsxKbKeyName[b],
+                        psx_kb_scancode_to_name(s_psx_binds[p][b]),
+                        psx_kb_scancode_to_name(s_psx_binds_alt[p][b]));
+            else
+                fprintf(f, "%-9s = %s\n", kPsxKbKeyName[b],
+                        psx_kb_scancode_to_name(s_psx_binds[p][b]));
+        }
         fprintf(f, "\n");
     }
     fclose(f);
@@ -157,9 +188,25 @@ static int psx_kb_load_ini(const char* path) {
         while (*val && isspace((unsigned char)*val)) ++val;
         size_t vl = strlen(val); while (vl > 0 && isspace((unsigned char)val[vl-1])) val[--vl] = '\0';
         for (char* c = key; *c; c++) *c = (char)tolower((unsigned char)*c);
+        /* Optional alternate bind after a comma: "cross = X, Mouse1". */
+        char* alt_val = NULL;
+        {
+            char* comma = strchr(val, ',');
+            if (comma) {
+                *comma = '\0';
+                alt_val = comma + 1;
+                size_t tl = strlen(val);
+                while (tl > 0 && isspace((unsigned char)val[tl-1])) val[--tl] = '\0';
+                while (*alt_val && isspace((unsigned char)*alt_val)) ++alt_val;
+                size_t al = strlen(alt_val);
+                while (al > 0 && isspace((unsigned char)alt_val[al-1])) alt_val[--al] = '\0';
+            }
+        }
         for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b) {
             if (!strcmp(key, kPsxKbKeyName[b])) {
                 s_psx_binds[player][b] = psx_kb_name_to_scancode(val);
+                s_psx_binds_alt[player][b] =
+                    alt_val ? psx_kb_name_to_scancode(alt_val) : SDL_SCANCODE_UNKNOWN;
                 if (psx_kb_key_is_native_only(b)) ++native_hits;
                 break;
             }
@@ -170,8 +217,11 @@ static int psx_kb_load_ini(const char* path) {
 }
 
 static void psx_kb_seed_defaults(void) {
-    for (int p = 0; p < PSX_BINDS_MAX_PLAYERS; ++p)
+    for (int p = 0; p < PSX_BINDS_MAX_PLAYERS; ++p) {
         memcpy(s_psx_binds[p], kPsxDefaults, sizeof(kPsxDefaults));
+        for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b)
+            s_psx_binds_alt[p][b] = SDL_SCANCODE_UNKNOWN;   /* no alt by default */
+    }
 }
 
 static int psx_kb_player_all_unbound(int player) {
@@ -221,9 +271,29 @@ void rui_psx_binds_set(const char* path, int player, int b, int scancode) {
     psx_kb_write_ini(path);
 }
 
+int rui_psx_binds_get_slot(const char* path, int player, int b, int slot) {
+    if (slot != 1) return rui_psx_binds_get(path, player, b);
+    if (!s_psx_binds_init) rui_psx_binds_init(path);
+    if (player < 0 || player >= PSX_BINDS_MAX_PLAYERS ||
+        b < 0 || b >= LNG_PSX_PAD_BUTTON_COUNT)
+        return SDL_SCANCODE_UNKNOWN;
+    return (int)s_psx_binds_alt[player][b];
+}
+
+void rui_psx_binds_set_slot(const char* path, int player, int b, int slot, int scancode) {
+    if (slot != 1) { rui_psx_binds_set(path, player, b, scancode); return; }
+    if (player < 0 || player >= PSX_BINDS_MAX_PLAYERS ||
+        b < 0 || b >= LNG_PSX_PAD_BUTTON_COUNT) return;
+    if (!s_psx_binds_init) rui_psx_binds_init(path);
+    s_psx_binds_alt[player][b] = (SDL_Scancode)scancode;
+    psx_kb_write_ini(path);
+}
+
 void rui_psx_binds_reset(const char* path, int player) {
     if (player < 0 || player >= PSX_BINDS_MAX_PLAYERS) return;
     if (!s_psx_binds_init) rui_psx_binds_init(path);
     memcpy(s_psx_binds[player], kPsxDefaults, sizeof(kPsxDefaults));
+    for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b)
+        s_psx_binds_alt[player][b] = SDL_SCANCODE_UNKNOWN;
     psx_kb_write_ini(path);
 }

--- a/src/consoles/psx/psx_binds.h
+++ b/src/consoles/psx/psx_binds.h
@@ -37,6 +37,12 @@ int rui_psx_binds_get(const char* path, int player, int b);
 // Rebind + persist.
 void rui_psx_binds_set(const char* path, int player, int b, int scancode);
 
+// Slot-aware variants: slot 0 is the primary bind, slot 1 the alternate.
+// Either slot asserts the input at runtime. Mouse buttons are representable
+// as pseudo-scancodes (Mouse1..Mouse5), matching psx_keybinds.c.
+int  rui_psx_binds_get_slot(const char* path, int player, int b, int slot);
+void rui_psx_binds_set_slot(const char* path, int player, int b, int slot, int scancode);
+
 // Reset one player to the shared default keyboard map + persist.
 void rui_psx_binds_reset(const char* path, int player);
 

--- a/src/consoles/psx/psx_profile.h
+++ b/src/consoles/psx/psx_profile.h
@@ -121,7 +121,6 @@ static inline void launcher_profile_apply_psx(RecompLauncherCGameInfo* gi) {
     // Controller: PSX has analog/digital pad modes + swapping DualShock art.
     gi->pad_mode_supported  = 1;
     gi->pad_mode_selectable = 1;       // per-game lock_mode may set this to 0
-    gi->allow_hybrid        = 1;
     gi->aspect_mask         = 0x1;     // 4:3 always; game adds 16:9 (0x2) / 21:9 (0x4)
     // Full PS1 settings surface.
     gi->has_window_size = 1; gi->has_renderer = 1; gi->has_supersampling = 1;

--- a/src/consoles/psx/psx_profile.h
+++ b/src/consoles/psx/psx_profile.h
@@ -64,6 +64,8 @@ static const SystemProfile kSystemProfilePsx = {
         "pad.tga", "pad_analog.tga", "pad_digital.tga",
         /* max_players */ 5, /* PSX + multitap ceiling; game num_players may be lower */
         /* has_pad_mode */ 1,
+        /* binds_per_input */ 2,  // primary + alternate; either asserts the
+                                  // input, and either may be a mouse button
     },
     // MEMCARD is PSX's real target shape (2 slots): the standalone "save" panel
     // (see kPanelsDashboardPsx above) renders a dual-slot picker + 15-block

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -593,7 +593,6 @@ typedef struct RecompLauncherCGameInfo {
     // analog/digital art are never shown (the generic pad.tga is used).
     int            pad_mode_supported;    // 0 = no pad-mode UI at all; 1 = show the selector + swapping art
     int            pad_mode_selectable;   // 0 = hide selector, force locked_pad_mode (game.lock_mode)
-    int            allow_hybrid;          // 0 = hide the Hybrid option
     int            locked_pad_mode;       // forced mode when !pad_mode_selectable
     int            lock_device;           // 1 = hide the player controller cards entirely (fixed pad)
     // Aspect ratios offered. bit0 = 4:3 (implied/always), bit1 = 16:9, bit2 = 21:9.


### PR DESCRIPTION
Launcher half of **mstan/psxrecomp#112**. That PR stops populating `allow_hybrid`, so the two must land together  -  this one removes the field from `RecompLauncherCGameInfo`.

Supersedes the launcher side of psxrecomp#107: it implements the UI that #107's runtime support needed but never had.

## Mouse buttons and dual binds actually reachable

psxrecomp's runtime gained mouse-button binds and a second bind slot per input, but the PSX rebind page could only ever set **one keyboard key** per input. The binds could be loaded from `keybinds.ini` and never set  -  the feature was unusable from the UI.

- PSX declares `binds_per_input = 2`, so every input renders **primary + alternate** chips. The launcher already had this machinery for N64; PSX simply never opted in.
- the PSX bind store learns the alternate slot and mouse pseudo-scancodes, reading and writing `cross = X, Mouse1` byte-identically to `psx_keybinds.c`
- a mouse button can be captured straight onto a chip

## Two bugs found while testing

**1. Alt binds were silently destroyed.** `psx_binds.c` writes `keybinds.ini` with its own writer, which knew nothing about alternates  -  so *any* rebind through the launcher erased every alt bind in the file. It round-trips them now.

**2. Every mouse bind displayed as `(unbound)`.** Mouse pseudo-scancodes sit above SDL's keyboard space, so `SDL_GetScancodeName()` returns nothing and `scancode_label()` fell through to `(unbound)`. The bind was written and persisted correctly the whole time  -  purely a display failure, which made a working feature look completely broken during testing.

## Gamepad navigation suspended while capturing

A controller drove menu focus while a bind prompt was open, so pressing a pad button moved the selection instead of being captured.

Swallowing pad events doesn't fix it: ImGui's SDL backend **polls** gamepad state in `NewFrame` (`ImGui_ImplSDL3_UpdateGamepads`) rather than reading the event queue. Clearing `ImGuiConfigFlags_NavEnableGamepad` for the frame is what actually suppresses it. Keyboard nav stays on so Esc/arrows/Enter still work while listening.

## Hybrid removed from the selector

Hybrid is no longer player-selectable  -  it survives only as a mod-only mode a trusted plugin requests at runtime (Tomba's hybrid controller mod). The launcher shouldn't offer it and games shouldn't have to opt out of it.

- Hybrid segment gone; the selector is **Analog / D-Pad**
- `allow_hybrid` removed from `LauncherModel`, `RecompLauncherCGameInfo` and both console profiles
- a stale persisted `pad_mode` of `0` snaps to Analog unconditionally, matching the runtime's migration

## Not addressed

PSX still has **no gamepad-bind store or column** (`has_pad_binds` unset), so DualShock buttons can't be rebound at all  -  pad mapping comes from SDL's controller database. Genesis is the only console with that path today. Tracked separately; it needs a runtime change too, since `controller_pad_buttons()` reads fixed `SDL_CONTROLLER_BUTTON_*` mappings.

## Testing

Tomba 1 with the paired psxrecomp branch: two chips per input, mouse binds captured and displayed correctly, binds persist across restarts, alt binds survive a launcher rebind, and a connected DualShock no longer steals focus during capture.
