### PR TITLE
launcher: PSX mouse + dual binds without Hybrid removal

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,6 +109,17 @@ if(BUILD_TESTING)
     target_include_directories(recomp-runtime-ui-test PRIVATE src)
     add_test(NAME recomp-runtime-ui COMMAND $<TARGET_FILE:recomp-runtime-ui-test>)
 
+    add_executable(recomp-ui-psx-binds-test
+        tests/psx_binds_test.c
+        src/consoles/psx/psx_binds.c)
+    target_include_directories(recomp-ui-psx-binds-test PRIVATE
+        src src/common src/consoles/psx)
+    target_link_libraries(recomp-ui-psx-binds-test PRIVATE ${RUI_SDL_TARGET})
+    add_test(
+        NAME recomp-ui-psx-binds
+        COMMAND $<TARGET_FILE:recomp-ui-psx-binds-test>
+                "${CMAKE_CURRENT_BINARY_DIR}/psx-binds-test.ini")
+
     add_executable(recomp-runtime-ui-imgui-test
         tests/runtime_ui_imgui_test.cpp
         src/common/recomp_runtime_ui.c

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -7539,6 +7539,24 @@ bool try_capture(LauncherModel* m, const SDL_Event& ev) {
         return true;   // swallow all other input (keyboard included) while pad-capturing
     }
 
+    /* Mouse buttons are bindable inputs on stores that keep alternates
+     * (PSX): bind-a-mouse-button is the whole point of the alt slot. ImGui
+     * opens capture on release, so the next down event is deliberate. */
+    if (m->capturing && !m->capture_pad) {
+        const SystemProfile* mprof = (const SystemProfile*)m->profile;
+        const bool alt_store = mprof && mprof->controller.binds_per_input >= 2;
+        if (ev.type == SDL_EVENT_MOUSE_BUTTON_UP) return true;   /* swallow */
+        if (ev.type == SDL_EVENT_MOUSE_BUTTON_DOWN) {
+            if (!alt_store || !m->capture_mouse_armed) return true;
+            int btn = (int)ev.button.button;      /* SDL: 1 L, 2 M, 3 R, 4/5 side */
+            if (btn >= 1 && btn <= 5) {
+                launcher_binds_set_button_slot(m, m->cfg_player + 1, m->capture_btn,
+                                               m->capture_slot, 512 + btn);
+                launcher_model_cancel_capture(m);
+            }
+            return true;
+        }
+    }
     if (ev.type != SDL_EVENT_KEY_DOWN) return true;   // swallow non-key input while capturing
     if (m->capturing) {
         // N64's input.cfg keeps two alternate binds per input, so a keyboard
@@ -7546,7 +7564,10 @@ bool try_capture(LauncherModel* m, const SDL_Event& ev) {
         // Single-bind stores (SNES/PSX/GBA) use the legacy scancode setter
         // (capture_slot is always 0 for them).
         const SystemProfile* prof = (const SystemProfile*)m->profile;
-        if (prof && prof->controller.binds_per_input >= 2)
+        if (prof && prof->controller.binds_per_input >= 2 && prof->id && !strcmp(prof->id, "psx"))
+            launcher_binds_set_button_slot(m, m->cfg_player + 1, m->capture_btn,
+                                           m->capture_slot, (int)LNG_EVSCAN(ev));
+        else if (prof && prof->controller.binds_per_input >= 2)
             launcher_binds_set_field(m, m->cfg_player + 1, m->capture_btn, m->capture_slot,
                                      RUI_N64_FIELD_KEY, (int)LNG_EVSCAN(ev));
         else
@@ -7793,6 +7814,22 @@ extern "C" LngAction launcher_backend_run(LauncherPlatform* p,
         }
 
         ImGui_ImplOpenGL3_NewFrame();
+        /* Suspend ImGui's GAMEPAD navigation while a bind capture is open.
+         *
+         * The SDL backend POLLS gamepad state in NewFrame (see
+         * ImGui_ImplSDL3_UpdateGamepads) rather than reading the SDL event
+         * queue, so swallowing pad events in try_capture cannot stop the pad
+         * from driving the menu: press a button to bind it and the focus
+         * jumps instead. Clearing the flag for the frame is the only thing
+         * that actually suppresses it. Keyboard nav stays on so Esc, arrows
+         * and Enter still work while listening. */
+        {
+            ImGuiIO& nav_io = ImGui::GetIO();
+            if (m->capturing || m->hk_capturing || m->camera_capturing)
+                nav_io.ConfigFlags &= ~ImGuiConfigFlags_NavEnableGamepad;
+            else
+                nav_io.ConfigFlags |= ImGuiConfigFlags_NavEnableGamepad;
+        }
         LNG_ImplSDL_NewFrame();
         if (force_dpi) {   // Windows has no native point/pixel split — inject it
             ImGuiIO& io = ImGui::GetIO();

--- a/src/common/launcher_binds.c
+++ b/src/common/launcher_binds.c
@@ -199,6 +199,15 @@ static void copy_str(char* d, size_t cap, const char* s) {
 
 static const char* scancode_label(SDL_Scancode sc) {
     if (sc == SDL_SCANCODE_UNKNOWN) return "(unbound)";
+    /* Mouse buttons are bound as pseudo-scancodes ABOVE SDL keyboard space
+     * (512 + SDL button), so SDL_GetScancodeName knows nothing about them
+     * and every mouse bind rendered as "(unbound)" - the bind had actually
+     * been written and persisted, it was purely a display failure. */
+    if ((int)sc > 512 && (int)sc <= 517) {
+        static const char* const kMouseNames[5] =
+            { "Mouse1", "Mouse2", "Mouse3", "Mouse4", "Mouse5" };
+        return kMouseNames[(int)sc - 513];
+    }
     const char* n = SDL_GetScancodeName(sc);
     return (n && n[0]) ? n : "(unbound)";
 }
@@ -226,8 +235,12 @@ static void reload_player_display(LauncherModel* m, int player) {
         const char* guid = psx_player_guid(m, player);
         for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b) {
             copy_str(m->binds[player - 1][b], sizeof(m->binds[player - 1][b]),
-                     scancode_label((SDL_Scancode)rui_psx_binds_get(
-                         keybinds_file_path(), player - 1, b)));
+                     scancode_label((SDL_Scancode)rui_psx_binds_get_slot(
+                         keybinds_file_path(), player - 1, b, 0)));
+            copy_str(m->binds_alt[player - 1][b],
+                     sizeof(m->binds_alt[player - 1][b]),
+                     scancode_label((SDL_Scancode)rui_psx_binds_get_slot(
+                         keybinds_file_path(), player - 1, b, 1)));
             rui_psx_pad_binds_label(psx_input_ini_path(), guid, b,
                                     m->pad_binds[player - 1][b],
                                     (int)sizeof(m->pad_binds[player - 1][b]));
@@ -521,6 +534,20 @@ void launcher_binds_reset_camera(LauncherModel* m) {
     launcher_binds_refresh_camera(m);
 }
 
+/* Slot-aware setter for stores that keep an alternate bind per input.
+ * PSX keeps two (primary + alt, either may be a mouse pseudo-scancode). */
+void launcher_binds_set_button_slot(LauncherModel* m, int player, int b,
+                                    int slot, int scancode) {
+    if (!m || !is_psx_profile(m)) return;
+    if (player < 1 || player > LNG_MAX_PLAYERS) return;
+    if (b < 0 || b >= LNG_PSX_PAD_BUTTON_COUNT) return;
+    rui_psx_binds_set_slot(keybinds_file_path(), player - 1, b, slot, scancode);
+    char* dst = (slot == 1) ? m->binds_alt[player - 1][b] : m->binds[player - 1][b];
+    size_t cap = (slot == 1) ? sizeof(m->binds_alt[player - 1][b])
+                             : sizeof(m->binds[player - 1][b]);
+    copy_str(dst, cap, scancode_label((SDL_Scancode)scancode));
+}
+
 void launcher_binds_set_button(LauncherModel* m, int player, int b, int scancode) {
     if (is_n64_profile(m)) {
         // Keyboard capture into the N64 store routes through the field API
@@ -529,11 +556,7 @@ void launcher_binds_set_button(LauncherModel* m, int player, int b, int scancode
         return;
     }
     if (is_psx_profile(m)) {
-        if (player < 1 || player > LNG_MAX_PLAYERS) return;
-        if (b < 0 || b >= LNG_PSX_PAD_BUTTON_COUNT) return;
-        rui_psx_binds_set(keybinds_file_path(), player - 1, b, scancode);
-        copy_str(m->binds[player - 1][b], sizeof(m->binds[player - 1][b]),
-                 scancode_label((SDL_Scancode)scancode));
+        launcher_binds_set_button_slot(m, player, b, 0, scancode);
         return;
     }
     if (player < 1 || player > 2) return;

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -2611,10 +2611,11 @@ void launcher_model_begin_capture_slot(LauncherModel* m, int b, int slot) {
     m->capturing     = true;
     m->capture_btn   = b;
     m->capture_slot  = (slot == 1) ? 1 : 0;
-    m->hk_capturing = false;
-    m->capturing    = true;
+    /* ImGui activates a button on RELEASE, so the click that opened this
+     * capture is already fully consumed by the time capturing is true.
+     * Arm straight away: the next press is a deliberate new click. */
+    m->capture_mouse_armed = true;
     m->capture_pad  = false;
-    m->capture_btn  = b;
 }
 void launcher_model_begin_pad_capture(LauncherModel* m, int b) {
     launcher_model_begin_capture(m, b);

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -462,7 +462,7 @@ typedef struct {
     int       capture_btn;       // generic index into the active profile's ControllerSpec.buttons[] (0..button_count-1)
     int       capture_slot;      // alternate-bind slot being captured (0 always;
                                  // 1 only for consoles with two bind slots per
-                                 // input — N64's input.cfg format)
+                                 // input — N64 input.cfg and PSX keybinds.ini)
     // When capturing, whether the GAMEPAD bind (button/axis) is being captured
     // instead of the keyboard scancode — Genesis has_pad_binds, and PSX's
     // Gamepad Bindings panel (per selected GUID).
@@ -475,6 +475,9 @@ typedef struct {
     bool      map_all_active;
     bool      map_all_wait_release;
     int       map_all_step;
+    // A mouse button may be BOUND on stores that keep alternates (PSX). ImGui
+    // opens capture on release, so the next down event is a deliberate bind.
+    bool      capture_mouse_armed;
     bool      camera_capturing;  // capturing an enabled Voxel camera key
     int       capture_camera;    // LNG_CAMERA_* index
     bool      hk_capturing;      // capturing a system hotkey
@@ -784,6 +787,9 @@ void launcher_model_begin_capture(LauncherModel* m, int b);
 // launcher_model_begin_capture() is slot 0. Only consoles whose bind bridge
 // stores two slots per input (N64) show slot-1 chips.
 void launcher_model_begin_capture_slot(LauncherModel* m, int b, int slot);
+// Write one bind slot (0 primary, 1 alternate) for stores that keep two.
+void launcher_binds_set_button_slot(LauncherModel* m, int player, int b,
+                                    int slot, int scancode);
 // Begin capturing the GAMEPAD bind (button or axis) for button `b` instead of
 // a keyboard scancode. Used by Genesis has_pad_binds and the PSX Gamepad
 // Bindings panel. Esc cancels.

--- a/src/consoles/psx/psx_binds.c
+++ b/src/consoles/psx/psx_binds.c
@@ -49,7 +49,20 @@ static const SDL_Scancode kPsxDefaults[LNG_PSX_PAD_BUTTON_COUNT] = {
 };
 
 static SDL_Scancode s_psx_binds[PSX_BINDS_MAX_PLAYERS][LNG_PSX_PAD_BUTTON_COUNT];
+/* Alternate (secondary) bind per input. Either slot asserts the input.
+ * Persisted in keybinds.ini as a comma-separated second value
+ * ("cross = X, Mouse1"), byte-identical to what psx_keybinds.c writes.
+ * UNKNOWN = no alt bound. */
+static SDL_Scancode s_psx_binds_alt[PSX_BINDS_MAX_PLAYERS][LNG_PSX_PAD_BUTTON_COUNT];
 static int s_psx_binds_init = 0;
+
+/* Mouse-button pseudo-scancodes, mirroring psx_keybinds.c exactly: values
+ * sit above SDL keyboard scancode space so they flow through the same
+ * bind/save/load machinery as ordinary scancodes. INI names Mouse1..5. */
+#define PSX_MOUSE_SC_BASE 512
+#define PSX_MOUSE_SC(btn) ((SDL_Scancode)(PSX_MOUSE_SC_BASE + (btn)))
+#define PSX_IS_MOUSE_SC(sc) \
+    ((int)(sc) > PSX_MOUSE_SC_BASE && (int)(sc) <= PSX_MOUSE_SC_BASE + 5)
 
 // Same scancode<->name normalization psx_keybinds.c/keybinds.c use (SDL name
 // first, then a handful of common aliases) so files round-trip identically
@@ -74,10 +87,21 @@ static SDL_Scancode psx_kb_name_to_scancode(const char* name) {
     if (!strcmp(buf, "escape") || !strcmp(buf, "esc")) return SDL_SCANCODE_ESCAPE;
     if (!strcmp(buf, "backspace")) return SDL_SCANCODE_BACKSPACE;
     if (!strcmp(buf, "none") || !buf[0]) return SDL_SCANCODE_UNKNOWN;
+    /* Mouse buttons (SDL order: 1 left, 2 middle, 3 right, 4/5 side). */
+    if (!strncmp(buf, "mouse", 5) && buf[5] >= '1' && buf[5] <= '5' && !buf[6])
+        return PSX_MOUSE_SC(buf[5] - '0');
+    if (!strcmp(buf, "lmb")) return PSX_MOUSE_SC(1);
+    if (!strcmp(buf, "mmb")) return PSX_MOUSE_SC(2);
+    if (!strcmp(buf, "rmb")) return PSX_MOUSE_SC(3);
     return SDL_SCANCODE_UNKNOWN;
 }
 static const char* psx_kb_scancode_to_name(SDL_Scancode sc) {
     if (sc == SDL_SCANCODE_UNKNOWN) return "None";
+    if (PSX_IS_MOUSE_SC(sc)) {
+        static const char* const kMouseNames[5] =
+            { "Mouse1", "Mouse2", "Mouse3", "Mouse4", "Mouse5" };
+        return kMouseNames[(int)sc - PSX_MOUSE_SC_BASE - 1];
+    }
     const char* n = SDL_GetScancodeName(sc);
     return (n && n[0]) ? n : "None";
 }
@@ -93,8 +117,15 @@ static void psx_kb_write_ini(const char* path) {
         "# Use SDL key names, or \"None\" to leave an input unbound.\n\n");
     for (int p = 0; p < PSX_BINDS_MAX_PLAYERS; ++p) {
         fprintf(f, "[player%d]\n", p + 1);
-        for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b)
-            fprintf(f, "%-9s = %s\n", kPsxKbKeyName[b], psx_kb_scancode_to_name(s_psx_binds[p][b]));
+        for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b) {
+            if (s_psx_binds_alt[p][b] != SDL_SCANCODE_UNKNOWN)
+                fprintf(f, "%-9s = %s, %s\n", kPsxKbKeyName[b],
+                        psx_kb_scancode_to_name(s_psx_binds[p][b]),
+                        psx_kb_scancode_to_name(s_psx_binds_alt[p][b]));
+            else
+                fprintf(f, "%-9s = %s\n", kPsxKbKeyName[b],
+                        psx_kb_scancode_to_name(s_psx_binds[p][b]));
+        }
         fprintf(f, "\n");
     }
     fclose(f);
@@ -157,9 +188,25 @@ static int psx_kb_load_ini(const char* path) {
         while (*val && isspace((unsigned char)*val)) ++val;
         size_t vl = strlen(val); while (vl > 0 && isspace((unsigned char)val[vl-1])) val[--vl] = '\0';
         for (char* c = key; *c; c++) *c = (char)tolower((unsigned char)*c);
+        /* Optional alternate bind after a comma: "cross = X, Mouse1". */
+        char* alt_val = NULL;
+        {
+            char* comma = strchr(val, ',');
+            if (comma) {
+                *comma = '\0';
+                alt_val = comma + 1;
+                size_t tl = strlen(val);
+                while (tl > 0 && isspace((unsigned char)val[tl-1])) val[--tl] = '\0';
+                while (*alt_val && isspace((unsigned char)*alt_val)) ++alt_val;
+                size_t al = strlen(alt_val);
+                while (al > 0 && isspace((unsigned char)alt_val[al-1])) alt_val[--al] = '\0';
+            }
+        }
         for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b) {
             if (!strcmp(key, kPsxKbKeyName[b])) {
                 s_psx_binds[player][b] = psx_kb_name_to_scancode(val);
+                s_psx_binds_alt[player][b] =
+                    alt_val ? psx_kb_name_to_scancode(alt_val) : SDL_SCANCODE_UNKNOWN;
                 if (psx_kb_key_is_native_only(b)) ++native_hits;
                 break;
             }
@@ -170,8 +217,11 @@ static int psx_kb_load_ini(const char* path) {
 }
 
 static void psx_kb_seed_defaults(void) {
-    for (int p = 0; p < PSX_BINDS_MAX_PLAYERS; ++p)
+    for (int p = 0; p < PSX_BINDS_MAX_PLAYERS; ++p) {
         memcpy(s_psx_binds[p], kPsxDefaults, sizeof(kPsxDefaults));
+        for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b)
+            s_psx_binds_alt[p][b] = SDL_SCANCODE_UNKNOWN;   /* no alt by default */
+    }
 }
 
 static int psx_kb_player_all_unbound(int player) {
@@ -221,9 +271,29 @@ void rui_psx_binds_set(const char* path, int player, int b, int scancode) {
     psx_kb_write_ini(path);
 }
 
+int rui_psx_binds_get_slot(const char* path, int player, int b, int slot) {
+    if (slot != 1) return rui_psx_binds_get(path, player, b);
+    if (!s_psx_binds_init) rui_psx_binds_init(path);
+    if (player < 0 || player >= PSX_BINDS_MAX_PLAYERS ||
+        b < 0 || b >= LNG_PSX_PAD_BUTTON_COUNT)
+        return SDL_SCANCODE_UNKNOWN;
+    return (int)s_psx_binds_alt[player][b];
+}
+
+void rui_psx_binds_set_slot(const char* path, int player, int b, int slot, int scancode) {
+    if (slot != 1) { rui_psx_binds_set(path, player, b, scancode); return; }
+    if (player < 0 || player >= PSX_BINDS_MAX_PLAYERS ||
+        b < 0 || b >= LNG_PSX_PAD_BUTTON_COUNT) return;
+    if (!s_psx_binds_init) rui_psx_binds_init(path);
+    s_psx_binds_alt[player][b] = (SDL_Scancode)scancode;
+    psx_kb_write_ini(path);
+}
+
 void rui_psx_binds_reset(const char* path, int player) {
     if (player < 0 || player >= PSX_BINDS_MAX_PLAYERS) return;
     if (!s_psx_binds_init) rui_psx_binds_init(path);
     memcpy(s_psx_binds[player], kPsxDefaults, sizeof(kPsxDefaults));
+    for (int b = 0; b < LNG_PSX_PAD_BUTTON_COUNT; ++b)
+        s_psx_binds_alt[player][b] = SDL_SCANCODE_UNKNOWN;
     psx_kb_write_ini(path);
 }

--- a/src/consoles/psx/psx_binds.h
+++ b/src/consoles/psx/psx_binds.h
@@ -37,6 +37,12 @@ int rui_psx_binds_get(const char* path, int player, int b);
 // Rebind + persist.
 void rui_psx_binds_set(const char* path, int player, int b, int scancode);
 
+// Slot-aware variants: slot 0 is the primary bind, slot 1 the alternate.
+// Either slot asserts the input at runtime. Mouse buttons are representable
+// as pseudo-scancodes (Mouse1..Mouse5), matching psx_keybinds.c.
+int  rui_psx_binds_get_slot(const char* path, int player, int b, int slot);
+void rui_psx_binds_set_slot(const char* path, int player, int b, int slot, int scancode);
+
 // Reset one player to the shared default keyboard map + persist.
 void rui_psx_binds_reset(const char* path, int player);
 

--- a/src/consoles/psx/psx_profile.h
+++ b/src/consoles/psx/psx_profile.h
@@ -75,6 +75,8 @@ static const SystemProfile kSystemProfilePsx = {
         "pad.tga", "pad_analog.tga", "pad_digital.tga",
         /* max_players */ 8, /* dual multitap ceiling; game num_players may be lower */
         /* has_pad_mode */ 1,
+        /* binds_per_input */ 2,  // primary + alternate; either asserts the
+                                  // input, and either may be a mouse button
     },
     // MEMCARD is PSX's real target shape (2 slots): the standalone "save" panel
     // (see kPanelsDashboardPsx above) renders a dual-slot picker + 15-block

--- a/tests/psx_binds_test.c
+++ b/tests/psx_binds_test.c
@@ -1,0 +1,69 @@
+#include "consoles/psx/psx_binds.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+enum {
+    TEST_CROSS = 6,
+    TEST_MOUSE1 = 513
+};
+
+static void require(int condition, const char *message)
+{
+    if (condition) return;
+    fprintf(stderr, "FAIL: %s\n", message);
+    exit(1);
+}
+
+static int file_contains(const char *path, const char *needle)
+{
+    FILE *file = fopen(path, "rb");
+    char text[8192];
+    size_t size;
+    if (!file) return 0;
+    size = fread(text, 1, sizeof(text) - 1, file);
+    fclose(file);
+    text[size] = '\0';
+    return strstr(text, needle) != NULL;
+}
+
+int main(int argc, char **argv)
+{
+    const char *path;
+    int primary;
+    if (argc != 2) {
+        fprintf(stderr, "usage: psx_binds_test <temporary-ini>\n");
+        return 2;
+    }
+    path = argv[1];
+    remove(path);
+
+    rui_psx_binds_init(path);
+    primary = rui_psx_binds_get_slot(path, 0, TEST_CROSS, 0);
+    require(primary != 0, "Cross has a seeded primary binding");
+    require(rui_psx_binds_get_slot(path, 0, TEST_CROSS, 1) == 0,
+            "Cross alternate starts unbound");
+
+    rui_psx_binds_set_slot(path, 0, TEST_CROSS, 1, TEST_MOUSE1);
+    require(rui_psx_binds_get_slot(path, 0, TEST_CROSS, 0) == primary,
+            "setting alternate preserves primary");
+    require(rui_psx_binds_get_slot(path, 0, TEST_CROSS, 1) == TEST_MOUSE1,
+            "mouse pseudo-scancode round-trips in memory");
+    require(file_contains(path, "Mouse1"),
+            "mouse alternate persists by its runtime-compatible name");
+
+    rui_psx_binds_set_slot(path, 0, TEST_CROSS, 0, primary);
+    require(rui_psx_binds_get_slot(path, 0, TEST_CROSS, 1) == TEST_MOUSE1,
+            "rewriting primary does not erase alternate");
+    require(file_contains(path, "Mouse1"),
+            "rewriting primary preserves alternate on disk");
+
+    rui_psx_binds_reset(path, 0);
+    require(rui_psx_binds_get_slot(path, 0, TEST_CROSS, 1) == 0,
+            "reset clears alternate binding");
+
+    remove(path);
+    puts("PSX dual-bind persistence tests passed");
+    return 0;
+}


### PR DESCRIPTION
Ports the additive/bug-fix half of #22 onto current master while preserving the newer PSX per-GUID gamepad-binding flow.\n\nIncluded:\n- primary + alternate keyboard/mouse bind chips for PSX\n- runtime-compatible Mouse1..Mouse5 persistence\n- preserve alternates when rewriting a primary bind\n- suspend ImGui gamepad navigation during capture\n- focused PSX bind persistence regression test\n\nExplicitly excluded: the Hybrid selector and llow_hybrid ABI removal from #22. That is a behavioral/paired-runtime decision and should be handled separately with psxrecomp#112.\n\nValidation: clean SDL2 standalone build; PSX bind persistence test; runtime UI tests; ImGui runtime UI test; asset manifest and PSX asset staging tests all pass.