### PR TITLE
Integrate host-owned launcher defaults and bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ RecompLauncherCGameInfo gi = {0};
 launcher_profile_apply("snes", &gi);   // "psx", "n64", ... — one call sets the console identity
 gi.name = "My Game";
 gi.expected_crc = 0x1B4B2E9C; gi.has_expected_crc = 1;
+RecompLauncherCSettings defaults = { /* authoritative first-run values */ };
+gi.default_settings = &defaults;       // optional Restore Defaults action
 /* ...per-game overrides... */
 
 char out_rom[512];
@@ -417,6 +419,13 @@ snesrecomp `docs/RECOMP_NET.md` → "Soft-return rematch checklist".
   resolution, and committing changes before launch; recomp-ui never executes
   package code.
 - **Footer** — PLAY, skip-launcher-on-boot (+ confirm modal), gamepad navigation.
+
+---
+
+When `RecompLauncherCGameInfo.default_settings` is non-NULL, the Settings
+footer also exposes a confirmed **Restore Defaults** action. The snapshot is
+copied at launcher initialization; resetting never changes the separately
+owned ROM selection or deletes save files.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,9 @@ gi.name = "My Game";
 gi.expected_crc = 0x1B4B2E9C; gi.has_expected_crc = 1;
 RecompLauncherCSettings defaults = { /* authoritative first-run values */ };
 gi.default_settings = &defaults;       // optional Restore Defaults action
+gi.has_assist_tools = 1;               // optional host-defined opt-in page
+gi.assist_tools_note = "Enables host convenience features.";
+gi.credits_text = "Original game and port credits."; // optional read-only page
 /* ...per-game overrides... */
 
 char out_rom[512];
@@ -419,6 +422,10 @@ snesrecomp `docs/RECOMP_NET.md` → "Soft-return rematch checklist".
   resolution, and committing changes before launch; recomp-ui never executes
   package code.
 - **Footer** — PLAY, skip-launcher-on-boot (+ confirm modal), gamepad navigation.
+- **Optional host pages** — an Assist Tools opt-in backed by
+  `RecompLauncherCSettings.assist_tools`, plus host-owned read-only Credits
+  text. Games that do not supply these capabilities retain the original three
+  views.
 
 ---
 
@@ -426,6 +433,17 @@ When `RecompLauncherCGameInfo.default_settings` is non-NULL, the Settings
 footer also exposes a confirmed **Restore Defaults** action. The snapshot is
 copied at launcher initialization; resetting never changes the separately
 owned ROM selection or deletes save files.
+
+`RecompLauncherCGameInfo.has_assist_tools` adds an Assist Tools page and
+persists its checkbox through `RecompLauncherCSettings.assist_tools`.
+An opt-in `settings_bindings` host can keep keyboard and standard-controller
+bindings directly in the settings structure instead of pointing the launcher
+at a runtime-specific bind file. The same mode can supply named global Assist
+actions; they appear on the Assist page and are returned to the host as SDL
+scancodes plus portable standard-controller button/axis encodings.
+`credits_text` adds a Credits page. Both are additive host capabilities:
+recomp-ui defines presentation and navigation, while the game host defines
+the meaning of Assist Tools and owns the UTF-8 credits text.
 
 ---
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -102,6 +102,18 @@ a confirmed Restore Defaults action in the Settings footer. Confirmation
 replaces only the editable settings value; ROM selection and save files remain
 separately owned.
 
+Hosts may also add two top-level pages without forking the renderer.
+`has_assist_tools` exposes a host-defined opt-in backed by the additive
+`Settings.assist_tools` field and an optional explanatory note.
+`settings_bindings` is a separate opt-in for hosts whose runtime consumes the
+returned settings directly. It adds per-player keyboard/controller arrays and
+optional named Assist-action arrays. Keyboard entries are SDL scancodes;
+controller entries encode standard SDL gamepad buttons or signed axes. Hosts
+without this flag continue through their existing native bind bridges.
+`credits_text` exposes read-only, host-owned UTF-8 credits. Both capabilities
+default absent, preserving the original Dashboard/Settings/Controller view
+set for existing games.
+
 ## Concrete C shape (data-driven, no fake OOP)
 
 ```c

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -96,6 +96,12 @@ The System is the **template**; the Game **refines** it.
 | Saves not always; SRAM vs memcard | Save module, optional, `kind`-specialized |
 | 2 vs 4 pads; expose 1/2/4 | `SystemProfile.max_players` + `Game.exposed_players` |
 
+Hosts may optionally provide a complete `default_settings` snapshot through
+the C ABI. The launcher copies it during model initialization and then exposes
+a confirmed Restore Defaults action in the Settings footer. Confirmation
+replaces only the editable settings value; ROM selection and save files remain
+separately owned.
+
 ## Concrete C shape (data-driven, no fake OOP)
 
 ```c

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -3115,6 +3115,170 @@ static bool enabled_camera_controls(const LauncherModel* m) {
     return false;
 }
 
+const char* settings_key_label(int scancode) {
+    if (scancode <= 0) return "(unbound)";
+    const char* name = SDL_GetScancodeName((SDL_Scancode)scancode);
+    return (name && name[0]) ? name : "(unbound)";
+}
+
+void settings_pad_label(int binding, char* out, size_t capacity) {
+    if (!out || !capacity) return;
+    const char* name = nullptr;
+    char text[48] = {};
+    if (RECOMP_LAUNCHER_PAD_IS_BUTTON(binding)) {
+        int code = RECOMP_LAUNCHER_PAD_BUTTON_CODE(binding);
+        name = SDL_GetGamepadStringForButton((LNG_GamepadButton)code);
+        snprintf(text, sizeof text, "%s", (name && name[0]) ? name : "button");
+    } else if (RECOMP_LAUNCHER_PAD_IS_AXIS(binding)) {
+        int code = RECOMP_LAUNCHER_PAD_AXIS_CODE(binding);
+        name = SDL_GetGamepadStringForAxis(code);
+        snprintf(text, sizeof text, "%s%c",
+                 (name && name[0]) ? name : "axis",
+                 RECOMP_LAUNCHER_PAD_AXIS_POSITIVE(binding) ? '+' : '-');
+    } else {
+        snprintf(text, sizeof text, "(unbound)");
+    }
+    snprintf(out, capacity, "%s", text);
+}
+
+void draw_assist_binding_editor(LauncherModel* m, const LauncherTheme& th,
+                                const char* table_id, int action_limit,
+                                bool show_reset) {
+    if (!m->settings_bindings || m->assist_binding_count <= 0 ||
+        !m->assist_binding_labels)
+        return;
+    ImGui::PushStyleColor(ImGuiCol_Text, col(th.accent2));
+    ImGui::TextUnformatted("ASSIST CONTROLS");
+    ImGui::PopStyleColor();
+    ImGui::TextColored(col(th.text_muted),
+                       "Global controls; they only operate while Assist Tools is enabled.");
+    if (ImGui::BeginTable(table_id, 3, ImGuiTableFlags_SizingFixedFit |
+                                      ImGuiTableFlags_RowBg)) {
+        ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthFixed,
+                                px(150));
+        ImGui::TableSetupColumn("Keyboard", ImGuiTableColumnFlags_WidthFixed,
+                                px(180));
+        ImGui::TableSetupColumn("Controller", ImGuiTableColumnFlags_WidthFixed,
+                                px(180));
+        ImGui::TableHeadersRow();
+        int count = m->assist_binding_count;
+        if (action_limit > 0 && count > action_limit) count = action_limit;
+        for (int action = 0; action < count; ++action) {
+            ImGui::PushID(action);
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
+            ImGui::AlignTextToFramePadding();
+            ImGui::TextUnformatted(m->assist_binding_labels[action]);
+            ImGui::TableSetColumnIndex(1);
+            bool capture_key = m->capturing && m->capture_assist &&
+                               !m->capture_pad && m->capture_btn == action;
+            if (ImGui::Button(
+                    capture_key ? "[ press a key... ]" :
+                        settings_key_label(m->s.assist_key_bind[action]),
+                    ImVec2(px(170), 0)))
+                launcher_model_begin_assist_capture(m, action, false);
+            ImGui::TableSetColumnIndex(2);
+            bool capture_pad = m->capturing && m->capture_assist &&
+                               m->capture_pad && m->capture_btn == action;
+            char pad[48];
+            settings_pad_label(m->s.assist_pad_bind[action], pad, sizeof pad);
+            if (ImGui::Button(
+                    capture_pad ? "[ press a button... ]" : pad,
+                    ImVec2(px(170), 0)))
+                launcher_model_begin_assist_capture(m, action, true);
+            ImGui::PopID();
+        }
+        ImGui::EndTable();
+    }
+    if (show_reset && ImGui::Button("Reset Assist Controls"))
+        launcher_model_reset_assist_bindings(m);
+    if (m->capturing && m->capture_assist)
+        ImGui::TextColored(col(th.warn), "Listening... (Esc cancels)");
+}
+
+void draw_controller_assist_shortcuts(LauncherModel* m,
+                                      const LauncherTheme& th) {
+    ImGui::PushStyleColor(ImGuiCol_Text, col(th.accent2));
+    ImGui::TextUnformatted("ASSIST SHORTCUTS");
+    ImGui::PopStyleColor();
+    ImGui::SameLine();
+    ImGui::TextColored(col(th.text_muted),
+                       "(global; requires Assist Tools)");
+    if (ImGui::BeginTable("controller_assist_binds", 2,
+                          ImGuiTableFlags_SizingStretchSame)) {
+        for (int action = 0;
+             action < m->assist_binding_count && action < 2; ++action) {
+            ImGui::TableNextColumn();
+            ImGui::PushID(action);
+            ImGui::AlignTextToFramePadding();
+            ImGui::TextUnformatted(m->assist_binding_labels[action]);
+            ImGui::SameLine(0, px(8));
+            bool capture_key = m->capturing && m->capture_assist &&
+                               !m->capture_pad && m->capture_btn == action;
+            if (ImGui::Button(
+                    capture_key ? "[ key... ]" :
+                        settings_key_label(m->s.assist_key_bind[action]),
+                    ImVec2(px(105), 0)))
+                launcher_model_begin_assist_capture(m, action, false);
+            ImGui::SameLine(0, px(5));
+            bool capture_pad = m->capturing && m->capture_assist &&
+                               m->capture_pad && m->capture_btn == action;
+            char pad[48];
+            settings_pad_label(m->s.assist_pad_bind[action], pad, sizeof pad);
+            if (ImGui::Button(capture_pad ? "[ button... ]" : pad,
+                              ImVec2(px(135), 0)))
+                launcher_model_begin_assist_capture(m, action, true);
+            ImGui::PopID();
+        }
+        ImGui::EndTable();
+    }
+    if (m->capturing && m->capture_assist)
+        ImGui::TextColored(col(th.warn), "Listening... (Esc cancels)");
+}
+
+void draw_assist_tools(LauncherModel* m, const LauncherTheme& th) {
+    if (!begin_panel("assist_tools_page", 0, false)) {
+        end_panel();
+        return;
+    }
+    eyebrow("ASSIST TOOLS / CHEATS");
+    bool enabled = m->s.assist_tools != 0;
+    if (ImGui::Checkbox("Enable Assist Tools / Cheats", &enabled))
+        m->s.assist_tools = enabled ? 1 : 0;
+    ImGui::Dummy(ImVec2(0, px(6)));
+    ImGui::PushStyleColor(ImGuiCol_Text, col(th.text_muted));
+    ImGui::PushTextWrapPos();
+    ImGui::TextWrapped("%s",
+        (m->assist_tools_note && m->assist_tools_note[0])
+            ? m->assist_tools_note
+            : "This optional host mode enables game-specific convenience "
+              "features. The game window should disclose when it is active.");
+    ImGui::PopTextWrapPos();
+    ImGui::PopStyleColor();
+    if (m->settings_bindings) {
+        ImGui::Dummy(ImVec2(0, px(8)));
+        draw_assist_binding_editor(m, th, "assist_binds", 0, true);
+    }
+    end_panel();
+}
+
+void draw_credits(LauncherModel* m, const LauncherTheme& th) {
+    if (!begin_panel("credits_page", 0, false)) {
+        end_panel();
+        return;
+    }
+    eyebrow("CREDITS");
+    ImGui::PushStyleColor(ImGuiCol_Text, col(th.text));
+    ImGui::PushTextWrapPos();
+    ImGui::TextWrapped("%s",
+        (m->credits_text && m->credits_text[0])
+            ? m->credits_text
+            : "Credits have not been supplied for this title.");
+    ImGui::PopTextWrapPos();
+    ImGui::PopStyleColor();
+    end_panel();
+}
+
 // CONTROLLER-view rebind page: input source + deadzone, and the keyboard
 // bindings grid — reached from the dashboard CONTROLLER panel's Configure
 // button. The bindings grid walks the ACTIVE SystemProfile's
@@ -3557,7 +3721,7 @@ void draw_controller_config_view(LauncherModel* m, const LauncherTheme& th) {
         // A pad-bind console (Genesis) offers a KEY chip AND a GAMEPAD chip per
         // row — the legacy launcher's "Set key" / "Set pad" pair. Otherwise the
         // grid is keyboard-only, exactly as before.
-        const bool has_pad = spec.has_pad_binds != 0;
+        const bool has_pad = spec.has_pad_binds != 0 || m->settings_bindings;
 
         // When the player's source is a gamepad the N64 store captures pad
         // fields, not keys — reflect that in the card title and the capture
@@ -3633,7 +3797,10 @@ void draw_controller_config_view(LauncherModel* m, const LauncherTheme& th) {
                     // KEY chip
                     const bool cap_key = m->capturing && !m->capture_pad && m->capture_btn == b;
                     if (cap_key) ImGui::PushStyleColor(ImGuiCol_Button, col(th.accent));
-                    if (ImGui::Button(cap_key ? "[ press a key... ]" : m->binds[p][b], ImVec2(chip_w, 0)))
+                    const char* key_text = m->settings_bindings
+                        ? settings_key_label(m->s.player_key_bind[p][b])
+                        : m->binds[p][b];
+                    if (ImGui::Button(cap_key ? "[ press a key... ]" : key_text, ImVec2(chip_w, 0)))
                         launcher_model_begin_capture(m, b);
                     if (cap_key) ImGui::PopStyleColor();
                     // GAMEPAD chip (pad-bind consoles only: Genesis)
@@ -3641,7 +3808,13 @@ void draw_controller_config_view(LauncherModel* m, const LauncherTheme& th) {
                         ImGui::SameLine(0, chip_gap);
                         ImGui::PushID("pad");
                         const bool cap_pad = m->capturing && m->capture_pad && m->capture_btn == b;
-                        const char* pl = m->pad_binds[p][b][0] ? m->pad_binds[p][b] : "(unbound)";
+                        char settings_pad[48];
+                        settings_pad_label(m->s.player_pad_bind[p][b],
+                                           settings_pad, sizeof settings_pad);
+                        const char* pl = m->settings_bindings
+                            ? settings_pad
+                            : (m->pad_binds[p][b][0]
+                                ? m->pad_binds[p][b] : "(unbound)");
                         if (cap_pad) ImGui::PushStyleColor(ImGuiCol_Button, col(th.accent));
                         if (ImGui::Button(cap_pad ? "[ press a button... ]" : pl, ImVec2(chip_w, 0)))
                             launcher_model_begin_pad_capture(m, b);
@@ -3654,7 +3827,12 @@ void draw_controller_config_view(LauncherModel* m, const LauncherTheme& th) {
             ImGui::EndTable();
         }
         ImGui::Spacing();
-        if (ImGui::Button("Reset to Defaults")) launcher_binds_reset_player(m, m->cfg_player + 1);
+        if (ImGui::Button("Reset to Defaults")) {
+            if (m->settings_bindings)
+                launcher_model_reset_player_bindings(m, m->cfg_player);
+            else
+                launcher_binds_reset_player(m, m->cfg_player + 1);
+        }
         if (m->capturing) ImGui::TextColored(col(th.warn), "Listening... (Esc cancels)");
         } // !is_psx
     } end_panel();
@@ -3677,6 +3855,12 @@ void draw_controller_config_view(LauncherModel* m, const LauncherTheme& th) {
             bool ch = m->zapper_crosshair;
             if (ImGui::Checkbox("Show crosshair (hides the OS cursor)", &ch))
                 launcher_model_toggle_zapper_crosshair(m);
+        } end_panel();
+    }
+
+    if (m->settings_bindings && m->has_assist_tools) {
+        if (begin_panel("cfg_assist_binds", 0)) {
+            draw_controller_assist_shortcuts(m, th);
         } end_panel();
     }
 }
@@ -7318,32 +7502,57 @@ void draw_ui(LauncherModel* m, const LauncherTheme& th, int logical_w, int logic
             ImGui::PopStyleColor();
         }
     ImGui::EndGroup();
-    {   // right-aligned netplay name + nav buttons
-        const char* label = (m->view == LNG_VIEW_DASHBOARD) ? "Settings" : "< Back";
-        const float w = px(110.0f);
-        const float gap = px(10.0f);
-        const float name_w = px(170.0f);
-        float right = ImGui::GetCursorPosX() + ImGui::GetContentRegionAvail().x;
-        float nav_y = hdr_top + px(6.0f);
-        if (m->view == LNG_VIEW_NETPLAY && m->netplay_supported) {
-            ImGui::SetCursorPos(ImVec2(right - w - name_w - px(10.0f), nav_y));
-            const char* player_label = m->s.netplay_player_name[0] ? m->s.netplay_player_name : "Set player name";
-            if (ImGui::Button(player_label, ImVec2(name_w, px(34)))) {
-                std::snprintf(m->netplay_name_edit, sizeof(m->netplay_name_edit), "%s",
-                              m->s.netplay_player_name);
-                m->netplay_name_modal_open = true;
+    {   // right-aligned top-level navigation
+        const float gap = px(6.0f);
+        const float resume_x = ImGui::GetCursorPosX();
+        const float resume_y = ImGui::GetCursorPosY();
+        const float right = ImGui::GetWindowContentRegionMax().x;
+        const float y = hdr_top + px(6.0f);
+        if (m->view == LNG_VIEW_DASHBOARD) {
+            const int count = 1 + (m->mods ? 1 : 0) +
+                              (m->has_assist_tools ? 1 : 0) +
+                              ((m->credits_text && m->credits_text[0]) ? 1 : 0);
+            const float w = px(110.0f);
+            const float total = w * count + gap * (count - 1);
+            ImGui::SetCursorPos(ImVec2(right - total, y));
+            if (ImGui::Button("Settings", ImVec2(w, px(34))))
+                launcher_model_set_view(m, LNG_VIEW_SETTINGS);
+            if (m->mods) {
+                ImGui::SameLine(0, gap);
+                if (ImGui::Button("Mods", ImVec2(w, px(34))))
+                    launcher_model_set_view(m, LNG_VIEW_MODS);
             }
+            if (m->has_assist_tools) {
+                ImGui::SameLine(0, gap);
+                if (ImGui::Button("Assist Tools", ImVec2(w, px(34))))
+                    launcher_model_set_view(m, LNG_VIEW_ASSIST_TOOLS);
+            }
+            if (m->credits_text && m->credits_text[0]) {
+                ImGui::SameLine(0, gap);
+                if (ImGui::Button("Credits", ImVec2(w, px(34))))
+                    launcher_model_set_view(m, LNG_VIEW_CREDITS);
+            }
+        } else {
+            const float w = px(110.0f);
+            const float name_w = px(170.0f);
+            if (m->view == LNG_VIEW_NETPLAY && m->netplay_supported) {
+                ImGui::SetCursorPos(ImVec2(right - w - name_w - gap, y));
+                const char* player_label = m->s.netplay_player_name[0]
+                    ? m->s.netplay_player_name : "Set player name";
+                if (ImGui::Button(player_label, ImVec2(name_w, px(34)))) {
+                    std::snprintf(m->netplay_name_edit,
+                                  sizeof(m->netplay_name_edit), "%s",
+                                  m->s.netplay_player_name);
+                    m->netplay_name_modal_open = true;
+                }
+            }
+            ImGui::SetCursorPos(ImVec2(right - w, y));
+            if (ImGui::Button("< Back", ImVec2(w, px(34))))
+                launcher_model_set_view(m, LNG_VIEW_DASHBOARD);
         }
-        if (m->view == LNG_VIEW_DASHBOARD && m->mods) {
-            ImGui::SetCursorPos(ImVec2(right - w * 2.0f - gap, nav_y));
-            if (ImGui::Button("Mods", ImVec2(w, px(34))))
-                launcher_model_set_view(m, LNG_VIEW_MODS);
-        }
-        ImGui::SetCursorPos(ImVec2(right - w, nav_y));
-        if (ImGui::Button(label, ImVec2(w, px(34)))) {
-            launcher_model_set_view(m, m->view == LNG_VIEW_DASHBOARD
-                                        ? LNG_VIEW_SETTINGS : LNG_VIEW_DASHBOARD);
-        }
+        // Absolute placement prevents three dashboard buttons from mutating
+        // the title group's line state and wrapping Settings into the body.
+        ImGui::SetCursorPos(ImVec2(resume_x, resume_y));
     }
     // marquee underline: neon gradient rule under the header
     ImGui::Dummy(ImVec2(0, px(8.0f)));
@@ -7371,6 +7580,8 @@ void draw_ui(LauncherModel* m, const LauncherTheme& th, int logical_w, int logic
         case LNG_VIEW_CONTROLLER: draw_controller(m, th);           break;
         case LNG_VIEW_NETPLAY:    draw_netplay(m, th);              break;
         case LNG_VIEW_MODS:       draw_mods(m, th);                 break;
+        case LNG_VIEW_ASSIST_TOOLS: draw_assist_tools(m, th);        break;
+        case LNG_VIEW_CREDITS:      draw_credits(m, th);             break;
     }
     end_container();
 
@@ -7453,6 +7664,25 @@ bool try_capture(LauncherModel* m, const SDL_Event& ev) {
     // axis push (past a dead threshold) commits. PSX only accepts events from
     // the player's selected Input source device.
     if (m->capturing && m->capture_pad) {
+        if (m->settings_bindings) {
+            if (ev.type == SDL_EVENT_GAMEPAD_BUTTON_DOWN) {
+                launcher_model_set_captured_pad(
+                    m, RECOMP_LAUNCHER_PAD_BUTTON((int)LNG_EVGBTN(ev)));
+                launcher_model_cancel_capture(m);
+                return true;
+            }
+            if (ev.type == SDL_EVENT_GAMEPAD_AXIS_MOTION) {
+                const int val = (int)LNG_EVGAXISVAL(ev);
+                if (val >= 20000 || val <= -20000) {
+                    launcher_model_set_captured_pad(
+                        m, RECOMP_LAUNCHER_PAD_AXIS(
+                               (int)LNG_EVGAXIS(ev), val > 0));
+                    launcher_model_cancel_capture(m);
+                }
+                return true;
+            }
+            return true;
+        }
         const SystemProfile* cap_prof = (const SystemProfile*)m->profile;
         const bool psx_cap = cap_prof && cap_prof->id && !strcmp(cap_prof->id, "psx");
         const uint32_t want_id = m->player_pad_id[m->cfg_player];
@@ -7594,7 +7824,9 @@ bool try_capture(LauncherModel* m, const SDL_Event& ev) {
         // Single-bind stores (SNES/PSX/GBA) use the legacy scancode setter
         // (capture_slot is always 0 for them).
         const SystemProfile* prof = (const SystemProfile*)m->profile;
-        if (prof && prof->controller.binds_per_input >= 2 && prof->id && !strcmp(prof->id, "psx"))
+        if (m->settings_bindings)
+            launcher_model_set_captured_key(m, (int)LNG_EVSCAN(ev));
+        else if (prof && prof->controller.binds_per_input >= 2 && prof->id && !strcmp(prof->id, "psx"))
             launcher_binds_set_button_slot(m, m->cfg_player + 1, m->capture_btn,
                                            m->capture_slot, (int)LNG_EVSCAN(ev));
         else if (prof && prof->controller.binds_per_input >= 2)

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -3709,7 +3709,12 @@ void draw_controller_config_view(LauncherModel* m, const LauncherTheme& th) {
         } else {
         // Alternate binds per input (N64's input.cfg keeps two; SNES/GBA
         // keep one). 0 in the spec reads as 1 (older positional initializers).
-        const int bpi = spec.binds_per_input < 1 ? 1 : spec.binds_per_input;
+        // Host-owned settings arrays have one keyboard and one controller
+        // value per action, independent of a console bridge's alternate-slot
+        // format (for example N64 input.cfg). Keep that opt-in store on its
+        // own two-chip path instead of accidentally editing the native store.
+        const int bpi = m->settings_bindings
+            ? 1 : (spec.binds_per_input < 1 ? 1 : spec.binds_per_input);
 
         // Stores that follow the input SOURCE (N64: one shared table per device
         // TYPE) must re-read display strings on entry so switching

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -6289,6 +6289,12 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
         ImGui::SetCursorScreenPos(ImVec2(origin.x, cta_y + (play_h - ImGui::GetFrameHeight()) * 0.5f));
         if (ImGui::Checkbox("Skip launcher on boot", &skip))
             launcher_model_request_skip_toggle(m);
+    } else if (m->view == LNG_VIEW_SETTINGS &&
+               launcher_model_can_restore_defaults(m)) {
+        ImGui::SetCursorScreenPos(
+            ImVec2(origin.x, cta_y + (play_h - px(34.0f)) * 0.5f));
+        if (ImGui::Button("Restore Defaults", ImVec2(px(150.0f), px(34.0f))))
+            launcher_model_request_restore_defaults(m);
     }
     if (m->view == LNG_VIEW_NETPLAY) {
         const float action_w = px(190.0f);
@@ -7223,6 +7229,29 @@ void draw_skip_modal(LauncherModel* m) {
     }
 }
 
+void draw_restore_defaults_modal(LauncherModel* m) {
+    if (m->defaults_modal_open) ImGui::OpenPopup("Restore default settings?");
+    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    if (ImGui::BeginPopupModal("Restore default settings?", nullptr,
+                               ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::TextWrapped(
+            "This resets display, audio, controller, and launcher choices. "
+            "Your selected ROM, SRAM, and save states are not changed.");
+        ImGui::Spacing();
+        if (ImGui::Button("Cancel", ImVec2(px(120), 0))) {
+            launcher_model_cancel_restore_defaults(m);
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::SameLine();
+        if (ImGui::Button("Restore Defaults", ImVec2(px(150), 0))) {
+            launcher_model_restore_defaults(m);
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+    }
+}
+
 void draw_ui(LauncherModel* m, const LauncherTheme& th, int logical_w, int logical_h) {
     ImGuiViewport* vp = ImGui::GetMainViewport();
     ImGui::SetNextWindowPos(vp->Pos);
@@ -7359,6 +7388,7 @@ void draw_ui(LauncherModel* m, const LauncherTheme& th, int logical_w, int logic
     draw_netplay_password_modal(m, th);
     draw_netplay_direct_modal(m, th);
     draw_netplay_room_modal(m, th);
+    draw_restore_defaults_modal(m);
     // Transfer Pak config modal (N64): opened by any tile, dashboard or
     // Controller page. Drawn at root so it isn't clipped by a card child.
     if (m->tpak_slots > 0) draw_tpak_modal(m, th);

--- a/src/common/launcher_debug.c
+++ b/src/common/launcher_debug.c
@@ -156,6 +156,8 @@ void launcher_debug_step(LauncherPlatform* p, LauncherModel* m) {
         if      (strcmp(v, "dashboard")  == 0) launcher_model_set_view(m, LNG_VIEW_DASHBOARD);
         else if (strcmp(v, "settings")   == 0) launcher_model_set_view(m, LNG_VIEW_SETTINGS);
         else if (strcmp(v, "controller") == 0) launcher_model_set_view(m, LNG_VIEW_CONTROLLER);
+        else if (strcmp(v, "assist_tools") == 0) launcher_model_set_view(m, LNG_VIEW_ASSIST_TOOLS);
+        else if (strcmp(v, "credits") == 0) launcher_model_set_view(m, LNG_VIEW_CREDITS);
     } else if (strncmp(c, "player:", 7) == 0) {
         // Select which player the Controller view configures. Clamp to the
         // launcher's real player range (N64 profiles run up to 4) instead of

--- a/src/common/launcher_debug.h
+++ b/src/common/launcher_debug.h
@@ -7,7 +7,8 @@
 // Driven by the LNG_SCRIPT env var: a ';'-separated command list, executed one
 // command per frame.
 //
-//   view:dashboard|settings|controller   switch view (no clicking required)
+//   view:dashboard|settings|controller|assist_tools|credits
+//                                          switch view (no clicking required)
 //   player:0|1                           which player the controller view edits
 //   size:WxH                             resize the window (tests live reflow)
 //   click:X,Y                            synthetic click at logical coords

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -283,6 +283,10 @@ void launcher_model_init(LauncherModel* m,
     m->mod_selected = 0;
     m->mod_package_selected = 0;
     m->mod_show_packages = false;
+    if (game && game->default_settings) {
+        m->default_settings = *game->default_settings;
+        m->has_default_settings = true;
+    }
     m->s.adaptive_view =
         (m->adaptive_view_supported && m->s.adaptive_view) ? 1 : 0;
 
@@ -752,6 +756,25 @@ void launcher_model_set_view(LauncherModel* m, LngView v) {
 void launcher_model_open_config(LauncherModel* m, int player) {
     m->cfg_player = clampi(player, 0, LNG_MAX_PLAYERS - 1);
     m->view = LNG_VIEW_CONTROLLER;
+}
+
+bool launcher_model_can_restore_defaults(const LauncherModel* m) {
+    return m && m->has_default_settings;
+}
+
+void launcher_model_request_restore_defaults(LauncherModel* m) {
+    if (!launcher_model_can_restore_defaults(m)) return;
+    m->defaults_modal_open = true;
+}
+
+void launcher_model_restore_defaults(LauncherModel* m) {
+    if (!launcher_model_can_restore_defaults(m)) return;
+    m->s = m->default_settings;
+    m->defaults_modal_open = false;
+}
+
+void launcher_model_cancel_restore_defaults(LauncherModel* m) {
+    if (m) m->defaults_modal_open = false;
 }
 
 void launcher_model_cycle_scale(LauncherModel* m) {

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -52,7 +52,10 @@ static const char* kHotkeyNames[LNG_HK_COUNT] = {
     "FPS readout", "Toggle renderer",
     "Solar level up", "Solar level down", "Resume live solar"
 };
-static const char* kViewNames[5] = { "Dashboard", "Settings", "Controller", "Netplay", "Mods" };
+static const char* kViewNames[7] = {
+    "Dashboard", "Settings", "Controller", "Netplay", "Mods",
+    "Assist Tools", "Credits"
+};
 static const char* kSrcNames[3]  = { "None", "Keyboard", "Gamepad" };
 
 static void safe_copy(char* dst, size_t cap, const char* src) {
@@ -200,6 +203,14 @@ void launcher_model_init(LauncherModel* m,
         m->adaptive_view_supported = game->adaptive_view_supported != 0;
         m->display_layout_labels = game->display_layout_labels;
         m->num_display_layouts = game->num_display_layouts;
+        m->has_assist_tools     = game->has_assist_tools != 0;
+        m->assist_tools_note    = game->assist_tools_note;
+        m->settings_bindings    = game->settings_bindings != 0;
+        m->assist_binding_labels = game->assist_binding_labels;
+        m->assist_binding_count =
+            clampi(game->assist_binding_count, 0,
+                   RECOMP_LAUNCHER_MAX_ASSIST_BINDINGS);
+        m->credits_text         = game->credits_text;
         m->tpak_slots           = clampi(game->tpak_slots, 0, RECOMP_LAUNCHER_MAX_TPAKS);
         m->tpak_inspect_cb      = game->tpak_inspect;
         m->audio_device_labels  = game->audio_device_labels;
@@ -2639,6 +2650,7 @@ void launcher_model_begin_capture_slot(LauncherModel* m, int b, int slot) {
      * Arm straight away: the next press is a deliberate new click. */
     m->capture_mouse_armed = true;
     m->capture_pad  = false;
+    m->capture_assist = false;
 }
 void launcher_model_begin_pad_capture(LauncherModel* m, int b) {
     launcher_model_begin_capture(m, b);
@@ -2671,9 +2683,64 @@ void launcher_model_map_all_advance(LauncherModel* m) {
     m->map_all_wait_release = true;
     launcher_model_begin_pad_capture(m, kPsxGamepadBindOrder[m->map_all_step]);
 }
+void launcher_model_begin_assist_capture(LauncherModel* m, int action,
+                                         bool gamepad) {
+    if (!m->settings_bindings || action < 0 ||
+        action >= m->assist_binding_count)
+        return;
+    m->hk_capturing = false;
+    m->capturing = true;
+    m->capture_assist = true;
+    m->capture_pad = gamepad;
+    m->capture_btn = action;
+    m->capture_slot = 0;
+}
+void launcher_model_set_captured_key(LauncherModel* m, int scancode) {
+    if (!m || !m->capturing || m->capture_pad) return;
+    if (m->capture_assist) {
+        if (m->capture_btn >= 0 &&
+            m->capture_btn < m->assist_binding_count)
+            m->s.assist_key_bind[m->capture_btn] = scancode;
+    } else {
+        int buttons = launcher_model_active_button_count(m, m->cfg_player);
+        if (m->capture_btn >= 0 && m->capture_btn < buttons)
+            m->s.player_key_bind[m->cfg_player][m->capture_btn] = scancode;
+    }
+}
+void launcher_model_set_captured_pad(LauncherModel* m, int encoded_binding) {
+    if (!m || !m->capturing || !m->capture_pad) return;
+    if (m->capture_assist) {
+        if (m->capture_btn >= 0 &&
+            m->capture_btn < m->assist_binding_count)
+            m->s.assist_pad_bind[m->capture_btn] = encoded_binding;
+    } else {
+        int buttons = launcher_model_active_button_count(m, m->cfg_player);
+        if (m->capture_btn >= 0 && m->capture_btn < buttons)
+            m->s.player_pad_bind[m->cfg_player][m->capture_btn] =
+                encoded_binding;
+    }
+}
+void launcher_model_reset_player_bindings(LauncherModel* m, int player) {
+    if (!m || !m->settings_bindings || !m->has_default_settings) return;
+    player = clampi(player, 0, LNG_MAX_PLAYERS - 1);
+    memcpy(m->s.player_key_bind[player],
+           m->default_settings.player_key_bind[player],
+           sizeof m->s.player_key_bind[player]);
+    memcpy(m->s.player_pad_bind[player],
+           m->default_settings.player_pad_bind[player],
+           sizeof m->s.player_pad_bind[player]);
+}
+void launcher_model_reset_assist_bindings(LauncherModel* m) {
+    if (!m || !m->settings_bindings || !m->has_default_settings) return;
+    memcpy(m->s.assist_key_bind, m->default_settings.assist_key_bind,
+           sizeof m->s.assist_key_bind);
+    memcpy(m->s.assist_pad_bind, m->default_settings.assist_pad_bind,
+           sizeof m->s.assist_pad_bind);
+}
 void launcher_model_cancel_capture(LauncherModel* m) {
     m->capturing      = false;
     m->capture_pad    = false;
+    m->capture_assist = false;
     m->map_all_active = false;
     m->map_all_wait_release = false;
     m->map_all_step   = 0;
@@ -2744,6 +2811,6 @@ const char* launcher_hotkey_name(LngHotkey h) {
 }
 
 const char* launcher_view_name(LngView v) {
-    if (v < 0 || v > LNG_VIEW_MODS) return "?";
+    if (v < 0 || v > LNG_VIEW_CREDITS) return "?";
     return kViewNames[v];
 }

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -43,6 +43,8 @@ typedef enum {
     LNG_VIEW_CONTROLLER,
     LNG_VIEW_NETPLAY,
     LNG_VIEW_MODS,
+    LNG_VIEW_ASSIST_TOOLS,
+    LNG_VIEW_CREDITS,
 } LngView;
 
 typedef enum {
@@ -291,6 +293,12 @@ typedef struct {
     bool adaptive_view_supported;
     const char* const* display_layout_labels;
     int  num_display_layouts;
+    bool has_assist_tools;
+    const char* assist_tools_note;
+    bool settings_bindings;
+    const char* const* assist_binding_labels;
+    int assist_binding_count;
+    const char* credits_text;
     // Number of players the GAME actually supports. Mega Man X is 1-player, so
     // the launcher must not show a dead Player 2 row. Games that support 2
     // report 2 and the second row appears. Driven by data, never hardcoded.
@@ -483,6 +491,7 @@ typedef struct {
     bool      capture_mouse_armed;
     bool      camera_capturing;  // capturing an enabled Voxel camera key
     int       capture_camera;    // LNG_CAMERA_* index
+    bool      capture_assist;      // capture_btn indexes assist bindings
     bool      hk_capturing;      // capturing a system hotkey
     LngHotkey capture_hk;
     // Per-player bind-label display strings, indexed like capture_btn.
@@ -807,6 +816,12 @@ void launcher_model_begin_pad_capture(LauncherModel* m, int b);
 void launcher_model_begin_map_all(LauncherModel* m);
 // After a successful pad capture during Map All: advance or finish.
 void launcher_model_map_all_advance(LauncherModel* m);
+void launcher_model_begin_assist_capture(LauncherModel* m, int action,
+                                         bool gamepad);
+void launcher_model_set_captured_key(LauncherModel* m, int scancode);
+void launcher_model_set_captured_pad(LauncherModel* m, int encoded_binding);
+void launcher_model_reset_player_bindings(LauncherModel* m, int player);
+void launcher_model_reset_assist_bindings(LauncherModel* m);
 void launcher_model_cancel_capture(LauncherModel* m);
 // ---- hotkey capture ----
 void launcher_model_begin_hk_capture(LauncherModel* m, LngHotkey h);

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -369,6 +369,8 @@ typedef struct {
 
     // ---- editable settings (working copy of the C ABI struct) ----
     RecompLauncherCSettings s;
+    RecompLauncherCSettings default_settings;
+    bool      has_default_settings;
 
     // ---- transient UI state ----
     LngView   view;
@@ -451,6 +453,7 @@ typedef struct {
     int       netplay_host_max_players;
     /* Active room seat ceiling after create/join (0 = use game player_count). */
     int       netplay_lobby_max_slots;
+    bool      defaults_modal_open;   // confirmed full-settings reset
 
     // Selected gamepad per player (when player_src == 2). pad_id is the live
     // SDL_JoystickID; name is cached for display if the device disconnects.
@@ -521,6 +524,12 @@ void launcher_model_set_view(LauncherModel* m, LngView v);
 void launcher_model_open_config(LauncherModel* m, int player);  // -> Controller view
 void launcher_model_begin_camera_capture(LauncherModel* m, int action);
 void launcher_model_cancel_camera_capture(LauncherModel* m);
+
+// ---- restore host-provided settings defaults ----
+bool launcher_model_can_restore_defaults(const LauncherModel* m);
+void launcher_model_request_restore_defaults(LauncherModel* m);
+void launcher_model_restore_defaults(LauncherModel* m);
+void launcher_model_cancel_restore_defaults(LauncherModel* m);
 
 // ---- display settings ----
 void launcher_model_cycle_scale(LauncherModel* m);   // 1..6 wrap

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -39,6 +39,19 @@ extern "C" {
 #define RECOMP_LAUNCHER_HAS_MULTITAP_ENABLED 1
 /* Host may #ifdef this when reading multitap_analog (DualShock-on-tap hack). */
 #define RECOMP_LAUNCHER_HAS_MULTITAP_ANALOG 1
+#define RECOMP_LAUNCHER_MAX_BINDINGS 24
+#define RECOMP_LAUNCHER_MAX_ASSIST_BINDINGS 8
+
+/* Portable encoding used by host-owned controller bindings. Button and axis
+ * numbers are SDL's standard game-controller indices; zero remains unbound. */
+#define RECOMP_LAUNCHER_PAD_BUTTON(code) (1 + (code))
+#define RECOMP_LAUNCHER_PAD_AXIS(code, positive) \
+    (100 + ((code) * 2) + ((positive) ? 1 : 0))
+#define RECOMP_LAUNCHER_PAD_IS_BUTTON(value) ((value) > 0 && (value) < 100)
+#define RECOMP_LAUNCHER_PAD_IS_AXIS(value) ((value) >= 100)
+#define RECOMP_LAUNCHER_PAD_BUTTON_CODE(value) ((value) - 1)
+#define RECOMP_LAUNCHER_PAD_AXIS_CODE(value) (((value) - 100) / 2)
+#define RECOMP_LAUNCHER_PAD_AXIS_POSITIVE(value) (((value) - 100) & 1)
 
 // N64 Transfer Pak slots — one per controller port.
 #define RECOMP_LAUNCHER_MAX_TPAKS 4
@@ -560,6 +573,22 @@ struct RecompLauncherCSettings {
     // settings.toml and game.toml [controller] multitap_analog. Hosts may
     // also publish it in match_caps for the session.
     int  multitap_analog;
+
+    // ---- optional host assist/cheat gate ---------------------------------
+    // A game that sets GameInfo.has_assist_tools exposes this value in a
+    // dedicated launcher view. The host decides which runtime actions it
+    // gates. Appended additively so existing consumers remain unchanged.
+    int  assist_tools;        // bool: host-defined assists/cheats are enabled
+
+    /* Optional host-consumed bindings. A GameInfo with settings_bindings=1
+     * exposes keyboard + standard-controller chips on the Controller page.
+     * Keyboard values are SDL scancodes; pad values use the encoding above. */
+    int player_key_bind[RECOMP_LAUNCHER_MAX_PLAYERS]
+                       [RECOMP_LAUNCHER_MAX_BINDINGS];
+    int player_pad_bind[RECOMP_LAUNCHER_MAX_PLAYERS]
+                       [RECOMP_LAUNCHER_MAX_BINDINGS];
+    int assist_key_bind[RECOMP_LAUNCHER_MAX_ASSIST_BINDINGS];
+    int assist_pad_bind[RECOMP_LAUNCHER_MAX_ASSIST_BINDINGS];
 };
 
 // ---- host verification/inspection results (filled by the callbacks below) ----
@@ -983,6 +1012,19 @@ typedef struct RecompLauncherCGameInfo {
      * copies the snapshot during initialization. ROM and save files are not
      * part of this structure and are never deleted. */
     const RecompLauncherCSettings* default_settings;
+
+    /* Optional top-level launcher sections. `has_assist_tools` exposes a
+     * dedicated opt-in page backed by Settings.assist_tools. `credits_text`
+     * exposes a read-only Credits page and remains host-owned UTF-8 text. */
+    int  has_assist_tools;
+    const char* assist_tools_note;
+    const char* credits_text;
+    /* Host-owned binding mode. The active console profile supplies player
+     * button names; assist_binding_labels supplies the optional global action
+     * names (for example Rewind and Fast-forward). */
+    int settings_bindings;
+    const char* const* assist_binding_labels;
+    int assist_binding_count;
 } RecompLauncherCGameInfo;
 
 /* recomp_launcher_run_window return codes */

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -797,7 +797,6 @@ typedef struct RecompLauncherCGameInfo {
     // an Adaptive view toggle. Adaptive + fullscreen leaves the fixed aspect
     // control visible but disabled because the display chooses the live width.
     int  adaptive_view_supported;
-
     // Netplay is a title/developer capability, not a user setting. When set,
     // the dashboard exposes lobby host/join controls through host-owned
     // callbacks.
@@ -977,6 +976,13 @@ typedef struct RecompLauncherCGameInfo {
      * are appended so older zero-initialized hosts retain their exact UI. */
     const char* aspect_setting_label;
     const char* aspect_setting_help;
+
+    /* Optional complete host-owned defaults snapshot. When non-NULL, the
+     * Settings footer exposes a confirmed "Restore Defaults" action that
+     * copies this value into the launcher's editable settings. The launcher
+     * copies the snapshot during initialization. ROM and save files are not
+     * part of this structure and are never deleted. */
+    const RecompLauncherCSettings* default_settings;
 } RecompLauncherCGameInfo;
 
 /* recomp_launcher_run_window return codes */


### PR DESCRIPTION
Ports the legitimate, opt-in functionality from #7 onto current master without regressing newer setup, netplay, mods, display-layout, PSX per-device/map-all, or dual-bind capture paths.\n\nIncludes:\n- host-provided Restore Defaults snapshot\n- opt-in host-owned keyboard/controller settings arrays\n- opt-in Assist Tools and Credits views\n- assist binding capture/reset controls\n- integration fix keeping host-owned binding storage independent of native multi-slot console stores\n\nValidation:\n- clean standalone SDL2 configure/build\n- all 5 CTest tests pass (asset manifests, PSX staging, runtime UI, PSX dual-bind persistence, ImGui runtime UI)\n- original #7 reports DKC2 MSVC Release builds and its synthetic binding/lifecycle tests passing\n\nSDL3 was not available in this local MinGW environment; no SDL3-specific API was introduced by the port.\n\nSupersedes #7.