### PR TITLE
launcher: remove player-selectable Hybrid pad mode

### DIFF
--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -1706,17 +1706,18 @@ void panel_tpak_draw(LauncherModel* m, const LauncherTheme* th) {
     }
 }
 
-// PSX-style 3-way pad-mode selector: Hybrid / Analog / D-Pad segmented row.
-// Caller only draws this when pad_mode_supported && pad_mode_selectable (a
-// locked mode draws nothing — there's nothing to pick). The Hybrid segment is
-// itself hidden when !allow_hybrid, matching the original PSX launcher.
+// PSX-style pad-mode selector: Analog / D-Pad segmented row. Caller only draws
+// this when pad_mode_supported && pad_mode_selectable (a locked mode draws
+// nothing — there's nothing to pick). Hybrid is deliberately absent: it is a
+// mod-only mode a trusted game plugin requests at runtime, never a player
+// choice.
 void pad_mode_selector(LauncherModel* m, const LauncherTheme& th, int p, float w) {
     struct Seg { int mode; const char* label; };
     Seg segs[8];
     int n = 0;
     // A console with a custom pad-mode list (ControllerSpec.modes, e.g. Genesis
     // 3-Button/6-Button) drives the segments from that list; otherwise the
-    // legacy PSX-shaped Hybrid/Analog/D-Pad set (Hybrid gated by allow_hybrid).
+    // legacy PSX-shaped Analog/D-Pad set.
     const SystemProfile* prof = (const SystemProfile*)m->profile;
     if (prof && prof->controller.modes && prof->controller.mode_count > 0) {
         int mc = prof->controller.mode_count;
@@ -1724,12 +1725,11 @@ void pad_mode_selector(LauncherModel* m, const LauncherTheme& th, int p, float w
         for (int i = 0; i < mc; ++i)
             segs[n++] = { prof->controller.modes[i].mode, prof->controller.modes[i].label };
     } else {
-        if (m->allow_hybrid) segs[n++] = { 0, "Hybrid" };
         segs[n++] = { 1, "Analog" };
         segs[n++] = { 2, "D-Pad" };
     }
 
-    // Keyboard has no analog sticks — Hybrid/Analog are unavailable (PSX modes).
+    // Keyboard has no analog sticks — Analog is unavailable (PSX modes).
     const bool kb_digital_only =
         m->s.player_src[p] == 1 &&
         !(prof && prof->controller.modes && prof->controller.mode_count > 0);
@@ -1739,8 +1739,8 @@ void pad_mode_selector(LauncherModel* m, const LauncherTheme& th, int p, float w
     for (int i = 0; i < n; ++i) {
         if (i) ImGui::SameLine(0, gap);
         bool sel = m->s.pad_mode[p] == segs[i].mode;
-        // Modes 0 (Hybrid) and 1 (Analog) need sticks; grey out on keyboard.
-        const bool stick_mode = (segs[i].mode == 0 || segs[i].mode == 1);
+        // Analog needs sticks; grey out on keyboard.
+        const bool stick_mode = (segs[i].mode == 1);
         const bool disabled = kb_digital_only && stick_mode;
         ImGui::PushID(i);
         if (disabled) {

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -113,7 +113,6 @@ void launcher_model_init(LauncherModel* m,
 
         m->pad_mode_supported   = game->pad_mode_supported != 0;
         m->pad_mode_selectable  = game->pad_mode_selectable != 0;
-        m->allow_hybrid         = game->allow_hybrid != 0;
         m->locked_pad_mode      = clampi(game->locked_pad_mode, 0, 2);
         m->lock_device          = game->lock_device != 0;
         m->aspect_mask          = game->aspect_mask;
@@ -333,8 +332,10 @@ void launcher_model_init(LauncherModel* m,
                 for (int i = 0; i < pm_spec->mode_count; ++i)
                     if (pm_spec->modes[i].mode == m->s.pad_mode[p]) { ok = 1; break; }
                 if (!ok) m->s.pad_mode[p] = pm_spec->modes[0].mode;
-            } else if (!m->allow_hybrid && m->s.pad_mode[p] == 0) {
-                m->s.pad_mode[p] = 1;   // snap Hybrid -> Analog
+            } else if (m->s.pad_mode[p] == 0) {
+                /* Hybrid is mod-only and never selectable: migrate any stale
+                 * persisted value. The mod requests it at runtime instead. */
+                m->s.pad_mode[p] = 1;
             }
             /* Keyboard cannot drive Analog/Hybrid — force D-Pad. */
             if (m->s.player_src[p] == 1 &&
@@ -2531,10 +2532,10 @@ void launcher_model_set_pad_mode(LauncherModel* m, int player, int mode) {
             if (spec->modes[i].mode == mode) { m->s.pad_mode[player] = mode; return; }
         return;
     }
-    /* Keyboard has no sticks — Analog/Hybrid are unavailable. */
+    /* Keyboard has no sticks — Analog is unavailable. */
     if (m->s.player_src[player] == 1 && mode != 2) return;
     mode = clampi(mode, 0, 2);
-    if (mode == 0 && !m->allow_hybrid) mode = 1;   // Hybrid hidden -> snap to Analog
+    if (mode == 0) mode = 1;   /* Hybrid is mod-only -> snap to Analog */
     m->s.pad_mode[player] = mode;
 }
 

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -319,7 +319,6 @@ typedef struct {
     // ---- controller pad-mode caps (PlayStation-style analog/digital) ----
     bool     pad_mode_supported;    // false => no selector/art swap; generic pad.tga
     bool     pad_mode_selectable;   // false => selector hidden, mode forced to locked_pad_mode
-    bool     allow_hybrid;          // false => Hybrid option hidden
     int      locked_pad_mode;       // forced mode when !pad_mode_selectable
     bool     lock_device;           // true => hide the player controller cards entirely
 
@@ -721,9 +720,10 @@ void launcher_model_apply_msu1_patch(LauncherModel* m);
 void launcher_model_skip_msu1_patch(LauncherModel* m);
 
 // ---- controllers ----
-// PSX-style pad mode: 0=Hybrid, 1=Analog, 2=D-Pad. Gated: no-op when
-// !pad_mode_selectable (mode is locked); snaps away from Hybrid when
-// !allow_hybrid.
+// PSX-style pad mode: 1=Analog, 2=D-Pad. Gated: no-op when
+// !pad_mode_selectable (mode is locked). Mode 0 (Hybrid) is NOT selectable —
+// it is a mod-only mode requested at runtime by a trusted game plugin — so a
+// stale persisted 0 snaps to Analog.
 void launcher_model_set_pad_mode(LauncherModel* m, int player, int mode);
 void launcher_model_cycle_player_src(LauncherModel* m, int player); // None/Kbd/Pad
 void launcher_model_deadzone_delta(LauncherModel* m, int player, int delta);

--- a/src/common/launcher_system_types.h
+++ b/src/common/launcher_system_types.h
@@ -40,7 +40,7 @@ typedef struct { const char* label; int code; } ButtonDef;
 // text; `button_count` is how many LEADING entries of ControllerSpec.buttons[]
 // the rebind page shows in that mode (a Genesis 3-button pad has no X/Y/Z/Mode
 // rows). A profile that leaves ControllerSpec.modes NULL keeps the legacy
-// PSX-shaped selector (Hybrid/Analog/D-Pad, gated by allow_hybrid) with the
+// PSX-shaped selector (Analog/D-Pad) with the
 // full button set in every mode — PSX itself is untouched by this concept.
 typedef struct { int mode; const char* label; int button_count; } PadModeDef;
 

--- a/src/consoles/genesis/genesis_profile.h
+++ b/src/consoles/genesis/genesis_profile.h
@@ -127,10 +127,9 @@ static inline void launcher_profile_apply_genesis(RecompLauncherCGameInfo* gi) {
     gi->rom_noun = "ROM";
     // 3-Button/6-Button pad-mode selector (per player, engine PadType values).
     // The custom mode list lives on the SystemProfile row; these ABI flags
-    // just switch the selector on. allow_hybrid is a PSX-only concept.
+    // just switch the selector on.
     gi->pad_mode_supported  = 1;
     gi->pad_mode_selectable = 1;
-    gi->allow_hybrid        = 0;
     // Widescreen defaults ON at the console level (every shipped Genesis
     // recomp exposes the experimental 16:9 path); a per-game host overrides
     // to 0 when its layout isn't widescreen-capable (g_game_layout.ws_capable).

--- a/src/consoles/psx/psx_profile.h
+++ b/src/consoles/psx/psx_profile.h
@@ -134,7 +134,6 @@ static inline void launcher_profile_apply_psx(RecompLauncherCGameInfo* gi) {
     // Controller: PSX has analog/digital pad modes + swapping DualShock art.
     gi->pad_mode_supported  = 1;
     gi->pad_mode_selectable = 1;       // per-game lock_mode may set this to 0
-    gi->allow_hybrid        = 1;
     gi->aspect_mask         = 0x1;     // 4:3 always; game adds 16:9 (0x2) / 21:9 (0x4)
     // Full PS1 settings surface.
     gi->has_window_size = 1; gi->has_renderer = 1; gi->has_supersampling = 1;

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -696,7 +696,6 @@ typedef struct RecompLauncherCGameInfo {
     // analog/digital art are never shown (the generic pad.tga is used).
     int            pad_mode_supported;    // 0 = no pad-mode UI at all; 1 = show the selector + swapping art
     int            pad_mode_selectable;   // 0 = hide selector, force locked_pad_mode (game.lock_mode)
-    int            allow_hybrid;          // 0 = hide the Hybrid option
     int            locked_pad_mode;       // forced mode when !pad_mode_selectable
     int            lock_device;           // 1 = hide the player controller cards entirely (fixed pad)
     // Aspect ratios offered. bit0 = 4:3 (implied/always), bit1 = 16:9, bit2 = 21:9.


### PR DESCRIPTION
## Decision

Hybrid is no longer a player-selectable launcher/settings mode. The launcher now exposes only Analog and D-Pad. Hybrid remains available exclusively through psxrecomp's trusted mod API; Tomba's tomba.hybrid-controller package is the current consumer.

This is the behavioral/ABI half split out of closed #22. The additive mouse/dual-bind work already landed in #23.

## Behavior

- remove the Hybrid selector segment
- remove allow_hybrid from launcher model, console profiles, and RecompLauncherCGameInfo
- migrate stale persisted mode 0 (Hybrid) to Analog
- retain custom non-PSX mode lists such as Genesis 3/6-button unchanged

## Pairing

Must land with mstan/psxrecomp#112, which removes allow_hybrid at the caller/config layer while retaining the trusted mod override.

## Validation

- clean SDL2 configure/build
- CTest 5/5 passed
- paired Tomba + rebased psxrecomp#112 SDL2 runtime compiled and linked, including tomba_hybrid_controller_plugin.c
