### PR TITLE
psx: keep display enhancements mod-only

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,14 @@ if(BUILD_TESTING)
         COMMAND $<TARGET_FILE:recomp-ui-psx-binds-test>
                 "${CMAKE_CURRENT_BINARY_DIR}/psx-binds-test.ini")
 
+    add_executable(recomp-ui-psx-profile-test
+        tests/psx_profile_test.c)
+    target_include_directories(recomp-ui-psx-profile-test PRIVATE
+        src src/common src/consoles/psx)
+    add_test(
+        NAME recomp-ui-psx-profile
+        COMMAND $<TARGET_FILE:recomp-ui-psx-profile-test>)
+
     add_executable(recomp-runtime-ui-imgui-test
         tests/runtime_ui_imgui_test.cpp
         src/common/recomp_runtime_ui.c

--- a/src/consoles/psx/psx_profile.h
+++ b/src/consoles/psx/psx_profile.h
@@ -134,11 +134,15 @@ static inline void launcher_profile_apply_psx(RecompLauncherCGameInfo* gi) {
     // Controller: PSX has analog/digital pad modes + swapping DualShock art.
     gi->pad_mode_supported  = 1;
     gi->pad_mode_selectable = 1;       // per-game lock_mode may set this to 0
-    gi->aspect_mask         = 0x1;     // 4:3 always; game adds 16:9 (0x2) / 21:9 (0x4)
+    /* Display enhancements are mod-owned on PSX. Keep the generic View mode,
+     * Frame interpolation, and Skip FMVs rows absent by default; trusted game
+     * plugins activate those features after launcher resolution. */
+    gi->widescreen_supported = 0;
+    gi->aspect_mask           = 0;
     // Full PS1 settings surface.
     gi->has_window_size = 1; gi->has_renderer = 1; gi->has_supersampling = 1;
     gi->has_antialiasing = 1; gi->has_texture_filter = 1; gi->has_screen_kind = 1;
-    gi->has_frame_interp = 1; gi->has_spu_hq = 1; gi->has_skip_fmv = 1;
+    gi->has_frame_interp = 0; gi->has_spu_hq = 1; gi->has_skip_fmv = 0;
     gi->has_turbo_loads = 1; gi->has_bios = 1;
     gi->has_deadzone_pct = 1;
 }

--- a/tests/psx_profile_test.c
+++ b/tests/psx_profile_test.c
@@ -1,0 +1,25 @@
+#include "recomp_launcher.h"
+#include "consoles/psx/psx_profile.h"
+
+#include <assert.h>
+#include <string.h>
+
+int main(void) {
+    RecompLauncherCGameInfo game;
+    memset(&game, 0, sizeof(game));
+
+    launcher_profile_apply_psx(&game);
+
+    /* PSX display enhancements are mod-owned, never generic launcher rows. */
+    assert(game.widescreen_supported == 0);
+    assert(game.aspect_mask == 0);
+    assert(game.has_frame_interp == 0);
+    assert(game.has_skip_fmv == 0);
+
+    /* Unrelated PSX Display capabilities remain available. */
+    assert(game.has_renderer == 1);
+    assert(game.has_supersampling == 1);
+    assert(game.has_screen_kind == 1);
+
+    return 0;
+}


### PR DESCRIPTION
## Behavior

PSX View mode, Frame interpolation, and Skip FMVs are mod-owned enhancements. The generic launcher must never expose them.

- PSX profile defaults all three capabilities off
- adds a regression test proving those rows stay absent
- unrelated PSX Display controls remain enabled
- no effect on other console profiles

Pairs with the psxrecomp change that ignores legacy per-game offer flags and retains trusted activation APIs.

## Validation

- clean SDL2 build
- CTest 6/6 passed, including new PSX profile guard
- paired Tomba runtime compiled and linked with all three Tomba plugins
