### PR TITLE
Hide netplay disc diagnostics for offline titles

### DIFF
--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -1019,7 +1019,11 @@ void draw_verdict_block(const LauncherModel* m, const LauncherTheme& th, float a
                th, !pending, v.region[0] != '\0');
         kv_row("ISO header", pending ? dash : (v.iso_ok ? "OK" : "Mismatch"),
                th, !pending, v.iso_ok);
-        if (!pending && (v.track_count > 0 || v.netplay_detail[0])) {
+        // TOC fingerprinting is a netplay capability, not part of ordinary
+        // offline disc identification. Never expose it for offline titles,
+        // even if a host accidentally leaves stale netplay fields populated.
+        if (m->netplay_supported && !pending &&
+            (v.track_count > 0 || v.netplay_detail[0])) {
             char tracks_buf[32];
             if (v.track_count > 0)
                 std::snprintf(tracks_buf, sizeof(tracks_buf), "%d", v.track_count);
@@ -1029,7 +1033,8 @@ void draw_verdict_block(const LauncherModel* m, const LauncherTheme& th, float a
         }
         ImGui::EndTable();
     }
-    if (!pending && v.netplay_detail[0] && !v.netplay_ok) {
+    if (m->netplay_supported && !pending &&
+        v.netplay_detail[0] && !v.netplay_ok) {
         ImGui::Dummy(ImVec2(0, px(4)));
         ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + availw);
         ImGui::TextColored(col(th.warn), "%s", v.netplay_detail);


### PR DESCRIPTION
## Summary
- gate the PSX Tracks row behind the launcher model's netplay capability
- gate netplay TOC warning text behind the same capability
- defensively suppress stale host-provided netplay fields for offline games

## Validation
- clean MinGW/Ninja build
- all 6 recomp-ui CTest tests pass

Beads: beads-eio.3.24