### PR TITLE
Fix SDL3 C++ build: cast axis codes for GetGamepadStringForAxis.

### DIFF
--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -3136,7 +3136,7 @@ void settings_pad_label(int binding, char* out, size_t capacity) {
         snprintf(text, sizeof text, "%s", (name && name[0]) ? name : "button");
     } else if (RECOMP_LAUNCHER_PAD_IS_AXIS(binding)) {
         int code = RECOMP_LAUNCHER_PAD_AXIS_CODE(binding);
-        name = SDL_GetGamepadStringForAxis(code);
+        name = SDL_GetGamepadStringForAxis((LNG_GamepadAxis)code);
         snprintf(text, sizeof text, "%s%c",
                  (name && name[0]) ? name : "axis",
                  RECOMP_LAUNCHER_PAD_AXIS_POSITIVE(binding) ? '+' : '-');

--- a/src/common/launcher_binds.c
+++ b/src/common/launcher_binds.c
@@ -219,7 +219,7 @@ static void genesis_pad_label(int kind, int code, int axis_dir, char* out, size_
         const char* n = SDL_GetGamepadStringForButton((LNG_GamepadButton)code);
         copy_str(out, cap, (n && n[0]) ? n : "(unbound)");
     } else if (kind == RUI_GEN_BIND_AXIS) {
-        const char* n = SDL_GetGamepadStringForAxis(code);
+        const char* n = SDL_GetGamepadStringForAxis((LNG_GamepadAxis)code);
         char buf[32];
         snprintf(buf, sizeof(buf), "%s%c", (n && n[0]) ? n : "axis",
                  axis_dir < 0 ? '-' : '+');

--- a/src/common/launcher_sdlcompat.h
+++ b/src/common/launcher_sdlcompat.h
@@ -59,6 +59,7 @@
 // axis->name lookup
 #define SDL_GetGamepadStringForAxis(a)    SDL_GameControllerGetStringForAxis((SDL_GameControllerAxis)(a))
 typedef SDL_GameControllerButton  LNG_GamepadButton;
+typedef SDL_GameControllerAxis    LNG_GamepadAxis;
 
 // key-modifier masks (SDL3 renamed KMOD_* -> SDL_KMOD_*)
 #define SDL_KMOD_CTRL   KMOD_CTRL
@@ -82,6 +83,7 @@ typedef SDL_GameControllerButton  LNG_GamepadButton;
 #define LNG_EVJAXISVAL(ev)  ((ev).jaxis.value)
 #define LNG_EVJAXISWHICH(ev) ((ev).jaxis.which)
 typedef SDL_GamepadButton  LNG_GamepadButton;
+typedef SDL_GamepadAxis    LNG_GamepadAxis;
 #endif
 
 #endif // LAUNCHER_NG_SDLCOMPAT_H

--- a/src/consoles/psx/psx_pad_binds.c
+++ b/src/consoles/psx/psx_pad_binds.c
@@ -333,7 +333,7 @@ static void source_from_bind(int kind, int code, int axis_dir,
         const char* n = SDL_GetGamepadStringForButton((LNG_GamepadButton)code);
         copy_str(out, cap, (n && n[0]) ? n : "");
     } else if (kind == 2) {
-        const char* n = SDL_GetGamepadStringForAxis(code);
+        const char* n = SDL_GetGamepadStringForAxis((LNG_GamepadAxis)code);
         char buf[32];
         snprintf(buf, sizeof(buf), "%s%c", (n && n[0]) ? n : "axis",
                  axis_dir < 0 ? '-' : '+');


### PR DESCRIPTION
C++ rejects int→SDL_GamepadAxis; match the existing LNG_GamepadButton cast and add LNG_GamepadAxis in the SDL2/SDL3 compat shim.