### PR TITLE
Feat/hotfixnetplay ux

### DIFF
--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -5055,53 +5055,50 @@ void draw_netplay_room_modal(LauncherModel* m, const LauncherTheme& th) {
         }
         ImGui::EndTable();
     }
-    /* Session BIOS settle preview (OpenBIOS vs SCPH-1001). Mixed BIOSes desync. */
+    /* Session BIOS notice (OpenBIOS vs SCPH1001). Keep copy plain — hosts care
+     * about save-state compatibility, not kernel-RAM details. */
     {
-        int any_prefer_open = 0;
-        int any_prefer_scph = 0;
-        int any_cannot_scph = 0;
-        int any_missing_offer = 0;
+        int host_prefer_open = 0;
+        int host_found = 0;
+        int peers_agree_scph = 1;
         int saw = 0;
         for (int slot = 0; slot < max_slots; ++slot) {
             if (!occupied[slot]) continue;
             ++saw;
-            if (!slots[slot].bios_offer_valid) {
-                any_missing_offer = 1;
-                any_cannot_scph = 1;
-                continue;
+            const int offer_ok = slots[slot].bios_offer_valid;
+            const int prefer_open = !offer_ok || slots[slot].bios_prefer_openbios;
+            const int can_scph = offer_ok && slots[slot].bios_can_scph1001;
+            if (slots[slot].is_host) {
+                host_found = 1;
+                host_prefer_open = prefer_open ? 1 : 0;
             }
-            if (slots[slot].bios_prefer_openbios)
-                any_prefer_open = 1;
-            else
-                any_prefer_scph = 1;
-            if (!slots[slot].bios_can_scph1001) any_cannot_scph = 1;
+            if (prefer_open || !can_scph) peers_agree_scph = 0;
         }
-        if (saw >= 2) {
-            const int session_open =
-                any_prefer_open || any_cannot_scph || any_missing_offer;
+        if (saw >= 1 && host_found) {
             ImGui::Spacing();
-            if (session_open) {
-                ImGui::TextColored(col(th.warn),
-                    "Match BIOS: OpenBIOS (session only — mixed or missing "
-                    "SCPH-1001 dumps cannot use retail).");
+            ImGui::PushTextWrapPos(0.0f);
+            if (host_prefer_open) {
+                ImGui::TextColored(
+                    col(th.good),
+                    "Host has selected OpenBIOS for this session.\n"
+                    "Note: Save states are not cross compatible with SCPH1001 "
+                    "and OpenBIOS sessions");
+            } else if (peers_agree_scph) {
+                ImGui::TextColored(
+                    col(th.good),
+                    "All users agree on proprietary BIOS SCPH1001.bin for this "
+                    "session.\n"
+                    "Note: Save states are not cross compatible with SCPH1001 "
+                    "and OpenBIOS sessions");
             } else {
-                ImGui::TextColored(col(th.good),
-                    "Match BIOS: SCPH-1001 (all peers can run it; session only).");
+                ImGui::TextColored(
+                    col(th.warn),
+                    "1 or more users lacks proprietary BIOS, using OpenBIOS for "
+                    "this session instead.\n"
+                    "Note: Save states are not cross compatible with SCPH1001 "
+                    "and OpenBIOS sessions");
             }
-            if (ImGui::IsItemHovered()) {
-                ImGui::SetTooltip(
-                    "OpenBIOS and SCPH-1001 lay out kernel RAM differently. "
-                    "Netplay requires one session BIOS for all peers; it does "
-                    "not change your saved Settings preference.");
-            }
-            if (any_prefer_open && any_prefer_scph) {
-                ImGui::TextColored(col(th.warn),
-                    "Players disagree on BIOS preference — session settles to "
-                    "OpenBIOS so the match stays in sync.");
-            } else if (any_missing_offer) {
-                ImGui::TextColored(col(th.text_muted),
-                    "Waiting for every peer to advertise BIOS capability…");
-            }
+            ImGui::PopTextWrapPos();
         }
     }
     ImGui::Spacing();

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -3924,18 +3924,24 @@ void np_connect_and_list(LauncherModel* m) {
     if (!np) return;
     if (np->set_player_name && m->s.netplay_player_name[0])
         np->set_player_name(np->ctx, m->s.netplay_player_name);
-    if (np->connect && (!np->connected || !np->connected(np->ctx)))
+    const bool already = np->connected && np->connected(np->ctx);
+    const bool in_flight = np->connecting && np->connecting(np->ctx);
+    if (np->connect && !already && !in_flight)
         (void)np->connect(np->ctx);
     if (np->request_list)
         np->request_list(np->ctx);
     m->netplay_list_fresh = true;
+    if (!already)
+        std::snprintf(m->netplay_status, sizeof(m->netplay_status),
+                      "Connecting to lobby server…");
 }
 
 /* Reload server lobby table + UDP-browse LAN hosts (BEACON) / file registry. */
 void np_refresh_lobby_list(LauncherModel* m) {
     np_connect_and_list(m);
     m->netplay_selected_lobby = -1;
-    m->netplay_status[0] = '\0';
+    /* Keep Connecting… status from np_connect_and_list; clear only when
+     * the caller is an explicit Refresh after a prior error. */
 }
 
 static void mod_note_error(LauncherModel* m);
@@ -5439,6 +5445,18 @@ void draw_netplay(LauncherModel* m, const LauncherTheme& th) {
     if (np->launch_pending && np->launch_pending(np->ctx))
         np_try_launch(m);
 
+    const bool np_online = np->connected && np->connected(np->ctx);
+    const bool np_connecting = np->connecting && np->connecting(np->ctx);
+    if (np_online && m->netplay_status[0] &&
+        std::strncmp(m->netplay_status, "Connecting", 10) == 0) {
+        m->netplay_status[0] = '\0';
+    } else if (!np_online && !np_connecting && m->netplay_list_fresh &&
+               m->netplay_status[0] &&
+               std::strncmp(m->netplay_status, "Connecting", 10) == 0) {
+        std::snprintf(m->netplay_status, sizeof(m->netplay_status),
+                      "Could not reach lobby server.");
+    }
+
     begin_container("netplay_lobbies", ImVec2(0, 0), ImGuiChildFlags_None);
     ImGui::TextColored(col(th.accent2), "LOBBIES");
     if (m->netplay_status[0])
@@ -6596,7 +6614,11 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
         const float net_w = px(170.0f);
         ImGui::SetCursorScreenPos(ImVec2(play_x - net_w - px(12.0f), cta_y));
         if (ImGui::Button("NETPLAY", ImVec2(net_w, play_h))) {
-            np_connect_and_list(m);
+            /* Open the page immediately; connect/list runs on first draw
+             * (and continues off-thread) so Windows DNS/TCP never freezes UI. */
+            m->netplay_list_fresh = false;
+            std::snprintf(m->netplay_status, sizeof(m->netplay_status),
+                          "Connecting to lobby server…");
             launcher_model_set_view(m, LNG_VIEW_NETPLAY);
         }
     }

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -5056,11 +5056,13 @@ void draw_netplay_room_modal(LauncherModel* m, const LauncherTheme& th) {
         ImGui::EndTable();
     }
     /* Session BIOS notice (OpenBIOS vs SCPH1001). Keep copy plain — hosts care
-     * about save-state compatibility, not kernel-RAM details. */
+     * about save-state compatibility, not kernel-RAM details.
+     * Orange OpenBIOS override only when a peer cannot run SCPH; host retail
+     * preference otherwise settles SCPH (even if a guest prefers OpenBIOS). */
     {
         int host_prefer_open = 0;
         int host_found = 0;
-        int peers_agree_scph = 1;
+        int all_can_scph = 1;
         int saw = 0;
         for (int slot = 0; slot < max_slots; ++slot) {
             if (!occupied[slot]) continue;
@@ -5072,7 +5074,7 @@ void draw_netplay_room_modal(LauncherModel* m, const LauncherTheme& th) {
                 host_found = 1;
                 host_prefer_open = prefer_open ? 1 : 0;
             }
-            if (prefer_open || !can_scph) peers_agree_scph = 0;
+            if (!can_scph) all_can_scph = 0;
         }
         if (saw >= 1 && host_found) {
             ImGui::Spacing();
@@ -5083,7 +5085,7 @@ void draw_netplay_room_modal(LauncherModel* m, const LauncherTheme& th) {
                     "Host has selected OpenBIOS for this session.\n"
                     "Note: Save states are not cross compatible with SCPH1001 "
                     "and OpenBIOS sessions");
-            } else if (peers_agree_scph) {
+            } else if (all_can_scph) {
                 ImGui::TextColored(
                     col(th.good),
                     "All users agree on proprietary BIOS SCPH1001.bin for this "
@@ -7018,40 +7020,67 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
 
     /* ---- Page 1: BIOS / disc / generate -------------------------------- */
     const SetupPlatKind plat = setup_platform_kind(m->platform);
+    const bool media_confirm = launcher_model_setup_media_confirm_only(m);
 
-    ImGui::TextColored(col(th.accent), "Setup required");
-    ImGui::PushTextWrapPos(wrap_x);
-    if (plat == SETUP_PLAT_PSX && m->has_bios) {
-        ImGui::TextColored(col(th.text_muted),
-            "%s needs a playable %s before you can launch. This build includes "
-            "a bundled BIOS (OpenBIOS) by default. Setup also looks for a "
-            "retail SCPH1001.BIN beside the install and uses it when found; "
-            "otherwise OpenBIOS stays selected. Use a Redump-style .cue with "
-            "sibling .bin tracks (.iso is not accepted). Pick your %s below "
-            "(you must legally own these dumps).",
-            game, noun, noun);
-    } else if (plat == SETUP_PLAT_GBA && m->has_bios) {
-        ImGui::TextColored(col(th.text_muted),
-            "%s needs a Game Boy Advance BIOS dump and a playable %s before "
-            "you can launch. Pick both below (you must legally own these dumps).",
-            game, noun);
-    } else if (plat == SETUP_PLAT_SNES) {
-        ImGui::TextColored(col(th.text_muted),
-            "%s needs a playable Super Nintendo %s before you can launch. "
-            "Pick your file below (you must legally own this dump).",
-            game, noun);
-    } else if (m->has_bios) {
-        ImGui::TextColored(col(th.text_muted),
-            "%s needs a BIOS image and a playable %s before you can launch. "
-            "Pick both below (you must legally own these dumps).",
-            game, noun);
+    if (media_confirm) {
+        ImGui::TextColored(col(th.accent),
+                           m->has_bios ? "Confirm BIOS and disc"
+                                       : "Confirm disc");
+        ImGui::PushTextWrapPos(wrap_x);
+        if (plat == SETUP_PLAT_PSX && m->has_bios) {
+            ImGui::TextColored(col(th.text_muted),
+                "This build is already generated. Select a PlayStation BIOS "
+                "(or keep OpenBIOS) and a Redump-style .cue with sibling .bin "
+                "tracks so %s can launch. Your previous disc/BIOS picks were "
+                "cleared from settings.",
+                game);
+        } else if (m->has_bios) {
+            ImGui::TextColored(col(th.text_muted),
+                "This build is already ready. Confirm a BIOS image and a "
+                "playable %s below — previous picks were cleared from settings.",
+                noun);
+        } else {
+            ImGui::TextColored(col(th.text_muted),
+                "This build is already ready. Confirm a playable %s below — "
+                "the previous pick was cleared from settings.",
+                noun);
+        }
+        ImGui::PopTextWrapPos();
     } else {
-        ImGui::TextColored(col(th.text_muted),
-            "%s needs a playable %s before you can launch. Pick your file below "
-            "(you must legally own this dump).",
-            game, noun);
+        ImGui::TextColored(col(th.accent), "Setup required");
+        ImGui::PushTextWrapPos(wrap_x);
+        if (plat == SETUP_PLAT_PSX && m->has_bios) {
+            ImGui::TextColored(col(th.text_muted),
+                "%s needs a playable %s before you can launch. This build includes "
+                "a bundled BIOS (OpenBIOS) by default. Setup also looks for a "
+                "retail SCPH1001.BIN beside the install and uses it when found; "
+                "otherwise OpenBIOS stays selected. Use a Redump-style .cue with "
+                "sibling .bin tracks (.iso is not accepted). Pick your %s below "
+                "(you must legally own these dumps).",
+                game, noun, noun);
+        } else if (plat == SETUP_PLAT_GBA && m->has_bios) {
+            ImGui::TextColored(col(th.text_muted),
+                "%s needs a Game Boy Advance BIOS dump and a playable %s before "
+                "you can launch. Pick both below (you must legally own these dumps).",
+                game, noun);
+        } else if (plat == SETUP_PLAT_SNES) {
+            ImGui::TextColored(col(th.text_muted),
+                "%s needs a playable Super Nintendo %s before you can launch. "
+                "Pick your file below (you must legally own this dump).",
+                game, noun);
+        } else if (m->has_bios) {
+            ImGui::TextColored(col(th.text_muted),
+                "%s needs a BIOS image and a playable %s before you can launch. "
+                "Pick both below (you must legally own these dumps).",
+                game, noun);
+        } else {
+            ImGui::TextColored(col(th.text_muted),
+                "%s needs a playable %s before you can launch. Pick your file below "
+                "(you must legally own this dump).",
+                game, noun);
+        }
+        ImGui::PopTextWrapPos();
     }
-    ImGui::PopTextWrapPos();
     ImGui::Dummy(ImVec2(0, px(10)));
 
     if (m->has_bios) {
@@ -7192,7 +7221,11 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
         }
     }
 
-    if (m->prepare_disc_cb || m->prepare_with_progress_cb) {
+    /* Full first-run only: Generate & rebuild. Media-confirm (cleared disc/
+     * BIOS with sources already present) skips this — regenerate stays in
+     * Settings → SYSTEM when the host exposes it. */
+    if (!media_confirm &&
+        (m->prepare_disc_cb || m->prepare_with_progress_cb)) {
         ImGui::Dummy(ImVec2(0, px(12)));
         char section_buf[128];
         const char* section;
@@ -7297,8 +7330,12 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
     }
     if (!m->prepare_required_before_continue) {
         const bool ready = launcher_model_can_finish_setup(m);
+        const char* continue_lbl =
+            media_confirm
+                ? (m->has_bios ? "Confirm BIOS and disc" : "Confirm disc")
+                : "Continue to launcher";
         if (!ready) ImGui::BeginDisabled();
-        if (ImGui::Button("Continue to launcher", ImVec2(px(220), px(34)))) {
+        if (ImGui::Button(continue_lbl, ImVec2(px(220), px(34)))) {
             launcher_model_finish_setup(m);
             ImGui::CloseCurrentPopup();
         }
@@ -7311,6 +7348,9 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
                     ImGui::SetTooltip("Wait for the current job to finish");
                 else if (m->has_bios && !m->setup_bios_ok)
                     ImGui::SetTooltip("BIOS check required");
+                else if (m->profile && m->profile->verify.mode == 1 &&
+                         !m->verify.netplay_ok)
+                    ImGui::SetTooltip("Disc mount / track layout not accepted");
             }
         }
         ImGui::SameLine();

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -4772,9 +4772,13 @@ void draw_netplay_room_modal(LauncherModel* m, const LauncherTheme& th) {
 
     ImGui::OpenPopup("LOBBY");
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
-    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
-    ImGui::SetNextWindowSize(ImVec2(px(640), 0), ImGuiCond_Appearing);
-    if (!ImGui::BeginPopupModal("LOBBY", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) return;
+    /* Always recenter: content height changes as members join/leave, and
+     * ImGuiCond_Appearing left the room modal stuck off-center after join. */
+    ImGui::SetNextWindowPos(center, ImGuiCond_Always, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(ImVec2(px(640), 0), ImGuiCond_Always);
+    const ImGuiWindowFlags lobby_flags =
+        ImGuiWindowFlags_AlwaysAutoResize | ImGuiWindowFlags_NoMove;
+    if (!ImGui::BeginPopupModal("LOBBY", nullptr, lobby_flags)) return;
 
     /* Only file-backed LAN/Direct rooms show IP/Port. Server-list joins always
      * show the lobby URL — do not use Host Lobby's LAN checkbox or a stale

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -6667,7 +6667,9 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
         ImGui::IsKeyPressed(ImGuiKey_Backspace, false))
         ImGui::SetKeyboardFocusHere();
     float play_x = origin.x + fullw - play_w;
-    if (m->view == LNG_VIEW_DASHBOARD && m->netplay_supported) {
+    if (m->netplay_supported &&
+        (m->view == LNG_VIEW_DASHBOARD || m->view == LNG_VIEW_SETTINGS ||
+         m->view == LNG_VIEW_CONTROLLER)) {
         const float net_w = px(170.0f);
         ImGui::SetCursorScreenPos(ImVec2(play_x - net_w - px(12.0f), cta_y));
         if (ImGui::Button("NETPLAY", ImVec2(net_w, play_h))) {

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -7246,6 +7246,21 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
     ImGui::EndPopup();
 }
 
+
+static const char* generate_disabled_reason(const LauncherModel* m) {
+    if (!m) return "Generate is unavailable.";
+    const bool has_prep =
+        m->prepare_with_progress_cb != nullptr || m->prepare_disc_cb != nullptr;
+    if (!has_prep) {
+        return "Generate is unavailable (project/SDK not found).\n"
+               "Launch from RetComM, or run the game from its source tree "
+               "(src/current).";
+    }
+    if (!m->rom_present || !m->rom_full[0])
+        return "Select a disc image first";
+    return "Generate is unavailable.";
+}
+
 void draw_bios_confirm_modal(LauncherModel* m, const LauncherTheme& th) {
     if (m->bios_confirm_open) ImGui::OpenPopup("Switch BIOS?");
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
@@ -7281,7 +7296,7 @@ void draw_bios_confirm_modal(LauncherModel* m, const LauncherTheme& th) {
     if (!can_gen) {
         ImGui::EndDisabled();
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-            ImGui::SetTooltip("Select a disc image first");
+            ImGui::SetTooltip("%s", generate_disabled_reason(m));
     }
     ImGui::SameLine();
     if (ImGui::Button("Use OpenBIOS", ImVec2(px(130), px(32)))) {
@@ -7329,7 +7344,7 @@ void draw_bios_play_modal(LauncherModel* m, const LauncherTheme& th) {
     if (!can_gen) {
         ImGui::EndDisabled();
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-            ImGui::SetTooltip("Select a disc image first");
+            ImGui::SetTooltip("%s", generate_disabled_reason(m));
     }
     ImGui::SameLine();
     if (ImGui::Button("Use OpenBIOS", ImVec2(px(130), px(32))))

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -4975,6 +4975,13 @@ void draw_netplay_room_modal(LauncherModel* m, const LauncherTheme& th) {
                 ImGui::TextColored(col(th.good), "Connected");
             else
                 ImGui::TextColored(col(th.text_muted), "Waiting");
+            if (occupied[slot] && slots[slot].bios_offer_valid &&
+                ImGui::IsItemHovered()) {
+                ImGui::SetTooltip(
+                    "BIOS: %s%s",
+                    slots[slot].bios_prefer_openbios ? "OpenBIOS" : "SCPH-1001",
+                    slots[slot].bios_can_scph1001 ? "" : " (no SCPH dump)");
+            }
             ImGui::TableSetColumnIndex(4);
             table_row_vcenter(member_row_h, text_h);
             /* RTT to that seat from local peer — never on the local row. */
@@ -5043,6 +5050,55 @@ void draw_netplay_room_modal(LauncherModel* m, const LauncherTheme& th) {
             ImGui::PopID();
         }
         ImGui::EndTable();
+    }
+    /* Session BIOS settle preview (OpenBIOS vs SCPH-1001). Mixed BIOSes desync. */
+    {
+        int any_prefer_open = 0;
+        int any_prefer_scph = 0;
+        int any_cannot_scph = 0;
+        int any_missing_offer = 0;
+        int saw = 0;
+        for (int slot = 0; slot < max_slots; ++slot) {
+            if (!occupied[slot]) continue;
+            ++saw;
+            if (!slots[slot].bios_offer_valid) {
+                any_missing_offer = 1;
+                any_cannot_scph = 1;
+                continue;
+            }
+            if (slots[slot].bios_prefer_openbios)
+                any_prefer_open = 1;
+            else
+                any_prefer_scph = 1;
+            if (!slots[slot].bios_can_scph1001) any_cannot_scph = 1;
+        }
+        if (saw >= 2) {
+            const int session_open =
+                any_prefer_open || any_cannot_scph || any_missing_offer;
+            ImGui::Spacing();
+            if (session_open) {
+                ImGui::TextColored(col(th.warn),
+                    "Match BIOS: OpenBIOS (session only — mixed or missing "
+                    "SCPH-1001 dumps cannot use retail).");
+            } else {
+                ImGui::TextColored(col(th.good),
+                    "Match BIOS: SCPH-1001 (all peers can run it; session only).");
+            }
+            if (ImGui::IsItemHovered()) {
+                ImGui::SetTooltip(
+                    "OpenBIOS and SCPH-1001 lay out kernel RAM differently. "
+                    "Netplay requires one session BIOS for all peers; it does "
+                    "not change your saved Settings preference.");
+            }
+            if (any_prefer_open && any_prefer_scph) {
+                ImGui::TextColored(col(th.warn),
+                    "Players disagree on BIOS preference — session settles to "
+                    "OpenBIOS so the match stays in sync.");
+            } else if (any_missing_offer) {
+                ImGui::TextColored(col(th.text_muted),
+                    "Waiting for every peer to advertise BIOS capability…");
+            }
+        }
     }
     ImGui::Spacing();
     {

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -2506,19 +2506,22 @@ void launcher_model_skip_msu1_patch(LauncherModel* m) {
     update_msu1_patch_available(m);
 }
 
-/* PSX Hybrid/Analog need sticks; keyboard players are forced to D-Pad. */
+/* PSX Hybrid/Analog need sticks; keyboard players are forced to D-Pad.
+ * Gamepads default to Analog — virtually every modern pad has sticks. */
 static int pad_mode_is_psx_legacy(const LauncherModel* m) {
     const SystemProfile* prof = (const SystemProfile*)m->profile;
     const ControllerSpec* spec = prof ? &prof->controller : NULL;
     return !(spec && spec->modes && spec->mode_count > 0);
 }
 
-static void force_digital_if_keyboard(LauncherModel* m, int player) {
+static void apply_default_pad_mode_for_source(LauncherModel* m, int player) {
     if (!m->pad_mode_supported || !m->pad_mode_selectable) return;
     player = clampi(player, 0, LNG_MAX_PLAYERS - 1);
-    if (m->s.player_src[player] != 1) return;
     if (!pad_mode_is_psx_legacy(m)) return;
-    m->s.pad_mode[player] = 2;   // D-Pad / digital
+    if (m->s.player_src[player] == 1)
+        m->s.pad_mode[player] = 2;   // D-Pad / digital (no sticks)
+    else if (m->s.player_src[player] == 2)
+        m->s.pad_mode[player] = 1;   // Analog / DualShock
 }
 
 void launcher_model_set_pad_mode(LauncherModel* m, int player, int mode) {
@@ -2558,7 +2561,7 @@ int launcher_model_active_button_count(const LauncherModel* m, int player) {
 void launcher_model_cycle_player_src(LauncherModel* m, int player) {
     player = clampi(player, 0, LNG_MAX_PLAYERS - 1);
     m->s.player_src[player] = (m->s.player_src[player] + 1) % 3;  // None/Kbd/Pad
-    force_digital_if_keyboard(m, player);
+    apply_default_pad_mode_for_source(m, player);
 }
 
 void launcher_model_deadzone_delta(LauncherModel* m, int player, int delta) {
@@ -2583,7 +2586,7 @@ void launcher_model_set_source(LauncherModel* m, int player, int kind,
         m->player_pad_name[player][0] = '\0';
         m->s.player_gamepad_guid[player][0] = '\0';
     }
-    force_digital_if_keyboard(m, player);
+    apply_default_pad_mode_for_source(m, player);
 }
 
 // ---- mouse controls --------------------------------------------------------

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -1580,6 +1580,16 @@ void launcher_model_bios_play_cancel(LauncherModel* m) {
     m->bios_play_modal_open = false;
 }
 
+bool launcher_model_setup_media_confirm_only(const LauncherModel* m) {
+    if (!m || !m->setup_wizard_supported) return false;
+    if (m->prepare_required_before_continue) return false;
+    /* Codegen hosts keep prepare_* wired after the first Generate & rebuild.
+     * Missing that wiring means a cart / non-codegen first-run — keep the
+     * normal media picker copy, not the "confirm cleared paths" prompt. */
+    if (!m->prepare_with_progress_cb && !m->prepare_disc_cb) return false;
+    return true;
+}
+
 bool launcher_model_can_finish_setup(const LauncherModel* m) {
     if (!m) return false;
     if (m->setup_preparing) return false;

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -753,6 +753,11 @@ void launcher_model_set_mouse_bind(LauncherModel* m, int which, int button_index
 void launcher_model_set_gyro_sensitivity(LauncherModel* m, float value);
 
 // ---- first-run setup wizard ----
+// True when the wizard should ask only for BIOS/disc confirmation: prepare
+// callbacks exist (codegen host) but prepare_required_before_continue is 0
+// because generated sources / a full build are already present. Cleared
+// disc.cfg / BIOS paths reopen the wizard without the Generate & rebuild page.
+bool launcher_model_setup_media_confirm_only(const LauncherModel* m);
 // True when required BIOS + ROM/disc paths are present (readable), and when
 // prepare_required_before_continue is set, prepare (+ chained rebuild) has
 // succeeded. Fingerprint mismatch is allowed here.

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -963,7 +963,10 @@ typedef struct RecompLauncherCGameInfo {
 
     /* When 1, the setup modal hides "Continue to launcher" and requires
      * prepare (and rebuild when rebuild_after_prepare is set). Local codegen
-     * first-run: Generate & rebuild, then relaunch — Quit is the only other exit. */
+     * first-run: Generate & rebuild, then relaunch — Quit is the only other exit.
+     * When 0 but prepare_* is still wired (sources already generated), the
+     * wizard opens only for a cleared BIOS/disc pick and shows a media-confirm
+     * prompt instead of the full Generate & rebuild first-run page. */
     int prepare_required_before_continue;
 
     /* ---- portable toolchain step (appended; local codegen hosts) ----------

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -82,6 +82,10 @@ typedef struct RecompLauncherCNetplayMember {
     int  latency_ms;
     /* 1 when this row is the local client's seat (never show self-RTT). */
     int  is_local;
+    /* Peer BIOS offer from set_ready (0 if legacy / missing). */
+    int  bios_offer_valid;
+    int  bios_can_scph1001;
+    int  bios_prefer_openbios;
 } RecompLauncherCNetplayMember;
 
 typedef struct RecompLauncherCNetplayLaunch {
@@ -210,6 +214,8 @@ typedef struct RecompLauncherCNetplayCallbacks {
      * match_caps.multitap_analog; peers apply at match start. */
     int  (*multitap_analog_get)(void* ctx);
     int  (*multitap_analog_set)(void* ctx, int enable);
+    /* Optional: 1 while lobby DNS/TCP/WS upgrade runs off-thread. */
+    int  (*connecting)(void* ctx);
 } RecompLauncherCNetplayCallbacks;
 
 /* ---- schema-driven mods --------------------------------------------------


### PR DESCRIPTION
## Summary
- Lobby UX: always recenter the room modal as members join/leave; show session BIOS settle copy (OpenBIOS vs SCPH1001) with peer hover tooltips; only warn orange when someone lacks SCPH.
- Netplay connect: optional `connecting` callback so Host/Join doesn’t re-fire while DNS/TCP/WS is in flight; keep “Connecting…” status, clear it when online, and surface a reachability error if the attempt ends without a connection. Netplay entry from Dashboard/Settings/Controller opens the page immediately instead of blocking the UI thread.
- Setup wizard: when codegen prepare is wired but `prepare_required_before_continue` is already clear (sources present), reopen only as a media-confirm flow for cleared BIOS/disc picks — not the full Generate & rebuild first-run page.
- Controllers: gamepad sources default to Analog/DualShock; keyboard still forced to D-Pad.

## Test plan
- [ ] Open Host Lobby / Join with lobby server up — status shows Connecting then clears; no duplicate connect spam
- [ ] Kill/block lobby server — status becomes “Could not reach lobby server”
- [ ] Room modal stays centered as peers join/leave; BIOS notice + hover match settle rules
- [ ] Clear disc/BIOS on an already-built codegen title — wizard asks to confirm media only (no Generate & rebuild page)
- [ ] Cycle player source Kbd ↔ Pad — pad mode becomes D-Pad vs Analog as expected