### PR TITLE
launcher: hide disabled internal mod features

### DIFF
--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -5913,6 +5913,7 @@ void draw_netplay_room_modal(LauncherModel* m, const LauncherTheme& th) {
             for (int i = 0; i < feature_count; ++i) {
                 RecompLauncherCModFeature f{};
                 if (!mods->feature_get(mods->ctx, i, &f)) continue;
+                if (f.hidden && !f.enabled) continue;
                 ++shown;
                 ImGui::PushID(f.package_id);
                 ImGui::PushID(f.id);
@@ -7014,6 +7015,7 @@ static void draw_mod_features(LauncherModel* m, const LauncherTheme& th) {
         ModFeatureListItem item{};
         item.index = index;
         if (!mods->feature_get(mods->ctx, index, &item.feature) ||
+            (item.feature.hidden && !item.feature.enabled) ||
             !mod_feature_text_matches(m->mod_search, item.feature)) {
             continue;
         }

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -382,6 +382,10 @@ typedef struct RecompLauncherCModFeature {
      * conditionally presents camera bindings and the Mods detail links there.
      * Appended for ABI stability; zero keeps every existing feature unchanged. */
     int  camera_controls;
+    /* Hidden features are omitted from normal picker lists while disabled.
+     * Providers still expose them so an explicitly-enabled hidden feature can
+     * be shown and turned off again. */
+    int  hidden;
 } RecompLauncherCModFeature;
 
 typedef struct RecompLauncherCModOption {


### PR DESCRIPTION
Adds a hidden flag to mod features at the launcher ABI level and filters disabled hidden features from normal mod picker lists. Enabled hidden features remain visible so they can be turned off again.