### PR TITLE
launcher: add a Rewind on/off toggle to the Display card

### DIFF
--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -2645,12 +2645,26 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     }
 
     if (m->has_rewind_depth) {
+        row_label("Rewind", th);
+        bool rewind_on = m->s.rewind_enabled != 0;
+        if (ImGui::Checkbox("##rewind_enabled", &rewind_on))
+            launcher_model_toggle_rewind_enabled(m);
+        if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
+            ImGui::SetTooltip(
+                "Rewind the last few seconds of play (F8, or Select+R3).\n"
+                "Off by default: it keeps whole-machine snapshots in memory,\n"
+                "which costs hundreds of MB and a capture every few frames.\n"
+                "Turning it off frees that immediately.");
+        }
+        /* The two tuning rows only mean anything once it is on. */
+        ImGui::BeginDisabled(!rewind_on);
         row_label("Rewind buffer", th);
         if (ImGui::Button(launcher_model_rewind_depth_label(m), ImVec2(px(100), px(30))))
             launcher_model_cycle_rewind_depth(m);
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
             ImGui::SetTooltip(
                 "How many local rewind snapshots to keep (50 / 100 / 150 / 200).\n"
+                "Each one is a few MB of machine state.\n"
                 "Takes effect on the next launch.");
         }
         row_label("Rewind interval", th);
@@ -2662,6 +2676,7 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
                 "FMV still densifies toward 4 when this is sparser.\n"
                 "Takes effect on the next launch.");
         }
+        ImGui::EndDisabled();
     }
 
     /* Turbo loads is deliberately NOT a Display row on any console. Load

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -1319,6 +1319,11 @@ void launcher_model_toggle_spu_hq(LauncherModel* m) {
     m->s.spu_hq = !m->s.spu_hq;
 }
 
+void launcher_model_toggle_rewind_enabled(LauncherModel* m) {
+    if (!m || !m->has_rewind_depth) return;
+    m->s.rewind_enabled = !m->s.rewind_enabled;
+}
+
 void launcher_model_cycle_rewind_depth(LauncherModel* m) {
     if (!m || !m->has_rewind_depth) return;
     static const int opts[4] = {50, 100, 150, 200};

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -659,6 +659,9 @@ void launcher_model_toggle_frame_interp(LauncherModel* m);
 void launcher_model_cycle_interp_fps(LauncherModel* m);        // {0,90,120,144,165,240} wrap
 const char* launcher_model_interp_fps_label(const LauncherModel* m);  // "Display refresh"/"90 fps"
 void launcher_model_toggle_spu_hq(LauncherModel* m);
+// Local rewind on/off. Off by default: the ring holds whole-machine snapshots
+// on a frame cadence, so it is opt-in rather than a cost every host pays.
+void launcher_model_toggle_rewind_enabled(LauncherModel* m);
 void launcher_model_cycle_rewind_depth(LauncherModel* m);
 const char* launcher_model_rewind_depth_label(const LauncherModel* m);
 void launcher_model_cycle_rewind_interval(LauncherModel* m);

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -43,6 +43,8 @@ extern "C" {
 #define RECOMP_LAUNCHER_HAS_REWIND_DEPTH 1
 /* Host may #ifdef this when reading Settings.rewind_interval. */
 #define RECOMP_LAUNCHER_HAS_REWIND_INTERVAL 1
+/* Host may #ifdef this when reading Settings.rewind_enabled. */
+#define RECOMP_LAUNCHER_HAS_REWIND_ENABLED 1
 /* Host may #ifdef this when reading Settings.vsync. */
 #define RECOMP_LAUNCHER_HAS_VSYNC 1
 #define RECOMP_LAUNCHER_MAX_BINDINGS 24
@@ -757,6 +759,15 @@ struct RecompLauncherCSettings {
     char rom_patch_source_path[512];
     char rom_patch_sha1[41];
     char rom_patch_crc32[9];
+
+    /* Local rewind on/off (GameInfo.has_rewind_depth consoles).
+     *   0 = off, 1 = on.
+     * Stored plainly rather than 1-based like vsync, because here "unset" and
+     * "off" are the same answer: the host default is off, so a zero-initialized
+     * host predating this field gets the default it would have picked anyway.
+     * The ring holds whole-machine snapshots on a frame cadence, which is why
+     * it is opt-in. Appended additively. */
+    int  rewind_enabled;
 };
 
 /* Values for RecompLauncherCSettings.vsync (1-based; 0 = unset). */


### PR DESCRIPTION
Rewind has had tuning controls (buffer size, interval) but no way to turn it off. The runtime enabled it unless `PSX_REWIND=0` was set in the environment, which is not a switch a player can reach.

This adds the missing enable as a checkbox above the two tuning rows. Those rows are now disabled while it is off, since they describe a ring that does not exist yet.

## ABI

`Settings.rewind_enabled` is appended with the usual additive convention, plus `RECOMP_LAUNCHER_HAS_REWIND_ENABLED` for hosts that want to `#ifdef`.

It is stored plainly as `0`/`1` rather than 1-based like `vsync`. `vsync` needed the offset because `0` was a meaningful value there ("off") that a zero-initialized host could not distinguish from "no opinion". Here "unset" and "off" are the same answer — the host default is off — so a zero-initialized host predating the field lands on the default it would have chosen anyway.

## Why the tooltip says what it costs

That is the part a player cannot see: the ring holds whole-machine snapshots (2 MB main RAM + 1 MB VRAM + 512 KB SPU RAM each, uncompressed), a few hundred MB resident at the default depth, plus a capture every few frames.

## Pairs with

psxrecomp `feat/rewind-default-off`, which flips the runtime default to off and reads the new field. That branch needs this one to compile.

## Verification

Built standalone against SDL2; all 7 ctest tests pass. Rebased onto `a3cc33a` (gamepad nav) and re-verified.

Not visually confirmed — the launcher needs a display and a game to render against, so the checkbox has not been seen on screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AwqKPQFnK3x7xQbK4PQKj