### PR TITLE
launcher: multi-disc selection, app icon, and pad-art feedback

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,6 +135,24 @@ if(BUILD_TESTING)
         COMMAND $<TARGET_FILE:recomp-ui-psx-binds-test>
                 "${CMAKE_CURRENT_BINARY_DIR}/psx-binds-test.ini")
 
+    # Multi-disc roster: sibling autofill + per-slot binding. Includes
+    # launcher_model.c (not links it) to reach the static path rewriter, so the
+    # model's own deps are compiled in alongside.
+    add_executable(recomp-ui-launcher-discs-test
+        tests/launcher_discs_test.c
+        src/common/crc32.c
+        src/common/sha1.c
+        src/common/sha256.c
+        src/common/ips_patch.c
+        src/consoles/psx/memcard_format.c)
+    target_include_directories(recomp-ui-launcher-discs-test PRIVATE
+        src src/common src/consoles/psx)
+    target_link_libraries(recomp-ui-launcher-discs-test PRIVATE ${RUI_SDL_TARGET})
+    add_test(
+        NAME recomp-ui-launcher-discs
+        COMMAND $<TARGET_FILE:recomp-ui-launcher-discs-test>
+                "${CMAKE_CURRENT_BINARY_DIR}")
+
     add_executable(recomp-ui-psx-profile-test
         tests/psx_profile_test.c)
     target_include_directories(recomp-ui-psx-profile-test PRIVATE

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -2079,15 +2079,31 @@ void draw_player_panel(LauncherModel* m, const LauncherTheme& th, int p, float w
     {
         const SystemProfile* aprof = (const SystemProfile*)m->profile;
         const bool has_swap_art = aprof && aprof->controller.image_analog != nullptr;
-        // Show the digital pad ONLY for a game LOCKED to D-Pad mode. pad_mode
-        // selects which controller PROTOCOL the game is given, not which
-        // hardware the player is holding: on a title that offers analog at all,
-        // the player has an analog-capable pad in hand, and picking D-Pad mode
-        // does not turn their DualShock into a 1994 digital controller. Keying
-        // the art off the mode made Ape Escape — a dual-analog game — show the
-        // original PSX pad whenever the saved mode happened to be digital.
-        const bool digital_only = !m->pad_mode_selectable && m->locked_pad_mode == 2;
-        const bool digital = has_swap_art && digital_only;
+        // The art follows the SELECTED mode. The Analog / D-Pad pair right
+        // below this image is a two-state control with no other feedback, so
+        // the pad picture is the answer to "which did I just pick?" — leaving
+        // it on the DualShock while D-Pad is lit reads as a broken control.
+        //
+        // This deliberately replaces the earlier rule (art keyed only to a
+        // game LOCKED to D-Pad, on the reasoning that mode picks a PROTOCOL
+        // and the player is still physically holding a DualShock). Owner
+        // decision: the selector's feedback value wins.
+        //
+        // s.pad_mode already carries the locked value for a non-selectable
+        // title (launcher_model_init), so a locked D-Pad game keeps exactly
+        // the art it showed before. Mode 2 is D-Pad; 1 Analog, 0 Hybrid — both
+        // of those are stick-bearing pads and keep the analog image. A console
+        // with its own mode vocabulary (Genesis 3/6-Button) never reaches here:
+        // it ships a single pad image, so has_swap_art is false.
+        //
+        // Keyboard is digital at runtime whatever the stored mode says (the
+        // Analog segment is greyed out for it), so it shows the digital pad
+        // rather than promising sticks the player does not have.
+        const bool kb_digital =
+            m->s.player_src[p] == 1 &&
+            !(aprof && aprof->controller.modes && aprof->controller.mode_count > 0);
+        const bool digital =
+            has_swap_art && (kb_digital || m->s.pad_mode[p] == 2);
         const LauncherTexture& art = has_swap_art
             ? (digital ? g_pad_digital : g_pad_analog) : g_pad;
         // Center on the FITTED width so a near-square pad (N64) or a portrait

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -1020,6 +1020,31 @@ const LauncherTexture& verdict_texture(int verdict) {
     }
 }
 
+// Disc Selection dropdown for a multi-image title (GameInfo.discs). Draws
+// nothing at all for a single-image game, so every existing launcher keeps
+// its current layout. Selecting a row remounts that disc: the model re-runs
+// the disc verdict against it and records the choice in Settings.disc_index,
+// which the host persists like any other setting.
+void draw_disc_selector(LauncherModel* m, const LauncherTheme& th, float availw) {
+    const int count = launcher_model_disc_count(m);
+    if (count <= 1) return;
+    const int sel = launcher_model_disc_selected(m);
+
+    ImGui::TextColored(col(th.text_muted), "Disc Selection");
+    ImGui::Dummy(ImVec2(0, px(4)));
+    ImGui::SetNextItemWidth(availw);
+    if (ImGui::BeginCombo("##disc_selection",
+                          sel >= 0 ? launcher_model_disc_label(m, sel) : "")) {
+        for (int i = 0; i < count; ++i) {
+            if (ImGui::Selectable(launcher_model_disc_label(m, i), i == sel))
+                launcher_model_select_disc(m, i);
+            if (i == sel) ImGui::SetItemDefaultFocus();
+        }
+        ImGui::EndCombo();
+    }
+    ImGui::Dummy(ImVec2(0, px(10)));
+}
+
 // Disc-verdict block (verify.mode==1 systems, e.g. PSX): a verdict icon +
 // headline, followed by a Serial/Region/ISO-header checklist. Replaces the
 // CRC/SHA "verified" line that mode==0 (cart/ROM-hash) systems draw instead
@@ -1027,7 +1052,7 @@ const LauncherTexture& verdict_texture(int verdict) {
 // m->verify, populated by launcher_model_set_rom()/run_verify() in
 // launcher_model.c (real probe when the SystemProfile has one, a synthesized
 // placeholder verdict otherwise).
-void draw_verdict_block(const LauncherModel* m, const LauncherTheme& th, float availw) {
+void draw_verdict_block(LauncherModel* m, const LauncherTheme& th, float availw) {
     const VerifyResult& v = m->verify;
     // Keep the Serial/Region/ISO checklist mounted even before a disc is
     // picked (setup wizard) so AutoResize modals don't jump when verify runs.
@@ -1064,6 +1089,13 @@ void draw_verdict_block(const LauncherModel* m, const LauncherTheme& th, float a
     ImGui::SameLine(0, px(6));
     ImGui::TextColored(col(headline_color), "%s", headline);
     ImGui::Dummy(ImVec2(0, px(8)));
+
+    // Disc Selection: which image of a multi-disc set Play boots. It sits
+    // ABOVE the identity checklist on purpose — Serial / Region / ISO header
+    // describe the SELECTED disc (each disc of a set carries its own serial),
+    // so the control that decides which disc that is has to read first.
+    // Single-disc titles never compose this.
+    draw_disc_selector(m, th, availw);
 
     // Checklist: Serial / Region / ISO header. Before a disc is chosen, show
     // em-dashes with no pass/fail marks so the layout still reserves the rows.
@@ -1119,6 +1151,8 @@ void draw_game_panel(LauncherModel* m, const LauncherTheme& th, bool fill_h = fa
         // + Change ROM, plus the SAVES block when this game has battery SRAM.
         float reserve = px(198.0f);
         if (disc_verdict) reserve += px(120.0f);          // taller: icon+headline + tracks row
+        // Disc Selection label + combo + spacing, for a multi-image title.
+        if (launcher_model_disc_count(m) > 1) reserve += px(62.0f);
         if (m->saves_supported) reserve += px(96.0f);    // compact SAVES row below Change ROM
         if (m->password_save_path) reserve += px(96.0f); // password-save row (same footprint)
         if (m->msu1_patch_available) reserve += px(198.0f);  // MSU-1 patch-available sub-block
@@ -1164,8 +1198,22 @@ void draw_game_panel(LauncherModel* m, const LauncherTheme& th, bool fill_h = fa
         ImGui::EndTable();
     }
     ImGui::Dummy(ImVec2(0, px(12)));
-    char change_label[32];
-    snprintf(change_label, sizeof(change_label), "Change %s", noun);
+    // "Browse For Disc 2", not "Change Disc": on a multi-disc set the button
+    // does not swap which disc the game is on — the Disc Selection dropdown
+    // above does that — it re-points the SELECTED disc at a file on this
+    // machine. Naming the disc number is what keeps those two apart. A
+    // single-image title has nothing to number, so it reads "Browse For Disc"
+    // ("Browse For ROM" on cartridge consoles, from the profile's rom_noun).
+    const int disc_no = launcher_model_disc_count(m) > 1
+                            ? launcher_model_disc_number(
+                                  m, launcher_model_disc_selected(m))
+                            : 0;
+    char change_label[48];
+    if (disc_no > 0)
+        snprintf(change_label, sizeof(change_label), "Browse For %s %d", noun,
+                 disc_no);
+    else
+        snprintf(change_label, sizeof(change_label), "Browse For %s", noun);
     if (ImGui::Button(change_label, ImVec2(availw, px(34)))) {
         // Native file dialog filter comes from the active console's
         // SystemProfile.rom_filter — never a hardcoded per-system set. Every
@@ -1174,8 +1222,11 @@ void draw_game_panel(LauncherModel* m, const LauncherTheme& th, bool fill_h = fa
         // forgets rom_filter degrades to "any file" rather than prompting for
         // some other machine's media.
         const SystemProfile* prof = (const SystemProfile*)m->profile;
-        char title[48];
-        snprintf(title, sizeof(title), "Select %s", noun);
+        char title[64];
+        if (disc_no > 0)
+            snprintf(title, sizeof(title), "Select %s %d", noun, disc_no);
+        else
+            snprintf(title, sizeof(title), "Select %s", noun);
         if (prof && prof->rom_filter.patterns && prof->rom_filter.pattern_count > 0)
             request_rom_picker(m, title, prof->rom_filter.patterns,
                                prof->rom_filter.pattern_count,

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -196,7 +196,14 @@ static bool s_pad_nav_armed = false;
 
 char        g_pick_buf[512] = {};    // ROM picker result
 
-enum class BuiltinPickerKind { Rom, Bios, SetupToolchainZip };
+enum class BuiltinPickerKind { Rom, Bios, SetupToolchainZip, DiscSlot };
+
+/* Which disc row a DiscSlot browse is filling. Deliberately NOT a field of
+ * BuiltinRomPicker: open_builtin_file_picker default-constructs that struct,
+ * so anything stored there before the call is erased on the built-in-browser
+ * path while surviving on the native-dialog path -- a difference that would
+ * show up only on machines without a portal. */
+static int g_disc_slot_target = -1;
 
 struct BuiltinRomPicker {
     bool active = false;
@@ -318,6 +325,10 @@ static void apply_builtin_picker_selection(LauncherModel* m, const char* path) {
     } else if (g_rom_picker.kind == BuiltinPickerKind::SetupToolchainZip) {
         std::snprintf(m->setup_tc_zip, sizeof(m->setup_tc_zip), "%s", path);
         m->setup_error[0] = '\0';
+    } else if (g_rom_picker.kind == BuiltinPickerKind::DiscSlot) {
+        if (g_disc_slot_target >= 0)
+            launcher_model_set_disc_path(m, g_disc_slot_target, path);
+        g_disc_slot_target = -1;
     } else {
         launcher_model_set_rom(m, path);
     }
@@ -348,6 +359,18 @@ static void request_rom_picker(LauncherModel* m, const char* title,
                                const char* const* patterns, int pattern_count,
                                const char* description, bool from_setup) {
     request_file_picker(m, BuiltinPickerKind::Rom, title, patterns,
+                        pattern_count, description, from_setup);
+}
+
+/* Browse for ONE disc of a set. Binding is by slot, so filling in disc 3 does
+ * not change which disc is mounted (launcher_model_set_disc_path). */
+static void request_disc_slot_picker(LauncherModel* m, int slot,
+                                     const char* title,
+                                     const char* const* patterns,
+                                     int pattern_count, const char* description,
+                                     bool from_setup) {
+    g_disc_slot_target = slot;
+    request_file_picker(m, BuiltinPickerKind::DiscSlot, title, patterns,
                         pattern_count, description, from_setup);
 }
 
@@ -7796,6 +7819,140 @@ static void draw_setup_progress_modal(LauncherModel* m, const LauncherTheme& th)
         ImGui::OpenPopup(kProgPopup);
 }
 
+/* A hover "?" that parks a long explanation off-screen until asked for.
+ * The wizard's disc note is the tallest block on the page and is read once,
+ * on a first run; the disc rows underneath it are read every time. */
+static void setup_help_marker(const LauncherTheme& th, const char* text) {
+    ImGui::TextColored(col(th.text_muted), "(?)");
+    if (ImGui::IsItemHovered()) {
+        ImGui::BeginTooltip();
+        ImGui::PushTextWrapPos(ImGui::GetFontSize() * 32.0f);
+        ImGui::TextUnformatted(text);
+        ImGui::PopTextWrapPos();
+        ImGui::EndTooltip();
+    }
+}
+
+/* Multi-disc media section: one row per disc of the set, inside a single
+ * bordered frame.
+ *
+ * The wizard previously asked for one image, because persist_setup carried one
+ * path -- so a 3-disc set left the player to discover in the middle of disc 1's
+ * ending that discs 2 and 3 were never recorded. Asking for all of them up
+ * front is the fix; asking for them as three copies of the old full-height
+ * block is not, because the wizard is a fixed-height modal and three of those
+ * do not fit.
+ *
+ * So: the explanation collapses to a (?), the verdict block is drawn once for
+ * the set rather than once per disc, and each disc costs exactly one frame-high
+ * row. A 3-disc set is shorter here than the single-disc layout it replaces.
+ *
+ * Only disc 1 gates progress. Generate runs off the boot image, and discs 2..N
+ * matter later, at swap time -- blocking the wizard on all of them would strand
+ * a player who has disc 1 to hand and the rest in a drawer. */
+static void draw_setup_disc_frame(LauncherModel* m, const LauncherTheme& th,
+                                  const char* noun, const char* const* patterns,
+                                  int pattern_count, const char* pattern_desc,
+                                  const char* long_note) {
+    const int count = launcher_model_disc_count(m);
+    const int ready = launcher_model_discs_ready_count(m);
+    const int sel = launcher_model_disc_selected(m);
+
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextColored(col(th.text_muted),
+                       "This release was built from a %d-disc set.", count);
+    ImGui::SameLine();
+    setup_help_marker(th, long_note);
+    ImGui::SameLine();
+    {
+        char counter[48];
+        std::snprintf(counter, sizeof(counter), "%d of %d located", ready, count);
+        const float w = ImGui::CalcTextSize(counter).x;
+        const float avail = ImGui::GetContentRegionAvail().x;
+        if (avail > w) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + avail - w);
+        ImGui::TextColored(col(ready >= count ? th.good : th.warn), "%s", counter);
+    }
+
+    const float row_h = ImGui::GetFrameHeight() + px(6);
+    ImGui::BeginChild("##setup_discs", ImVec2(0, row_h * (float)count + px(10)),
+                      true);
+    for (int i = 0; i < count; ++i) {
+        const bool ok = launcher_model_disc_ready(m, i);
+        const bool required = (i == 0);
+        ImGui::PushID(i);
+
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextColored(col(ok ? th.good : (required ? th.warn : th.text_muted)),
+                           "%s", ok ? "OK" : (required ? "Needed" : "--"));
+        ImGui::SameLine(px(64));
+
+        ImGui::AlignTextToFramePadding();
+        ImGui::TextColored(col(th.text), "%s", launcher_model_disc_label(m, i));
+        ImGui::SameLine(px(140));
+
+        const char* dp = launcher_model_disc_path(m, i);
+        char elided[220];
+        ImGui::AlignTextToFramePadding();
+        if (dp && dp[0]) {
+            elide_left(dp, px(330), elided, sizeof(elided));
+            ImGui::TextColored(col(ok ? th.text : th.warn), "%s", elided);
+            if (ImGui::IsItemHovered()) ImGui::SetTooltip("%s", dp);
+        } else {
+            ImGui::TextColored(col(th.text_muted), "%s",
+                               required ? "(none selected)"
+                                        : "(optional -- needed to swap discs)");
+        }
+
+        ImGui::SameLine();
+        {
+            const float avail = ImGui::GetContentRegionAvail().x;
+            const float bw = px(96);
+            if (avail > bw) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + avail - bw);
+            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(px(10), px(4)));
+            if (ImGui::Button("Browse", ImVec2(bw, 0))) {
+                char title[96];
+                std::snprintf(title, sizeof(title), "Select %s (.cue/.bin/.car)",
+                              launcher_model_disc_label(m, i));
+                request_disc_slot_picker(m, i, title, patterns, pattern_count,
+                                         pattern_desc, true);
+            }
+            ImGui::PopStyleVar();
+        }
+        ImGui::PopID();
+    }
+    ImGui::EndChild();
+
+    /* Sets are usually stored with the disc number in the path, so one browse
+     * is normally enough. Offered rather than automatic: it binds paths the
+     * player did not choose, and a wrong guess that appears without being
+     * asked for is worse than a button that was not pressed. */
+    const bool can_autofill = ready > 0 && ready < count;
+    ImGui::BeginDisabled(!can_autofill);
+    if (ImGui::Button("Find other discs", ImVec2(px(150), px(28)))) {
+        const int filled = launcher_model_autofill_sibling_discs(m);
+        std::snprintf(m->setup_status, sizeof(m->setup_status),
+                      filled > 0 ? "Located %d more disc image(s)."
+                                 : "No sibling disc images found next to the "
+                                   "one you picked -- browse for them.",
+                      filled);
+    }
+    ImGui::EndDisabled();
+    if (ImGui::IsItemHovered() && !can_autofill && ready == 0)
+        ImGui::SetTooltip("Pick one disc first, then this looks for the rest.");
+    ImGui::SameLine();
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextColored(col(th.text_muted),
+                       "Only %s is required now; the rest can wait.",
+                       launcher_model_disc_label(m, 0));
+
+    /* Verdict describes the MOUNTED disc, so it is drawn once for the set, not
+     * once per row -- and it already carries the Disc Selection dropdown that
+     * says which disc that is. */
+    if (sel >= 0 && m->profile && m->profile->verify.mode == 1)
+        draw_verdict_block(m, th, ImGui::GetContentRegionAvail().x);
+    (void)noun;
+}
+
 void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
     if (!m->setup_wizard_supported) return;
     if (!m->setup_wizard_open && !m->setup_preparing) return;
@@ -8104,9 +8261,33 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
         ImGui::Dummy(ImVec2(0, px(12)));
     }
 
-    ImGui::Text("%s. %s image", m->has_bios ? "2" : "1", noun);
+    /* A multi-disc set asks for every image, in one compact frame, and parks the
+     * long note behind a (?). See draw_setup_disc_frame. */
+    const bool multi_disc = launcher_model_disc_count(m) > 1;
+    static const char* kPsxDiscNote =
+        "psxrecomp games require a .cue + .bin dump of the disc, or an "
+        "official re-release image (.car, e.g. from the Steam Special "
+        "Edition).\n\n"
+        "A single-track .bin or .iso cannot be converted to multitrack. "
+        "Redump-style dumps are the usual source; you can make your own from "
+        "the original disc with redumper "
+        "(https://github.com/superg/redumper).\n\n"
+        "Always point Generate at the .cue when one exists.";
+
+    if (multi_disc)
+        ImGui::Text("%s. %s images", m->has_bios ? "2" : "1", noun);
+    else
+        ImGui::Text("%s. %s image", m->has_bios ? "2" : "1", noun);
     ImGui::PushTextWrapPos(wrap_x);
-    if (plat == SETUP_PLAT_PSX) {
+    if (multi_disc) {
+        ImGui::PopTextWrapPos();
+        static const char* kDiscPatterns[] = {"*.cue", "*.bin", "*.img",
+                                              "*.iso", "*.car"};
+        draw_setup_disc_frame(m, th, noun, kDiscPatterns, 5,
+                              "Disc image (.cue .bin .img .iso .car)",
+                              kPsxDiscNote);
+        ImGui::PushTextWrapPos(wrap_x);
+    } else if (plat == SETUP_PLAT_PSX) {
         /* Keep the note as one wrapped TextColored block — SameLine +
          * TextLinkOpenURL after a wrapped line leaves a huge empty gap in
          * BeginPopupModal (Windows first-run wizard regression). */
@@ -8132,7 +8313,7 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
         ImGui::TextColored(col(th.text_muted), "%s", media_help);
     }
     ImGui::PopTextWrapPos();
-    {
+    if (!multi_disc) {
         const char* rp = m->rom_present ? m->rom_full : "(none selected)";
         char relided[220];
         elide_left(rp, px(360), relided, sizeof(relided));

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -7850,82 +7850,102 @@ static void setup_help_marker(const LauncherTheme& th, const char* text) {
  * Only disc 1 gates progress. Generate runs off the boot image, and discs 2..N
  * matter later, at swap time -- blocking the wizard on all of them would strand
  * a player who has disc 1 to hand and the rest in a drawer. */
+/* Multi-disc media section: one row per disc of the set, in one bordered frame.
+ *
+ * The wizard previously asked for one image, because persist_setup carried one
+ * path -- so a 3-disc set left the player to discover mid-game that discs 2 and
+ * 3 were never recorded. Asking for all of them is the fix; asking as N copies
+ * of the old full-height block is not, because the wizard is a fixed-height
+ * modal.
+ *
+ * A row is: "Disc N", the file, and Browse. There is deliberately no status
+ * column -- the path IS the status (a located disc shows its file, an unlocated
+ * one shows the greyed name to look for), and a separate OK/Needed column both
+ * repeated that and cost the width the path needed.
+ *
+ * Every disc is required. Building one disc at a time is not supported, so a
+ * partially located set cannot produce a working install and the wizard should
+ * not let one through.
+ */
 static void draw_setup_disc_frame(LauncherModel* m, const LauncherTheme& th,
-                                  const char* noun, const char* const* patterns,
+                                  const char* const* patterns,
                                   int pattern_count, const char* pattern_desc,
                                   const char* long_note) {
     const int count = launcher_model_disc_count(m);
     const int ready = launcher_model_discs_ready_count(m);
-    const int sel = launcher_model_disc_selected(m);
 
     ImGui::AlignTextToFramePadding();
-    ImGui::TextColored(col(th.text_muted),
-                       "This release was built from a %d-disc set.", count);
+    ImGui::TextColored(col(ready >= count ? th.good : th.warn),
+                       "%d of %d located", ready, count);
+    ImGui::SameLine();
+    ImGui::TextColored(col(th.text_muted), "- all discs are required.");
     ImGui::SameLine();
     setup_help_marker(th, long_note);
-    ImGui::SameLine();
-    {
-        char counter[48];
-        std::snprintf(counter, sizeof(counter), "%d of %d located", ready, count);
-        const float w = ImGui::CalcTextSize(counter).x;
-        const float avail = ImGui::GetContentRegionAvail().x;
-        if (avail > w) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + avail - w);
-        ImGui::TextColored(col(ready >= count ? th.good : th.warn), "%s", counter);
-    }
 
-    const float row_h = ImGui::GetFrameHeight() + px(6);
-    ImGui::BeginChild("##setup_discs", ImVec2(0, row_h * (float)count + px(10)),
-                      true);
+    /* Size the frame to hold every row. Getting this wrong scrolls the last
+     * disc out of sight, which on a 3-disc set hides a required field. */
+    const float row_h = ImGui::GetFrameHeightWithSpacing();
+    const float pad = ImGui::GetStyle().WindowPadding.y * 2.0f;
+    ImGui::BeginChild("##setup_discs", ImVec2(0, row_h * (float)count + pad),
+                      true, ImGuiWindowFlags_NoScrollbar);
+    const float btn_w = px(88);
     for (int i = 0; i < count; ++i) {
         const bool ok = launcher_model_disc_ready(m, i);
-        const bool required = (i == 0);
+        const char* dp = launcher_model_disc_path(m, i);
         ImGui::PushID(i);
 
         ImGui::AlignTextToFramePadding();
-        ImGui::TextColored(col(ok ? th.good : (required ? th.warn : th.text_muted)),
-                           "%s", ok ? "OK" : (required ? "Needed" : "--"));
-        ImGui::SameLine(px(64));
-
-        ImGui::AlignTextToFramePadding();
         ImGui::TextColored(col(th.text), "%s", launcher_model_disc_label(m, i));
-        ImGui::SameLine(px(140));
+        ImGui::SameLine(px(72));
 
-        const char* dp = launcher_model_disc_path(m, i);
-        char elided[220];
+        /* Reserve the button's column first so a long path is elided into the
+         * space that is actually left, instead of running under the button. */
+        const float row_w = ImGui::GetContentRegionAvail().x;
+        const float text_w = row_w - btn_w - px(12);
+
+        char elided[260];
         ImGui::AlignTextToFramePadding();
-        if (dp && dp[0]) {
-            elide_left(dp, px(330), elided, sizeof(elided));
-            ImGui::TextColored(col(ok ? th.text : th.warn), "%s", elided);
+        if (ok) {
+            elide_left(dp, text_w, elided, sizeof(elided));
+            ImGui::TextColored(col(th.text), "%s", elided);
             if (ImGui::IsItemHovered()) ImGui::SetTooltip("%s", dp);
         } else {
-            ImGui::TextColored(col(th.text_muted), "%s",
-                               required ? "(none selected)"
-                                        : "(optional -- needed to swap discs)");
+            /* Not located: show the file NAME the project was built from. It
+             * is the one useful hint we have -- the player is looking for their
+             * own copy of that image, and the developer's absolute path is
+             * meaningless on their machine while the file name is not. */
+            const char* hint = launcher_model_disc_suggested_name(m, i);
+            if (hint && hint[0]) {
+                elide_left(hint, text_w, elided, sizeof(elided));
+                ImGui::TextColored(col(th.text_muted), "%s", elided);
+                if (ImGui::IsItemHovered())
+                    ImGui::SetTooltip("Look for a file named:\n%s", hint);
+            } else {
+                ImGui::TextColored(col(th.text_muted), "(not selected)");
+            }
         }
 
         ImGui::SameLine();
         {
             const float avail = ImGui::GetContentRegionAvail().x;
-            const float bw = px(96);
-            if (avail > bw) ImGui::SetCursorPosX(ImGui::GetCursorPosX() + avail - bw);
-            ImGui::PushStyleVar(ImGuiStyleVar_FramePadding, ImVec2(px(10), px(4)));
-            if (ImGui::Button("Browse", ImVec2(bw, 0))) {
+            if (avail > btn_w)
+                ImGui::SetCursorPosX(ImGui::GetCursorPosX() + avail - btn_w);
+            if (ImGui::Button("Browse", ImVec2(btn_w, 0))) {
                 char title[96];
                 std::snprintf(title, sizeof(title), "Select %s (.cue/.bin/.car)",
                               launcher_model_disc_label(m, i));
                 request_disc_slot_picker(m, i, title, patterns, pattern_count,
                                          pattern_desc, true);
             }
-            ImGui::PopStyleVar();
         }
         ImGui::PopID();
     }
     ImGui::EndChild();
 
-    /* Sets are usually stored with the disc number in the path, so one browse
-     * is normally enough. Offered rather than automatic: it binds paths the
-     * player did not choose, and a wrong guess that appears without being
-     * asked for is worse than a button that was not pressed. */
+    /* Sets almost always carry the disc number in the path, so one browse is
+     * normally enough. Offered rather than automatic: it binds paths the player
+     * did not choose, and a wrong guess that appears unasked-for is worse than
+     * a button that was not pressed. */
     const bool can_autofill = ready > 0 && ready < count;
     ImGui::BeginDisabled(!can_autofill);
     if (ImGui::Button("Find other discs", ImVec2(px(150), px(28)))) {
@@ -7939,18 +7959,6 @@ static void draw_setup_disc_frame(LauncherModel* m, const LauncherTheme& th,
     ImGui::EndDisabled();
     if (ImGui::IsItemHovered() && !can_autofill && ready == 0)
         ImGui::SetTooltip("Pick one disc first, then this looks for the rest.");
-    ImGui::SameLine();
-    ImGui::AlignTextToFramePadding();
-    ImGui::TextColored(col(th.text_muted),
-                       "Only %s is required now; the rest can wait.",
-                       launcher_model_disc_label(m, 0));
-
-    /* Verdict describes the MOUNTED disc, so it is drawn once for the set, not
-     * once per row -- and it already carries the Disc Selection dropdown that
-     * says which disc that is. */
-    if (sel >= 0 && m->profile && m->profile->verify.mode == 1)
-        draw_verdict_block(m, th, ImGui::GetContentRegionAvail().x);
-    (void)noun;
 }
 
 void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
@@ -8165,14 +8173,13 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
         ImGui::TextColored(col(th.accent), "Setup required");
         ImGui::PushTextWrapPos(wrap_x);
         if (plat == SETUP_PLAT_PSX && m->has_bios) {
+            /* The BIOS and disc sections below each answer this for themselves,
+             * so a paragraph restating both only pushes the controls off a
+             * fixed-height modal. The detail it used to carry lives behind the
+             * disc section's (?). */
             ImGui::TextColored(col(th.text_muted),
-                "%s needs a playable %s before you can launch. This build includes "
-                "a bundled BIOS (OpenBIOS) by default. Setup also looks for a "
-                "retail SCPH1001.BIN beside the install and uses it when found; "
-                "otherwise OpenBIOS stays selected. Use a Redump-style .cue with "
-                "sibling .bin tracks (.iso is not accepted). Pick your %s below "
-                "(you must legally own these dumps).",
-                game, noun, noun);
+                "%s needs a %s to launch. You must legally own the dumps.",
+                game, noun);
         } else if (plat == SETUP_PLAT_GBA && m->has_bios) {
             ImGui::TextColored(col(th.text_muted),
                 "%s needs a Game Boy Advance BIOS dump and a playable %s before "
@@ -8211,9 +8218,8 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
                   "300c20df… — dumped from a Game Boy Advance). Setup packages "
                   "do not ship a redistributable GBA BIOS."
             : (plat == SETUP_PLAT_PSX)
-                ? "Default: bundled OpenBIOS. Setup auto-selects SCPH1001.BIN "
-                  "if it finds a validated dump beside the install; otherwise "
-                  "browse for your own (exactly 512 KB)."
+                ? "Optional \u2014 OpenBIOS is used unless you browse for a "
+                  "retail dump (exactly 512 KB)."
                 : "Browse for a BIOS image required by this console.";
         const char* empty_bios_label =
             offers_bundled ? "OpenBIOS" : "(none selected)";
@@ -8275,7 +8281,8 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
         "Always point Generate at the .cue when one exists.";
 
     if (multi_disc)
-        ImGui::Text("%s. %s images", m->has_bios ? "2" : "1", noun);
+        ImGui::Text("%s. Disc images (%d)", m->has_bios ? "2" : "1",
+                    launcher_model_disc_count(m));
     else
         ImGui::Text("%s. %s image", m->has_bios ? "2" : "1", noun);
     ImGui::PushTextWrapPos(wrap_x);
@@ -8283,7 +8290,7 @@ void draw_setup_wizard_modal(LauncherModel* m, const LauncherTheme& th) {
         ImGui::PopTextWrapPos();
         static const char* kDiscPatterns[] = {"*.cue", "*.bin", "*.img",
                                               "*.iso", "*.car"};
-        draw_setup_disc_frame(m, th, noun, kDiscPatterns, 5,
+        draw_setup_disc_frame(m, th, kDiscPatterns, 5,
                               "Disc image (.cue .bin .img .iso .car)",
                               kPsxDiscNote);
         ImGui::PushTextWrapPos(wrap_x);

--- a/src/common/launcher_gl.c
+++ b/src/common/launcher_gl.c
@@ -20,6 +20,21 @@
 #define STBI_ONLY_JPEG
 #include "third_party/stb_image.h"
 
+unsigned char* launcher_image_load_rgba(const char* path, int* w, int* h) {
+    int iw = 0, ih = 0, comp = 0;
+    if (!path || !path[0]) return NULL;
+    unsigned char* pixels = stbi_load(path, &iw, &ih, &comp, 4);   // force RGBA
+    if (!pixels) return NULL;
+    if (iw <= 0 || ih <= 0) { stbi_image_free(pixels); return NULL; }
+    if (w) *w = iw;
+    if (h) *h = ih;
+    return pixels;
+}
+
+void launcher_image_free(unsigned char* pixels) {
+    if (pixels) stbi_image_free(pixels);
+}
+
 // Shared upload path. `colorkey_tol` < 0 disables color-keying.
 static LauncherTexture load_impl(const char* path, int colorkey_tol) {
     LauncherTexture t = { 0, 0, 0 };

--- a/src/common/launcher_gl.h
+++ b/src/common/launcher_gl.h
@@ -32,6 +32,19 @@ LauncherTexture launcher_texture_load_colorkey(const char* path, int tolerance);
 
 void launcher_texture_free(LauncherTexture* t);
 
+// Decode an image file to a tightly-packed RGBA8 buffer, WITHOUT touching GL.
+// For the one consumer that needs pixels rather than a texture: the window /
+// taskbar icon, which SDL wants as a surface. Returns NULL on failure; on
+// success *w and *h are the image size and the caller must release the buffer
+// with launcher_image_free().
+//
+// This lives here rather than in the caller because launcher_gl.c owns the
+// launcher's PRIVATE stb_image instance (STB_IMAGE_STATIC — see the comment
+// there): a second copy in another translation unit is exactly the symbol
+// collision that build was set up to avoid.
+unsigned char* launcher_image_load_rgba(const char* path, int* w, int* h);
+void           launcher_image_free(unsigned char* pixels);
+
 #ifdef __cplusplus
 }
 #endif

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -907,6 +907,22 @@ void launcher_model_set_disc_path(LauncherModel* m, int idx, const char* path) {
         launcher_model_set_rom(m, launcher_model_disc_path(m, idx));
 }
 
+const char* launcher_model_disc_suggested_name(const LauncherModel* m, int idx) {
+    const char* p;
+    const char* slash;
+    const char* back;
+    if (!m || idx < 0 || idx >= m->num_discs || !m->discs) return "";
+    /* Deliberately the ROSTER path, not launcher_model_disc_path(): once the
+     * player locates their own copy this is still the build's file name, and
+     * the caller only uses it while the slot is unlocated. */
+    p = m->discs[idx].path;
+    if (!p || !p[0]) return "";
+    slash = strrchr(p, '/');
+    back = strrchr(p, '\\');
+    if (back && (!slash || back > slash)) slash = back;
+    return slash ? slash + 1 : p;
+}
+
 bool launcher_model_disc_ready(const LauncherModel* m, int idx) {
     if (!m || idx < 0 || idx >= m->num_discs) return false;
     return lm_path_exists(launcher_model_disc_path(m, idx)) ? true : false;
@@ -2184,6 +2200,13 @@ bool launcher_model_can_finish_setup(const LauncherModel* m) {
      * Codegen hosts may also require a successful prepare/rebuild. */
     if (!m->rom_present || !m->rom_full[0]) return false;
     if (m->has_bios && !m->setup_bios_ok) return false;
+    /* A set is all-or-nothing: building one disc at a time is not supported, so
+     * a partially located set cannot produce a working install. Letting the
+     * wizard close on one located disc would defer that failure to whenever the
+     * player first needs disc 2. */
+    if (m->num_discs > 1 &&
+        launcher_model_discs_ready_count(m) < m->num_discs)
+        return false;
     if (m->prepare_required_before_continue && !m->setup_prepare_satisfied)
         return false;
     /* Disc titles: local setup only needs a readable, title-matching mount.

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -303,6 +303,7 @@ void launcher_model_init(LauncherModel* m,
         m->memcard_inspect_cb   = game->memcard_inspect;  // real memcard summary (PSX), or NULL
         m->bios_verify_cb       = game->bios_verify;
         m->persist_setup_cb     = game->persist_setup;
+        m->persist_setup_discs_cb = game->persist_setup_discs;  // NULL on older hosts
         m->persist_setup_ctx    = game->persist_setup_ctx;
         /* Wizard + Generate & rebuild are a single opt-in. Without the flag,
          * ignore prepare/rebuild/toolchain even if a host filled them — keeps
@@ -881,6 +882,135 @@ void launcher_model_select_disc(LauncherModel* m, int idx) {
     /* set_rom re-runs the disc verdict against the newly mounted image and
      * calls back into lm_bind_disc_selection, which writes s.disc_index. */
     launcher_model_set_rom(m, launcher_model_disc_path(m, idx));
+}
+
+/* Cheap existence probe. The model has no stat() wrapper and does not want
+ * one: everywhere else it already opens the file it cares about. */
+static int lm_path_exists(const char* path) {
+    FILE* f;
+    if (!path || !path[0]) return 0;
+    f = fopen(path, "rb");
+    if (!f) return 0;
+    fclose(f);
+    return 1;
+}
+
+void launcher_model_set_disc_path(LauncherModel* m, int idx, const char* path) {
+    if (!m || idx < 0 || idx >= m->num_discs) return;
+    safe_copy(m->disc_path_override[idx], sizeof(m->disc_path_override[idx]),
+              (path && path[0]) ? path : "");
+    /* Locating the SELECTED disc is also a statement about what is mounted, so
+     * rebind the ROM and let verification re-run. Locating any other slot is
+     * pure bookkeeping and must NOT disturb the current mount or verdict --
+     * a player filling in disc 3 has not asked to boot disc 3. */
+    if (idx == m->disc_selected)
+        launcher_model_set_rom(m, launcher_model_disc_path(m, idx));
+}
+
+bool launcher_model_disc_ready(const LauncherModel* m, int idx) {
+    if (!m || idx < 0 || idx >= m->num_discs) return false;
+    return lm_path_exists(launcher_model_disc_path(m, idx)) ? true : false;
+}
+
+int launcher_model_discs_ready_count(const LauncherModel* m) {
+    int i, n = 0;
+    if (!m) return 0;
+    for (i = 0; i < m->num_discs; ++i)
+        if (launcher_model_disc_ready(m, i)) ++n;
+    return n;
+}
+
+/* Rewrite every "disc N" / "cd N" token in a path to a different number.
+ *
+ * All occurrences, not the first: sets are commonly stored one folder per
+ * disc, so the number appears in the directory AND the file name
+ * (".../Foo (Disc 1)/Foo (Disc 1).cue"). Replacing only one of them yields a
+ * path that does not exist and the guess is silently wasted.
+ *
+ * The alphabetic part matches case-insensitively; the digits must match
+ * exactly, so "Disc 1" never rewrites the "1" in "Final Fantasy 11". */
+static int lm_swap_disc_token(const char* in, const char* word, int sep,
+                              int from_num, int to_num, char* out, size_t cap) {
+    char from_tok[24], num_tok[12];
+    size_t wlen, i = 0, o = 0, flen, nlen;
+    int hits = 0;
+    if (!in || !out || cap == 0) return 0;
+    snprintf(from_tok, sizeof(from_tok), "%s%s%d", word, sep ? " " : "", from_num);
+    snprintf(num_tok, sizeof(num_tok), "%d", to_num);
+    flen = strlen(from_tok);
+    nlen = strlen(num_tok);
+    wlen = strlen(word);
+    while (in[i]) {
+        int match = 1;
+        size_t k;
+        for (k = 0; k < flen; ++k) {
+            char a = in[i + k], b = from_tok[k];
+            if (!a) { match = 0; break; }
+            if (k < wlen) {          /* letters: fold case */
+                if (a >= 'A' && a <= 'Z') a = (char)(a - 'A' + 'a');
+                if (b >= 'A' && b <= 'Z') b = (char)(b - 'A' + 'a');
+            }
+            if (a != b) { match = 0; break; }
+        }
+        /* Reject a digit immediately after the token so "Disc 1" does not
+         * match inside "Disc 12". */
+        if (match && in[i + flen] >= '0' && in[i + flen] <= '9') match = 0;
+        if (match) {
+            /* Copy the matched word and separator VERBATIM and swap only the
+             * digits. Emitting a normalised "disc N" instead would lowercase
+             * a source that wrote "Disc N", and the candidate path would then
+             * not exist on any case-sensitive filesystem -- i.e. it would find
+             * nothing on Linux while appearing to work on Windows. */
+            const size_t keep = wlen + (sep ? 1u : 0u);
+            if (o + keep + nlen >= cap) return 0;
+            memcpy(out + o, in + i, keep);
+            o += keep;
+            memcpy(out + o, num_tok, nlen);
+            o += nlen;
+            i += flen;
+            ++hits;
+        } else {
+            if (o + 1 >= cap) return 0;
+            out[o++] = in[i++];
+        }
+    }
+    out[o] = '\0';
+    return hits;
+}
+
+int launcher_model_autofill_sibling_discs(LauncherModel* m) {
+    static const char* kWords[] = {"disc", "cd"};
+    int src = -1, i, filled = 0;
+    if (!m || m->num_discs <= 1) return 0;
+    /* Any located disc can seed the others; prefer the lowest so the common
+     * "player picked disc 1" case reads naturally in the derived paths. */
+    for (i = 0; i < m->num_discs; ++i)
+        if (launcher_model_disc_ready(m, i)) { src = i; break; }
+    if (src < 0) return 0;
+
+    for (i = 0; i < m->num_discs; ++i) {
+        const char* base;
+        int from_num, to_num, w, sep;
+        char cand[512];
+        if (i == src || launcher_model_disc_ready(m, i)) continue;
+        base = launcher_model_disc_path(m, src);
+        from_num = launcher_model_disc_number(m, src);
+        to_num = launcher_model_disc_number(m, i);
+        if (from_num == to_num) continue;
+        for (w = 0; w < 2 && !launcher_model_disc_ready(m, i); ++w) {
+            for (sep = 1; sep >= 0; --sep) {
+                if (!lm_swap_disc_token(base, kWords[w], sep, from_num, to_num,
+                                        cand, sizeof(cand)))
+                    continue;
+                if (!lm_path_exists(cand)) continue;
+                /* Bookkeeping only -- never moves the mount (see set_disc_path). */
+                launcher_model_set_disc_path(m, i, cand);
+                ++filled;
+                break;
+            }
+        }
+    }
+    return filled;
 }
 
 void launcher_model_set_rom(LauncherModel* m, const char* path) {
@@ -1700,18 +1830,50 @@ static int lm_running_exe_dir(char* out, size_t cap) {
 
 /* Persist ROM/BIOS picks where codegen hosts and the relaunched exe look:
  * cwd, running-exe dir, and (when known) the rebuild output dir. */
+/* disc.cfg body for a multi-disc set: one path per line, in disc order.
+ *
+ * Back-compatible in the direction that matters -- a reader that takes only
+ * the first line gets disc 1, which is exactly what it got before. Slots the
+ * player has not located are written as empty lines rather than skipped, so
+ * line N stays disc N and a later fill-in does not renumber the file.
+ *
+ * Returns 0 when there is nothing multi-disc to write, and the caller falls
+ * back to the single-path form. */
+static int lm_compose_disc_cfg(LauncherModel* m, char* out, size_t cap) {
+    int i;
+    size_t o = 0;
+    if (!m || m->num_discs <= 1 || !out || cap == 0) return 0;
+    out[0] = '\0';
+    for (i = 0; i < m->num_discs; ++i) {
+        const char* p = launcher_model_disc_path(m, i);
+        size_t n = p ? strlen(p) : 0;
+        if (o + n + 2 >= cap) return 0;
+        if (i) out[o++] = '\n';
+        if (n) { memcpy(out + o, p, n); o += n; }
+        out[o] = '\0';
+    }
+    return launcher_model_discs_ready_count(m) > 0;
+}
+
 static void lm_persist_setup_sidecars(LauncherModel* m) {
     char exe_dir[1024];
+    char disc_cfg[LNG_MAX_DISCS * 520];
     const char* rom = (m && m->rom_full[0]) ? m->rom_full : NULL;
     const char* bios =
         (m && m->has_bios && m->s.bios_path[0]) ? m->s.bios_path : NULL;
-    /* PSX hosts read disc.cfg; cart hosts read rom.cfg — write both names. */
+    /* A multi-disc set writes every located image; a single-image title (and
+     * any set where nothing is located yet) writes the mounted path as before. */
+    const char* disc_value =
+        lm_compose_disc_cfg(m, disc_cfg, sizeof(disc_cfg)) ? disc_cfg : rom;
+    /* PSX hosts read disc.cfg; cart hosts read rom.cfg — write both names.
+     * rom.cfg stays single-path: it is the cart-host contract and has no
+     * concept of a set. */
     lm_write_sidecar_in_dir(NULL, "rom.cfg", rom);
-    lm_write_sidecar_in_dir(NULL, "disc.cfg", rom);
+    lm_write_sidecar_in_dir(NULL, "disc.cfg", disc_value);
     lm_write_sidecar_in_dir(NULL, "bios.cfg", bios);
     if (lm_running_exe_dir(exe_dir, sizeof(exe_dir))) {
         lm_write_sidecar_in_dir(exe_dir, "rom.cfg", rom);
-        lm_write_sidecar_in_dir(exe_dir, "disc.cfg", rom);
+        lm_write_sidecar_in_dir(exe_dir, "disc.cfg", disc_value);
         lm_write_sidecar_in_dir(exe_dir, "bios.cfg", bios);
     }
     if (m && m->relaunch_exe[0]) {
@@ -1726,14 +1888,27 @@ static void lm_persist_setup_sidecars(LauncherModel* m) {
                 memcpy(rdir, m->relaunch_exe, n);
                 rdir[n] = '\0';
                 lm_write_sidecar_in_dir(rdir, "rom.cfg", rom);
-                lm_write_sidecar_in_dir(rdir, "disc.cfg", rom);
+                lm_write_sidecar_in_dir(rdir, "disc.cfg", disc_value);
                 lm_write_sidecar_in_dir(rdir, "bios.cfg", bios);
             }
         }
     }
-    if (m && m->persist_setup_cb)
+    /* Prefer the multi-disc flush when the host offers one and this title has
+     * a roster: it carries every located image, where persist_setup_cb can
+     * only carry the mounted one. Older hosts leave the pointer NULL and keep
+     * the single-path path, which is still correct for a one-disc game. */
+    if (m && m->num_discs > 1 && m->persist_setup_discs_cb) {
+        const char* paths[LNG_MAX_DISCS];
+        int i, n = m->num_discs;
+        if (n > LNG_MAX_DISCS) n = LNG_MAX_DISCS;
+        for (i = 0; i < n; ++i)
+            paths[i] = launcher_model_disc_path(m, i);
+        m->persist_setup_discs_cb(m->persist_setup_ctx, paths, n,
+                                  bios ? bios : "");
+    } else if (m && m->persist_setup_cb) {
         m->persist_setup_cb(m->persist_setup_ctx, rom ? rom : "",
                             bios ? bios : "");
+    }
 }
 
 void launcher_model_set_bios_path(LauncherModel* m, const char* path) {

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -148,6 +148,73 @@ static float clampf(float v, float lo, float hi) {
     return v < lo ? lo : (v > hi ? hi : v);
 }
 
+// ---- multi-image disc roster helpers -------------------------------------
+// File-name stem (basename minus the last extension) of a path, lowercased
+// into `out`. Length 0 when there is nothing usable.
+static size_t lm_path_stem(const char* path, char* out, size_t cap) {
+    if (!path || !out || cap == 0) return 0;
+    out[0] = '\0';
+    const char* base = path;
+    for (const char* p = path; *p; ++p)
+        if (*p == '/' || *p == '\\') base = p + 1;
+    const char* dot = NULL;
+    for (const char* p = base; *p; ++p)
+        if (*p == '.') dot = p;
+    size_t n = dot && dot != base ? (size_t)(dot - base) : strlen(base);
+    if (n >= cap) n = cap - 1;
+    for (size_t i = 0; i < n; ++i) {
+        char c = base[i];
+        out[i] = (c >= 'A' && c <= 'Z') ? (char)(c + 32) : c;
+    }
+    out[n] = '\0';
+    return n;
+}
+
+// Compare two disc paths for "same image". Exact string equality first (the
+// common case: the launcher hands back exactly the path the host gave it),
+// then a case-insensitive compare of the file-name STEM. The stem, not the
+// whole name: a .cue and the .bin it owns are one disc, and hosts hand us
+// either — psxrecomp resolves a picked .cue to its .bin before it mounts —
+// so "Disc 2.cue" and "Disc 2.bin" must land on the same roster slot. Two
+// different discs of a set never share a stem; they are numbered.
+static int lm_path_eq(const char* a, const char* b) {
+    if (!a || !b || !a[0] || !b[0]) return 0;
+    if (strcmp(a, b) == 0) return 1;
+    char sa[128], sb[128];
+    if (!lm_path_stem(a, sa, sizeof(sa)) || !lm_path_stem(b, sb, sizeof(sb)))
+        return 0;
+    return strcmp(sa, sb) == 0;
+}
+
+// Roster slot whose effective path is `path`, or -1 when it is off-roster.
+static int lm_disc_index_for_path(const LauncherModel* m, const char* path) {
+    if (!m || m->num_discs <= 0 || !path || !path[0]) return -1;
+    for (int i = 0; i < m->num_discs; ++i)
+        if (lm_path_eq(launcher_model_disc_path(m, i), path)) return i;
+    return -1;
+}
+
+// Bind rom_full to the roster after any ROM change. Either the new path IS a
+// roster image (select that slot) or the player browsed to a replacement for
+// the slot they had selected (record it as that slot's override) — never a
+// silent collapse of an N-disc set to whatever single file was last picked.
+static void lm_bind_disc_selection(LauncherModel* m) {
+    if (!m || m->num_discs <= 0) {
+        if (m) m->disc_selected = -1;
+        return;
+    }
+    if (m->disc_selected < 0 || m->disc_selected >= m->num_discs)
+        m->disc_selected = 0;
+    const int hit = lm_disc_index_for_path(m, m->rom_full);
+    if (hit >= 0) {
+        m->disc_selected = hit;
+    } else if (m->rom_present) {
+        safe_copy(m->disc_path_override[m->disc_selected],
+                  sizeof(m->disc_path_override[m->disc_selected]), m->rom_full);
+    }
+    m->s.disc_index = launcher_model_disc_number(m, m->disc_selected);
+}
+
 static void run_verify(LauncherModel* m);   // fwd; defined below, called from launcher_model_set_rom
 static void update_msu1_patch_available(LauncherModel* m);   // fwd; called from launcher_model_set_rom
 static void lm_inspect_memcard(LauncherModel* m, int slot); // fwd; host memcard_inspect callback
@@ -215,6 +282,21 @@ void launcher_model_init(LauncherModel* m,
         m->has_player_name      = game->has_player_name != 0;
         m->identity_detail      = game->identity_detail;
         m->rom_noun             = game->rom_noun ? game->rom_noun : "ROM";
+        /* Multi-image roster. Only entries with a real path count: a host that
+         * declared N discs but left one path NULL publishes a set the player
+         * could select an unmountable slot from, so the roster stops at the
+         * first hole rather than offering a row that cannot boot. */
+        m->discs                = game->discs;
+        m->num_discs            = 0;
+        if (game->discs && game->num_discs > 0) {
+            const int cap = game->num_discs < LNG_MAX_DISCS
+                                ? game->num_discs : LNG_MAX_DISCS;
+            while (m->num_discs < cap &&
+                   game->discs[m->num_discs].path &&
+                   game->discs[m->num_discs].path[0])
+                m->num_discs++;
+        }
+        if (m->num_discs == 0) m->discs = NULL;
         m->language_labels      = game->language_labels;
         m->num_languages        = game->num_languages;
         m->disc_verify_cb       = game->disc_verify;      // real disc verdict (PSX), or NULL
@@ -332,6 +414,14 @@ void launcher_model_init(LauncherModel* m,
     }
 
     if (io) m->s = *io;
+    /* Seed the selected disc from the host's persisted setting BEFORE the ROM
+     * is read: launcher_model_set_rom() below binds initial_rom to the roster,
+     * and when that path is off-roster (the player relocated the image) the
+     * slot it lands on must be the one the host remembered, not slot 0.
+     * disc_index is 1-based; 0 = unset -> disc 1. */
+    m->disc_selected = m->num_discs > 0
+                           ? clampi(m->s.disc_index - 1, 0, m->num_discs - 1)
+                           : -1;
     /* Rewind buffer: 50/100/150/200; interval 1/4/8/12/15. */
     {
         int d = m->s.rewind_depth;
@@ -750,6 +840,49 @@ void launcher_model_commit(const LauncherModel* m, RecompLauncherCSettings* io) 
     if (io) *io = m->s;
 }
 
+int launcher_model_disc_count(const LauncherModel* m) {
+    return m ? m->num_discs : 0;
+}
+
+int launcher_model_disc_selected(const LauncherModel* m) {
+    if (!m || m->num_discs <= 0) return -1;
+    return clampi(m->disc_selected, 0, m->num_discs - 1);
+}
+
+int launcher_model_disc_number(const LauncherModel* m, int idx) {
+    if (!m || idx < 0 || idx >= m->num_discs || !m->discs) return 0;
+    /* 0 = the host left the number unset for an ordinary 1..N set. */
+    return m->discs[idx].number > 0 ? m->discs[idx].number : idx + 1;
+}
+
+const char* launcher_model_disc_label(const LauncherModel* m, int idx) {
+    if (!m || idx < 0 || idx >= m->num_discs || !m->discs) return "";
+    const char* label = m->discs[idx].label;
+    if (label && label[0]) return label;
+    /* Per-slot scratch so the returned pointer stays valid alongside every
+     * other row's label for as long as the caller is drawing the dropdown. */
+    LauncherModel* mm = (LauncherModel*)m;
+    snprintf(mm->disc_label_scratch[idx], sizeof(mm->disc_label_scratch[idx]),
+             "Disc %d", launcher_model_disc_number(m, idx));
+    return mm->disc_label_scratch[idx];
+}
+
+const char* launcher_model_disc_path(const LauncherModel* m, int idx) {
+    if (!m || idx < 0 || idx >= m->num_discs || !m->discs) return "";
+    if (m->disc_path_override[idx][0]) return m->disc_path_override[idx];
+    return m->discs[idx].path ? m->discs[idx].path : "";
+}
+
+void launcher_model_select_disc(LauncherModel* m, int idx) {
+    if (!m || m->num_discs <= 0) return;
+    if (idx < 0 || idx >= m->num_discs) return;
+    if (idx == m->disc_selected) return;
+    m->disc_selected = idx;
+    /* set_rom re-runs the disc verdict against the newly mounted image and
+     * calls back into lm_bind_disc_selection, which writes s.disc_index. */
+    launcher_model_set_rom(m, launcher_model_disc_path(m, idx));
+}
+
 void launcher_model_set_rom(LauncherModel* m, const char* path) {
     m->rom_present = path && path[0] != '\0';
     safe_copy(m->rom_full, sizeof(m->rom_full), m->rom_present ? path : "");
@@ -837,6 +970,11 @@ void launcher_model_set_rom(LauncherModel* m, const char* path) {
         }
     }
     if (!m->rom_size[0]) safe_copy(m->rom_size, sizeof(m->rom_size), "--");
+
+    /* Keep the roster selection and the mounted path in agreement BEFORE the
+     * verdict runs, so the checklist the dropdown sits above always describes
+     * the disc the dropdown is showing. */
+    lm_bind_disc_selection(m);
 
     run_verify(m);
     update_msu1_patch_available(m);

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -200,6 +200,11 @@ typedef struct {
     int (*bios_verify_cb)(const char* bios_path, RecompLauncherCBiosVerify* out);
     /* Optional host flush for first-run picks (project-root bios.cfg / disc.cfg). */
     int (*persist_setup_cb)(void* ctx, const char* rom_path, const char* bios_path);
+    /* Multi-disc flush. Used INSTEAD of persist_setup_cb when non-NULL and the
+     * title has a roster (num_discs > 1), so every located image is written,
+     * not just the selected one. See RecompLauncherCGameInfo.persist_setup_discs. */
+    int (*persist_setup_discs_cb)(void* ctx, const char* const* disc_paths,
+                                  int disc_count, const char* bios_path);
     void*       persist_setup_ctx;
     int (*prepare_disc_cb)(const char* source_path, char* out_disc_path, size_t out_cap,
                            char* err_msg, size_t err_cap);
@@ -604,6 +609,24 @@ const char* launcher_model_disc_path(const LauncherModel* m, int idx);
 // new image) and records the choice in settings so it persists. Out-of-range
 // indices are ignored; re-selecting the current disc is a no-op.
 void launcher_model_select_disc(LauncherModel* m, int idx);
+
+// ---- per-slot disc paths (setup wizard) ---------------------------------
+// Bind one slot's image without changing which disc is selected. This is what
+// the wizard's per-disc rows call: a player locating disc 3 is telling us
+// where disc 3 lives, not asking to boot it. Binding the SELECTED slot also
+// rebinds the ROM (and so re-runs verification), because for that slot the two
+// are the same fact. An empty/NULL path clears the slot.
+void launcher_model_set_disc_path(LauncherModel* m, int idx, const char* path);
+// True when slot idx has a path that exists on disk.
+bool launcher_model_disc_ready(const LauncherModel* m, int idx);
+// How many slots are ready — the "N of M selected" counter.
+int  launcher_model_discs_ready_count(const LauncherModel* m);
+// Fill unset slots by pattern-matching siblings of an already-located disc
+// (".../Foo (Disc 1).cue" -> ".../Foo (Disc 2).cue", including the parent
+// directory when the set is stored one folder per disc). Only writes slots
+// that are currently empty, and only when the candidate exists. Returns how
+// many slots were newly filled.
+int  launcher_model_autofill_sibling_discs(LauncherModel* m);
 
 // Full path of the currently selected ROM ("" when none).
 const char* launcher_model_rom_path(const LauncherModel* m);

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -617,6 +617,11 @@ void launcher_model_select_disc(LauncherModel* m, int idx);
 // rebinds the ROM (and so re-runs verification), because for that slot the two
 // are the same fact. An empty/NULL path clears the slot.
 void launcher_model_set_disc_path(LauncherModel* m, int idx, const char* path);
+// File NAME (no directory) the project was BUILT from for this slot, or "" when
+// the host published no path. The developer's absolute path is meaningless on a
+// player's machine, but the file name is exactly what they are looking for, so
+// the wizard shows it as the hint for an unlocated disc.
+const char* launcher_model_disc_suggested_name(const LauncherModel* m, int idx);
 // True when slot idx has a path that exists on disk.
 bool launcher_model_disc_ready(const LauncherModel* m, int idx);
 // How many slots are ready — the "N of M selected" counter.

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -77,6 +77,13 @@ typedef enum {
 // headroom for future systems without another struct-layout change.
 #define LNG_MAX_BUTTONS 24
 
+// Upper bound on a multi-image title's disc roster (GameInfo.num_discs).
+// The largest shipped PS1 sets are 4 discs (Final Fantasy IX, Xenogears is
+// 2); 8 leaves headroom without making the model struct meaningfully bigger.
+// A host that publishes more discs than this has its roster clamped, and the
+// discs past the cap simply do not appear in the dropdown.
+#define LNG_MAX_DISCS 8
+
 // Upper bound on a SystemProfile's ControllerSpec.max_players — sizes the
 // per-player state below. Mirrors RECOMP_LAUNCHER_MAX_PLAYERS (the ABI
 // player-array width, recomp_launcher.h): N64 exposes 4 controller ports.
@@ -400,6 +407,27 @@ typedef struct {
     bool     sha_match;      // any known_sha256 matched
     bool     sha1_match;     // any known_sha1_hex matched
 
+    // ---- multi-image disc roster (GameInfo.discs) ----
+    // Borrowed build roster: which discs this game was compiled against.
+    // num_discs <= 1 means a single-image title and none of the disc-selection
+    // UI composes. disc_selected is a 0-based index into discs[]; it tracks
+    // rom_full, so a browse-in rebinds the SELECTED slot rather than silently
+    // becoming "the disc" for a set the build still expects N images of.
+    const RecompLauncherCDisc* discs;
+    int      num_discs;
+    int      disc_selected;
+    // Session-only per-slot browse-in. The roster path is what the build was
+    // made against; when a player points slot i somewhere else this run, that
+    // path lives here and shadows discs[i].path. Only the SELECTED slot's
+    // path is persisted (settings disc path + disc_index), so an override on
+    // an unselected slot is deliberately not remembered across runs.
+    char     disc_path_override[LNG_MAX_DISCS][512];
+    // Formatted "Disc N" fallback text for a host that supplied no label.
+    // One slot per disc rather than one shared buffer, so a caller may hold
+    // two rows' labels at once (the combo does: preview plus the row it is
+    // drawing) without the second overwriting the first.
+    char     disc_label_scratch[LNG_MAX_DISCS][32];
+
     // ---- disc-verdict result (verify.mode==1 systems only; PSX today) ----
     // See VerifyResult above. Untouched (all-zero) for verify.mode==0 systems
     // (SNES) — panels branch on m->profile->verify.mode, never on this alone.
@@ -555,6 +583,27 @@ void launcher_model_commit(const LauncherModel* m, RecompLauncherCSettings* io);
 // Adopt a newly-picked ROM path (from the native file dialog): updates the
 // displayed file name / verification state.
 void launcher_model_set_rom(LauncherModel* m, const char* path);
+
+// ---- multi-image disc roster (GameInfo.discs) ----------------------------
+// Number of discs this build was made from. 0 or 1 => single-image title:
+// the Disc Selection dropdown does not compose and the browse button carries
+// no disc number.
+int  launcher_model_disc_count(const LauncherModel* m);
+// 0-based index of the selected roster slot, or -1 when there is no roster.
+int  launcher_model_disc_selected(const LauncherModel* m);
+// Disc number as printed on the media for slot `idx` (1-based). 0 when idx is
+// out of range.
+int  launcher_model_disc_number(const LauncherModel* m, int idx);
+// Dropdown row text for slot `idx` — the host's label when it gave one, else
+// "Disc <number>". Never NULL; "" when idx is out of range.
+const char* launcher_model_disc_label(const LauncherModel* m, int idx);
+// Effective image path for slot `idx`: this run's browse-in when the player
+// made one, otherwise the path the build was made against. "" out of range.
+const char* launcher_model_disc_path(const LauncherModel* m, int idx);
+// Select a disc: rebinds the ROM path (re-running verification against the
+// new image) and records the choice in settings so it persists. Out-of-range
+// indices are ignored; re-selecting the current disc is a no-op.
+void launcher_model_select_disc(LauncherModel* m, int idx);
 
 // Full path of the currently selected ROM ("" when none).
 const char* launcher_model_rom_path(const LauncherModel* m);

--- a/src/common/launcher_ng_capi.c
+++ b/src/common/launcher_ng_capi.c
@@ -51,6 +51,11 @@ int recomp_launcher_run_window(const char* window_title,
         return RECOMP_LAUNCHER_RESULT_UNAVAILABLE;
     }
 
+    /* Same icon the host's game window carries — see GameInfo.window_icon_path.
+     * Applied before the model is built so the window is never briefly shown
+     * under the placeholder icon. */
+    launcher_platform_set_icon(&plat, game ? game->window_icon_path : NULL);
+
     LauncherModel model;
     launcher_model_init(&model, io, game, initial_rom);
     launcher_binds_load(&model, game ? game->config_path : NULL,

--- a/src/common/launcher_platform.h
+++ b/src/common/launcher_platform.h
@@ -49,6 +49,18 @@ typedef struct LauncherPlatform {
 bool launcher_platform_open(LauncherPlatform* p, const char* title,
                             int logical_w, int logical_h);
 
+// Apply an image file as the window / taskbar icon. The launcher and the game
+// it boots are one product to the player, so the launcher must not sit in the
+// task switcher under the toolkit's default placeholder while the game beside
+// it carries the real art. The HOST supplies the path — the same file its own
+// runtime applies — because the icon's name and location are the host's
+// convention, not something a console-neutral launcher should guess.
+//
+// No-op for a NULL/empty path or an image that fails to decode: an icon is
+// decoration, never a reason to fail opening the launcher. Safe to call any
+// time after launcher_platform_open() returns true.
+void launcher_platform_set_icon(LauncherPlatform* p, const char* image_path);
+
 // Refresh logical/pixel sizes and display scale from the live window. Called
 // once per frame (and after resize / scale-change events).
 void launcher_platform_refresh_metrics(LauncherPlatform* p);

--- a/src/common/launcher_platform_sdl2.c
+++ b/src/common/launcher_platform_sdl2.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include "launcher_platform.h"
 #include "launcher_boot_timing.h"
+#include "launcher_gl.h"
 
 #include <stdio.h>
 
@@ -168,6 +169,29 @@ bool launcher_platform_open(LauncherPlatform* p, const char* title,
     launcher_platform_refresh_metrics(p);
     launcher_boot_timing_mark("rui:platform_open:window+gl_ready");
     return true;
+}
+
+void launcher_platform_set_icon(LauncherPlatform* p, const char* image_path) {
+    if (!p || !p->window || !image_path || !image_path[0]) return;
+    int w = 0, h = 0;
+    unsigned char* pixels = launcher_image_load_rgba(image_path, &w, &h);
+    if (!pixels) return;
+    /* SDL copies the pixels into its own icon storage, so the decoded buffer
+     * is ours to free as soon as SetWindowIcon returns. The channel masks are
+     * byte-order dependent: stb hands back R,G,B,A in memory order. */
+    SDL_Surface* surf = SDL_CreateRGBSurfaceFrom(
+        pixels, w, h, 32, w * 4,
+#if SDL_BYTEORDER == SDL_BIG_ENDIAN
+        0xff000000, 0x00ff0000, 0x0000ff00, 0x000000ff
+#else
+        0x000000ff, 0x0000ff00, 0x00ff0000, 0xff000000
+#endif
+    );
+    if (surf) {
+        SDL_SetWindowIcon(p->window, surf);
+        SDL_FreeSurface(surf);
+    }
+    launcher_image_free(pixels);
 }
 
 void launcher_platform_refresh_metrics(LauncherPlatform* p) {

--- a/src/common/launcher_platform_sdl3.c
+++ b/src/common/launcher_platform_sdl3.c
@@ -2,6 +2,7 @@
 
 #include "launcher_platform.h"
 #include "launcher_boot_timing.h"
+#include "launcher_gl.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -114,6 +115,22 @@ bool launcher_platform_open(LauncherPlatform* p, const char* title,
     launcher_platform_refresh_metrics(p);
     launcher_boot_timing_mark("rui:platform_open:window+gl_ready");
     return true;
+}
+
+void launcher_platform_set_icon(LauncherPlatform* p, const char* image_path) {
+    if (!p || !p->window || !image_path || !image_path[0]) return;
+    int w = 0, h = 0;
+    unsigned char* pixels = launcher_image_load_rgba(image_path, &w, &h);
+    if (!pixels) return;
+    /* SDL copies the pixels into its own icon storage, so the decoded buffer
+     * is ours to free as soon as SetWindowIcon returns. */
+    SDL_Surface* surf =
+        SDL_CreateSurfaceFrom(w, h, SDL_PIXELFORMAT_RGBA32, pixels, w * 4);
+    if (surf) {
+        SDL_SetWindowIcon(p->window, surf);
+        SDL_DestroySurface(surf);
+    }
+    launcher_image_free(pixels);
 }
 
 void launcher_platform_refresh_metrics(LauncherPlatform* p) {

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -768,6 +768,15 @@ struct RecompLauncherCSettings {
      * The ring holds whole-machine snapshots on a frame cadence, which is why
      * it is opt-in. Appended additively. */
     int  rewind_enabled;
+
+    /* ---- selected disc (GameInfo.discs titles) ---------------------------
+     * 1-based number of the disc the player has selected, so the choice is an
+     * ordinary persisted setting the host writes to its settings file
+     * alongside every other row here — which is what lets an external
+     * launcher manage it, and what makes the last-played disc come back next
+     * session. 0 = unset: the launcher seeds it by matching initial_rom
+     * against the roster, falling back to disc 1. Appended additively. */
+    int  disc_index;
 };
 
 /* Values for RecompLauncherCSettings.vsync (1-based; 0 = unset). */
@@ -836,6 +845,24 @@ typedef struct RecompLauncherCTpak {
     // 0 unknown/other (gray), 1 red, 2 blue, 3 yellow, 4 green.
     int  cart_kind;
 } RecompLauncherCTpak;
+
+// One image of a multi-image title, as the BUILD knows it. A PSX game built
+// from a 3-disc set publishes three of these, in disc order, and the launcher
+// renders a "Disc Selection" dropdown so the player picks which one Play
+// boots. This is the build's roster — the discs the game was compiled
+// against — not a scan of the player's folder; a player who moved one image
+// still browses for it, and that browse rebinds only the selected slot.
+typedef struct RecompLauncherCDisc {
+    // Disc number as printed on the media (1-based). 0 => use the array
+    // position + 1, so a host may leave this unset for an ordinary 1..N set.
+    int         number;
+    // Optional display name for the dropdown row. NULL/"" => the launcher
+    // shows "Disc <number>". Borrowed; must outlive the run_window call.
+    const char* label;
+    // The image the build was made against (a .cue where one exists).
+    // Borrowed; must outlive the run_window call.
+    const char* path;
+} RecompLauncherCDisc;
 
 typedef struct RecompLauncherCGameInfo {
     const char*    name;
@@ -1278,6 +1305,18 @@ typedef struct RecompLauncherCGameInfo {
     const char* rom_patch_note;
     const char* rom_patch_cache_dir;
     const char* rom_patch_required_sha1;
+
+    /* ---- multi-image titles (appended additively) ------------------------
+     * The roster of discs this build was made from, in disc order. When
+     * num_discs > 1 the game panel grows a "Disc Selection" dropdown above
+     * the identity checklist, the browse button names the selected disc
+     * ("Browse For Disc 2"), and Play boots whichever disc is selected —
+     * the chosen number rides back out in Settings.disc_index and the
+     * chosen path in out_rom_path. NULL/0 (every single-image title, and
+     * every host that predates this field) leaves the panel exactly as it
+     * is today apart from the button's verb. */
+    const RecompLauncherCDisc* discs;
+    int num_discs;
 } RecompLauncherCGameInfo;
 
 /* recomp_launcher_run_window return codes */

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -1334,6 +1334,27 @@ typedef struct RecompLauncherCGameInfo {
      * window with the toolkit default, exactly as before. Borrowed; must
      * outlive the run_window call. */
     const char* window_icon_path;
+
+    /* ---- multi-disc setup flush (appended additively) --------------------
+     * persist_setup carries ONE path, which is all a single-image title has.
+     * A multi-disc set needs every image the player located, not just the one
+     * the wizard happened to have selected -- otherwise the other discs are
+     * re-browsed on the next run, or worse, silently missing when the game
+     * asks for disc 2.
+     *
+     * When this is non-NULL and num_discs > 1, the launcher calls it INSTEAD
+     * of persist_setup after the wizard's picks are confirmed. disc_paths is
+     * disc-ordered with disc_count entries; a slot the player has not located
+     * is "" rather than NULL, so the host can still write a placeholder line
+     * and keep the file's disc ordering intact.
+     *
+     * Hosts that predate this field, and single-image titles, keep going
+     * through persist_setup unchanged -- so leaving this NULL is not a
+     * degraded path, it is the correct one for a one-disc game.
+     *
+     * Return 0 on success, like persist_setup. Uses persist_setup_ctx. */
+    int (*persist_setup_discs)(void* ctx, const char* const* disc_paths,
+                               int disc_count, const char* bios_path);
 } RecompLauncherCGameInfo;
 
 /* recomp_launcher_run_window return codes */

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -1317,6 +1317,23 @@ typedef struct RecompLauncherCGameInfo {
      * is today apart from the button's verb. */
     const RecompLauncherCDisc* discs;
     int num_discs;
+
+    /* ---- window / taskbar icon (appended additively) ---------------------
+     * Path to the image the HOST's own runtime applies as its window icon
+     * (PNG/TGA/JPEG). The launcher applies the SAME file so the two windows
+     * are one product in the task switcher instead of the game carrying the
+     * real art and the launcher the toolkit's placeholder. The host resolves
+     * it rather than the launcher guessing, because the file's name and
+     * location are the host's convention.
+     *
+     * On Windows the executable's embedded .ico already covers the whole
+     * process, so this mainly matters on Linux and macOS -- but it is applied
+     * everywhere so the two windows can never disagree.
+     *
+     * NULL/"" (and every host that predates this field) leaves the launcher
+     * window with the toolkit default, exactly as before. Borrowed; must
+     * outlive the run_window call. */
+    const char* window_icon_path;
 } RecompLauncherCGameInfo;
 
 /* recomp_launcher_run_window return codes */

--- a/tests/launcher_discs_test.c
+++ b/tests/launcher_discs_test.c
@@ -1,0 +1,114 @@
+/* Multi-disc roster: sibling autofill and per-slot binding.
+ *
+ * Includes the model translation unit so the static path-rewriting helper is
+ * reachable. That helper is where the risk lives -- it builds candidate paths
+ * that are then existence-checked, so a subtly wrong candidate does not fail
+ * loudly, it just silently finds nothing.
+ *
+ * Regression it exists for: the rewriter first emitted a normalised lowercase
+ * "disc N" instead of preserving the source's own "Disc N", which found every
+ * sibling on Windows and none on Linux.
+ */
+#include "launcher_model.c"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Pulled in by the model TU; unrelated to disc paths. */
+void launcher_binds_set_zapper(int a, int b);
+void launcher_binds_set_zapper(int a, int b) { (void)a; (void)b; }
+
+static int fails;
+
+static void expect(int cond, const char* what) {
+    if (cond) { printf("ok: %s\n", what); return; }
+    fprintf(stderr, "FAIL: %s\n", what);
+    ++fails;
+}
+
+static void touch(const char* path) {
+    FILE* f = fopen(path, "wb");
+    if (f) { fputc('x', f); fclose(f); }
+}
+
+static void test_token_rewriting(void) {
+    char out[512];
+
+    expect(lm_swap_disc_token("/x/Foo (Disc 1)/Foo (Disc 1).cue", "disc", 1,
+                              1, 2, out, sizeof(out)) == 2 &&
+           !strcmp(out, "/x/Foo (Disc 2)/Foo (Disc 2).cue"),
+           "rewrites every occurrence, preserving capitalisation");
+
+    expect(lm_swap_disc_token("/x/game cd1.cue", "cd", 0, 1, 3,
+                              out, sizeof(out)) == 1 &&
+           !strcmp(out, "/x/game cd3.cue"),
+           "cd1 -> cd3 with no separator");
+
+    expect(lm_swap_disc_token("/x/Final Fantasy 11 (Disc 1).cue", "disc", 1,
+                              1, 2, out, sizeof(out)) == 1 &&
+           !strcmp(out, "/x/Final Fantasy 11 (Disc 2).cue"),
+           "an unrelated number in the title is left alone");
+
+    expect(lm_swap_disc_token("/x/Foo (Disc 12).cue", "disc", 1, 1, 2,
+                              out, sizeof(out)) == 0,
+           "Disc 1 does not match inside Disc 12");
+}
+
+static void test_autofill(const char* dir) {
+    static RecompLauncherCDisc roster[3];
+    char p[3][512];
+    LauncherModel* m;
+    int i, filled;
+
+    for (i = 0; i < 3; ++i) {
+        snprintf(p[i], sizeof(p[i]), "%s/Game (Disc %d).cue", dir, i + 1);
+        roster[i].number = i + 1;
+        roster[i].label = NULL;
+        roster[i].path = "";
+    }
+    /* Only discs 1 and 3 exist: disc 2 must stay empty rather than be bound to
+     * a path that is merely plausible. */
+    touch(p[0]);
+    touch(p[2]);
+
+    m = (LauncherModel*)calloc(1, sizeof(LauncherModel));
+    if (!m) { fprintf(stderr, "FAIL: out of memory\n"); ++fails; return; }
+    m->discs = roster;
+    m->num_discs = 3;
+    m->disc_selected = 0;
+    safe_copy(m->disc_path_override[0], sizeof(m->disc_path_override[0]), p[0]);
+
+    expect(launcher_model_discs_ready_count(m) == 1, "seeded with 1 of 3 located");
+
+    filled = launcher_model_autofill_sibling_discs(m);
+    expect(filled == 1, "fills only the sibling that exists");
+    expect(launcher_model_disc_ready(m, 2), "disc 3 located");
+    expect(!launcher_model_disc_ready(m, 1),
+           "disc 2 left empty -- a missing file is not guessed at");
+    expect(!strcmp(launcher_model_disc_path(m, 0), p[0]), "disc 1 untouched");
+    expect(m->disc_selected == 0, "autofill never moves the mount");
+    expect(m->rom_full[0] == '\0', "autofill never binds the ROM");
+
+    /* Re-running must be idempotent, not additive. */
+    expect(launcher_model_autofill_sibling_discs(m) == 0,
+           "a second pass fills nothing new");
+
+    /* Binding a non-selected slot is bookkeeping only. */
+    launcher_model_set_disc_path(m, 1, p[1]);
+    expect(m->disc_selected == 0 && m->rom_full[0] == '\0',
+           "binding a non-selected slot leaves the mount alone");
+
+    free(m);
+    remove(p[0]);
+    remove(p[2]);
+}
+
+int main(int argc, char** argv) {
+    const char* dir = (argc > 1) ? argv[1] : ".";
+    test_token_rewriting();
+    test_autofill(dir);
+    if (fails) { fprintf(stderr, "\n%d FAILED\n", fails); return 1; }
+    printf("\nall passed\n");
+    return 0;
+}


### PR DESCRIPTION
Three launcher changes, driven by bringing a 3-disc PS1 title (Final Fantasy VII) through the launcher end to end.

## Multi-disc selection

A game built from more than one image now publishes its roster via `GameInfo.discs` / `num_discs`. The game panel grows a **Disc Selection** dropdown above the Serial / Region / ISO-header checklist — above it on purpose, since each disc of a set carries its own serial, so the control that decides which disc that is has to read first. Play boots whatever is selected, and the choice rides back out in `Settings.disc_index` for the host to persist like any other setting.

`Change Disc` becomes **`Browse For Disc 2`** (the selected disc's number), or `Browse For Disc` when single-disc. On a set the button no longer swaps which disc the game is on — the dropdown does that — it re-points the *selected* disc at a file on this machine, and naming the number is what keeps those two apart. A browse-in rebinds only that slot rather than collapsing an N-disc set to whatever single file was last picked.

Path matching compares file-name *stems*, so a `.cue` and the `.bin` it owns land on the same roster slot (hosts hand us either).

Every single-image title, and every host that predates the fields, is unchanged apart from the button's verb.

## Launcher window icon

Only the game called `SDL_SetWindowIcon`, so on Linux and macOS the launcher sat in the task switcher under the toolkit placeholder while the game beside it carried the real art. Windows hid this — the executable's embedded `.ico` covers the whole process.

The host supplies the file via `GameInfo.window_icon_path`; the launcher does not go looking, because the icon's name and location are the host's convention. The decode helper lives in `launcher_gl.c` since that TU owns the launcher's private `STB_IMAGE_STATIC` instance. A missing or undecodable image is a no-op.

## Pad art follows the selected mode

The Analog / D-Pad selector is a two-state control with no other feedback, so the pad picture above it is the answer to "which did I just pick?" — leaving it on the DualShock while D-Pad is lit reads as a broken control.

This reverses an earlier deliberate rule (art keyed only to a game *locked* to D-Pad, on the reasoning that `pad_mode` picks a protocol and the player is still physically holding a DualShock). That reasoning is sound; the selector's feedback value won. Locked titles are unaffected. Keyboard now shows the digital pad too, since it is digital at runtime whatever the stored mode says.

## Verification

Built and driven in a real launcher against a 3-disc set: the dropdown lists all three, selecting disc 2 remounts and re-verifies (serial flips `SCUS-94163` → `SCUS-94164`), the browse-in rebinds only the selected slot, and Play boots the selected disc. Window icon confirmed applied via `_NET_WM_ICON` (`nitems=262146`, 512x512).

Needs the matching psxrecomp side for the host wiring: mstan/psxrecomp#feat/multi-disc-launcher

## Setup wizard asks for every disc of a set, in one frame

The three changes above make the *launcher* multi-disc aware. The **setup
wizard** still asked for one image, because `persist_setup` carries one path.
So a player scaffolding a 3-disc set located disc 1 and found out somewhere in
disc 1's ending that discs 2 and 3 had never been recorded.

Asking for all of them is the fix. Asking as N copies of the existing
full-height media block is not — the wizard is a fixed-height modal and three of
those do not fit — so the section is rebuilt rather than repeated:

- the intro paragraph drops from six lines to one, and the BIOS blurb to one:
  both explained what the controls directly beneath them already state, and on
  a fixed-height modal that prose pushed those controls off the page. The
  detail lives behind a hover `(?)`;
- the verdict block is **not** drawn in the wizard. It carried a Disc Selection
  dropdown — redundant beside the rows that locate those same discs, and
  meaningless before anything is located — and a Serial / Region / ISO-header
  checklist that tells a player nothing actionable while they are still hunting
  for files. Both stay in the game panel, which is where choosing a disc
  belongs;
- each disc costs exactly one frame-high row: `Disc N`, the file, Browse. There
  is deliberately **no status column** — the path *is* the status, a located
  disc showing its file and an unlocated one the greyed name to look for, so
  the column both repeated that and cost the width the path needed.

A 3-disc set therefore renders **shorter** than the single-disc layout it
replaces.

An unlocated slot shows the file NAME the project was built from
(`launcher_model_disc_suggested_name`). The developer's absolute path is
meaningless on a player's machine; the file name is exactly what they are
looking for. Full path on hover once located.

**Every disc is required.** Building one disc at a time is not supported, so a
partially located set cannot produce a working install — `can_finish_setup()`
gates on all slots. Letting the wizard close on one located disc would only
defer the failure to whenever the player first needed disc 2.

**Find other discs** derives siblings from an already-located disc, since sets
almost always carry the number in the path. Offered rather than automatic: it
binds paths the player did not choose, and a wrong guess that appears without
being asked for is worse than a button that was not pressed.

### New model API

```
launcher_model_set_disc_path()            bind ONE slot
launcher_model_disc_ready()               does that slot's file exist
launcher_model_discs_ready_count()        the "N of M located" counter
launcher_model_autofill_sibling_discs()   derive the rest from one
```

Binding a non-selected slot is deliberately bookkeeping only — it must not
disturb the mount or re-run verification, because a player filling in disc 3 has
not asked to boot disc 3.

`persist_setup_discs` is **appended** to `RecompLauncherCGameInfo` rather than
replacing `persist_setup`, so no console's host has to change. It is used only
when the host provides it *and* the title has a roster; every other case keeps
the single-path flush, which stays correct for a one-disc game. `disc.cfg` grows
to one path per line, first line still disc 1.

The `BuiltinPickerKind::DiscSlot` target is stored outside `BuiltinRomPicker` on
purpose: `open_builtin_file_picker` default-constructs that struct, so a slot
stored there would survive the native-dialog path and be erased on the built-in
browser path — a divergence that shows up only on machines without a portal.

### Tests

`tests/launcher_discs_test.c` (new) covers the path rewriter and autofill end to
end. It earned its place before this landed: the rewriter first emitted a
normalised lowercase `disc N` instead of preserving the source's own `Disc N`,
so it found every sibling on Windows and **none** on Linux — silently, because a
wrong candidate simply fails its existence check rather than erroring. It also
pins that a missing sibling is left empty rather than guessed at, that autofill
is idempotent, that `Disc 1` does not match inside `Disc 12`, and that neither
autofill nor a non-selected bind moves the mount.

Inert until a host publishes a roster; the psxrecomp side does so in the matching
branch, which also writes the located set into `game.toml` — the roster is read
from there, not from `disc.cfg`.

### Verified on screen

The layout was then reviewed from an actual screenshot, which caught three
defects invisible to code review: `Needed` collided with `Disc 1` (the status
column's `SameLine` stop was narrower than its own widest label), the Browse
buttons were clipped because the path was drawn before the button's width was
reserved, and three rows overflowed the height computed for them — scrolling
disc 3, a required field, below the fold. Removing the status column and
reserving the button column first fixes all three rather than widening a stop.

Re-checked at 1100x880 in both states: 3-of-3 located showing real paths, and
0-of-3 showing suggested file names — no collision, no clipping, no scrollbar,
with Generate and Back/Quit still on the page.

Still not verified: a full first-run flow driven end to end (locate, Generate,
build, launch). The states above were reached by pointing the roster at
present and absent paths, not by walking the wizard through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0194TYJAqgyG9a9PJe9uUcgQ

