### PR TITLE
launcher: don't let the keyboard D-Pad default overwrite a locked pad mode

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,6 +177,25 @@ if(BUILD_TESTING)
         COMMAND $<TARGET_FILE:recomp-ui-launcher-setup-bios-test>
                 "${CMAKE_CURRENT_BINARY_DIR}")
 
+    # Per-seat pad_mode resolution: a locked mode (game.toml lock_mode) must
+    # survive the keyboard-has-no-sticks presentation default, because the
+    # selector that could undo it is hidden. Same include-the-TU shape as the
+    # two tests above.
+    add_executable(recomp-ui-launcher-pad-mode-test
+        tests/launcher_pad_mode_test.c
+        src/common/crc32.c
+        src/common/sha1.c
+        src/common/sha256.c
+        src/common/ips_patch.c
+        src/consoles/psx/memcard_format.c)
+    target_include_directories(recomp-ui-launcher-pad-mode-test PRIVATE
+        src src/common src/consoles/psx)
+    target_link_libraries(recomp-ui-launcher-pad-mode-test PRIVATE
+        ${RUI_SDL_TARGET})
+    add_test(
+        NAME recomp-ui-launcher-pad-mode
+        COMMAND $<TARGET_FILE:recomp-ui-launcher-pad-mode-test>)
+
     add_executable(recomp-ui-psx-profile-test
         tests/psx_profile_test.c)
     target_include_directories(recomp-ui-psx-profile-test PRIVATE

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -557,8 +557,33 @@ void launcher_model_init(LauncherModel* m,
                  * persisted value. The mod requests it at runtime instead. */
                 m->s.pad_mode[p] = 1;
             }
-            /* Keyboard cannot drive Analog/Hybrid — force D-Pad. */
-            if (m->s.player_src[p] == 1 &&
+            /* Keyboard cannot drive Analog/Hybrid — present D-Pad.
+             *
+             * This is a PRESENTATION default, not a hardware clamp. The host
+             * already short-circuits keyboard seats at the point of use:
+             * effective_player_mode() in psxrecomp's runtime/src/main.cpp
+             * reports DIGITAL for any seat whose kind is keyboard, whatever
+             * the seat's stored mode says. So nothing downstream depends on
+             * this value being 2 — it only decides what the selector shows.
+             *
+             * Which is why it must NOT run when the mode is locked. A locked
+             * title (game.toml [controller] lock_mode) hides the selector
+             * entirely, so once locked_pad_mode is overwritten with D-Pad
+             * there is no control left that can put it back — not the
+             * selector (hidden), not launcher_model_set_pad_mode() and not
+             * apply_default_pad_mode_for_source(), both of which correctly
+             * refuse to touch a locked mode. And a release install defaults
+             * Player 1's device to Keyboard, so EVERY fresh install of an
+             * Analog-locked dual-analog title (Ape Escape) went through here
+             * and came out digital-for-good: the game saw a plain SCPH-1080,
+             * right stick dead and left stick folded onto the D-pad, with no
+             * UI to correct it.
+             *
+             * Leaving the locked mode intact costs nothing while the keyboard
+             * is driving the seat, and is already right the moment the player
+             * attaches a real pad. */
+            if (m->pad_mode_selectable &&
+                m->s.player_src[p] == 1 &&
                 !(pm_spec && pm_spec->modes && pm_spec->mode_count > 0))
                 m->s.pad_mode[p] = 2;
         }

--- a/tests/launcher_pad_mode_test.c
+++ b/tests/launcher_pad_mode_test.c
@@ -1,0 +1,239 @@
+/* Per-seat pad_mode resolution in launcher_model_init(), and the interaction
+ * between a LOCKED mode and the keyboard-has-no-sticks presentation default.
+ *
+ * Regression it exists for: a PSX title whose game.toml declares
+ * `default_mode = "analog"` + `lock_mode = true` (Ape Escape) booted its pad
+ * DIGITAL on a fresh install. The lock IS honoured -- the !pad_mode_selectable
+ * branch of the gate assigns locked_pad_mode -- but the keyboard coercion that
+ * followed it in the same loop body had no selectable gate, and a release
+ * install defaults Player 1's device to Keyboard. So pad_mode[0] came out 2
+ * (D-Pad) on every first run of an Analog-locked title.
+ *
+ * That would be cosmetic if anything could undo it. Nothing can: lock_mode
+ * hides the selector, and both launcher_model_set_pad_mode() and
+ * apply_default_pad_mode_for_source() deliberately refuse to touch a locked
+ * mode. The value stayed 2 after the player assigned a real DualShock, the
+ * host read it back into player_mode[], and sio.c answered with the 4-byte
+ * digital pad response: right stick dead, left stick folded onto the D-pad.
+ *
+ * The coercion is a PRESENTATION default only -- psxrecomp's
+ * effective_player_mode() already reports DIGITAL for any keyboard seat
+ * regardless of the seat's stored mode -- so gating it on pad_mode_selectable
+ * costs nothing and keeps the locked mode intact for the pad that arrives later.
+ *
+ * Includes the model translation unit (as launcher_discs_test.c does) so the
+ * static pad-mode helpers are reachable.
+ */
+#include "launcher_model.c"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Pulled in by the model TU; unrelated to pad modes. */
+void launcher_binds_set_zapper(int a, int b);
+void launcher_binds_set_zapper(int a, int b) { (void)a; (void)b; }
+
+static int fails;
+
+static void expect(int cond, const char* what) {
+    if (cond) { printf("ok: %s\n", what); return; }
+    fprintf(stderr, "FAIL: %s\n", what);
+    ++fails;
+}
+
+static void expect_mode(const LauncherModel* m, int player, int want,
+                        const char* what) {
+    if (m->s.pad_mode[player] == want) { printf("ok: %s\n", what); return; }
+    fprintf(stderr, "FAIL: %s (pad_mode[%d] = %d, want %d)\n",
+            what, player, m->s.pad_mode[player], want);
+    ++fails;
+}
+
+/* PSX pad modes, mirroring the engine's PadMode enum
+ * (recompiler/src/config_loader.h: ANALOG = 1, DIGITAL = 2). 0 is Hybrid,
+ * which is mod-only and never selectable. */
+enum { PSX_ANALOG = 1, PSX_DIGITAL = 2 };
+/* recomp-ui player_src vocabulary: 0 None, 1 Keyboard, 2 Gamepad. */
+enum { SRC_NONE = 0, SRC_KEYBOARD = 1, SRC_GAMEPAD = 2 };
+
+static const char* kFixtureGuid = "030000004c0500006802000000000000";
+
+/* One launcher session: a game spec + the settings the host handed in.
+ * `locked` mirrors game.toml [controller] lock_mode; the host passes it as
+ * pad_mode_selectable = !lock_mode plus locked_pad_mode = the game-declared
+ * mode (see ae_fill_psx_launcher_game_info in psxrecomp runtime/src/main.cpp). */
+static LauncherModel* psx_session(int locked, int locked_mode,
+                                  int p0_src, int p0_persisted_mode) {
+    static RecompLauncherCGameInfo game;
+    static RecompLauncherCSettings io;
+    LauncherModel* m = (LauncherModel*)calloc(1, sizeof(LauncherModel));
+    if (!m) { fprintf(stderr, "FAIL: out of memory\n"); ++fails; return NULL; }
+
+    memset(&game, 0, sizeof(game));
+    launcher_profile_apply_psx(&game);
+    game.name = "Locked Mode Fixture";
+    game.num_players = 2;
+    game.pad_mode_selectable = locked ? 0 : 1;
+    game.locked_pad_mode = locked_mode;
+
+    memset(&io, 0, sizeof(io));
+    io.player_src[0] = p0_src;
+    io.pad_mode[0] = p0_persisted_mode;
+    io.player_src[1] = SRC_NONE;
+    io.pad_mode[1] = p0_persisted_mode;
+
+    launcher_model_init(m, &io, &game, NULL);
+    return m;
+}
+
+static LauncherModel* genesis_session(int p0_src, int p0_persisted_mode) {
+    static RecompLauncherCGameInfo game;
+    static RecompLauncherCSettings io;
+    LauncherModel* m = (LauncherModel*)calloc(1, sizeof(LauncherModel));
+    if (!m) { fprintf(stderr, "FAIL: out of memory\n"); ++fails; return NULL; }
+
+    memset(&game, 0, sizeof(game));
+    launcher_profile_apply_genesis(&game);
+    game.name = "Genesis Fixture";
+    game.num_players = 2;
+
+    memset(&io, 0, sizeof(io));
+    io.player_src[0] = p0_src;
+    io.pad_mode[0] = p0_persisted_mode;
+
+    launcher_model_init(m, &io, &game, NULL);
+    return m;
+}
+
+/* ---- the bug, exactly as the owner hit it -------------------------------- */
+static void test_locked_analog_keyboard_seat(void) {
+    /* Fresh release install of an Analog-locked title: Player 1's device
+     * defaults to keyboard (psxrecomp runtime/src/main.cpp seeds
+     * player_device[0] = "keyboard"), and settings.toml has nothing yet, so
+     * the host seeds pad_mode 0. */
+    LauncherModel* m = psx_session(1, PSX_ANALOG, SRC_KEYBOARD, 0);
+    if (!m) return;
+    expect(!m->pad_mode_selectable, "lock_mode hides the selector");
+    expect_mode(m, 0, PSX_ANALOG,
+                "locked ANALOG survives a keyboard seat (the reported bug)");
+    expect_mode(m, 1, PSX_ANALOG, "locked ANALOG applies to every seat");
+
+    /* The player now assigns a real DualShock. Nothing about that transition
+     * may be needed to REPAIR the mode -- there is no UI that could. */
+    launcher_model_set_source(m, 0, SRC_GAMEPAD, 7, "DualShock", kFixtureGuid);
+    expect_mode(m, 0, PSX_ANALOG, "still ANALOG once a gamepad is assigned");
+
+    /* Locked means locked in BOTH directions: the hidden selector cannot be
+     * driven, so a stray set_pad_mode must not push the seat to digital. */
+    launcher_model_set_pad_mode(m, 0, PSX_DIGITAL);
+    expect_mode(m, 0, PSX_ANALOG, "set_pad_mode is refused while locked");
+    free(m);
+}
+
+static void test_locked_analog_poisoned_settings(void) {
+    /* The corruption is durable: the host writes player_mode[] back to
+     * settings.toml, so a build that already shipped the bug hands the
+     * launcher a persisted DIGITAL for an ANALOG-locked title. The lock must
+     * override the stale value rather than adopt it. */
+    LauncherModel* m = psx_session(1, PSX_ANALOG, SRC_KEYBOARD, PSX_DIGITAL);
+    if (!m) return;
+    expect_mode(m, 0, PSX_ANALOG,
+                "a settings.toml poisoned with DIGITAL is re-clamped to the lock");
+    free(m);
+}
+
+static void test_locked_digital_still_digital(void) {
+    /* The other direction of the same lock: digital-only titles (X4, Tomba 2)
+     * must stay digital even for a gamepad seat, whose unlocked default would
+     * be Analog. */
+    LauncherModel* m = psx_session(1, PSX_DIGITAL, SRC_GAMEPAD, PSX_ANALOG);
+    if (!m) return;
+    expect_mode(m, 0, PSX_DIGITAL, "locked DIGITAL overrides a gamepad seat");
+    launcher_model_set_pad_mode(m, 0, PSX_ANALOG);
+    expect_mode(m, 0, PSX_DIGITAL,
+                "set_pad_mode is refused while locked (digital)");
+    free(m);
+}
+
+/* ---- unlocked behaviour must be exactly what it was ---------------------- */
+static void test_unlocked_keyboard_presents_dpad(void) {
+    LauncherModel* m = psx_session(0, PSX_ANALOG, SRC_KEYBOARD, PSX_ANALOG);
+    if (!m) return;
+    expect(m->pad_mode_selectable != 0, "no lock: the selector is live");
+    expect_mode(m, 0, PSX_DIGITAL,
+                "unlocked keyboard seat still presents D-Pad");
+    /* Analog is genuinely unavailable while the keyboard drives the seat. */
+    launcher_model_set_pad_mode(m, 0, PSX_ANALOG);
+    expect_mode(m, 0, PSX_DIGITAL,
+                "unlocked keyboard seat refuses an Analog pick");
+    free(m);
+}
+
+static void test_unlocked_keyboard_to_pad_self_corrects(void) {
+    /* Why the unlocked case was never as bad: assigning a pad goes through
+     * launcher_model_set_source -> apply_default_pad_mode_for_source, which
+     * is NOT gated off for an unlocked title and seeds Analog for a gamepad
+     * seat. So the unlocked equivalent of the bug repairs itself the moment
+     * the device is picked -- which is exactly the repair a locked title
+     * cannot perform. */
+    LauncherModel* m = psx_session(0, PSX_ANALOG, SRC_KEYBOARD, PSX_ANALOG);
+    if (!m) return;
+    expect_mode(m, 0, PSX_DIGITAL, "starts on D-Pad for the keyboard seat");
+    launcher_model_set_source(m, 0, SRC_GAMEPAD, 7, "DualShock", kFixtureGuid);
+    expect_mode(m, 0, PSX_ANALOG,
+                "assigning a gamepad re-defaults an unlocked seat to Analog");
+    /* And back: the presentation default follows the source both ways. */
+    launcher_model_set_source(m, 0, SRC_KEYBOARD, 0, NULL, NULL);
+    expect_mode(m, 0, PSX_DIGITAL,
+                "switching back to keyboard re-presents D-Pad");
+    free(m);
+}
+
+static void test_unlocked_hybrid_migrates(void) {
+    /* Hybrid (0) is mod-only and never selectable; a stale persisted 0 on a
+     * gamepad seat migrates to Analog. Unchanged by this fix, pinned because
+     * it shares the same gate. */
+    LauncherModel* m = psx_session(0, PSX_ANALOG, SRC_GAMEPAD, 0);
+    if (!m) return;
+    expect_mode(m, 0, PSX_ANALOG, "stale Hybrid migrates to Analog");
+    free(m);
+}
+
+/* ---- a console with its own mode vocabulary is untouched ----------------- */
+static void test_genesis_custom_mode_list(void) {
+    /* Genesis modes are 0 = 3-Button, 1 = 6-Button -- NOT the PSX
+     * Analog/D-Pad pair. The keyboard coercion has always skipped consoles
+     * with a custom mode list (a keyboard can drive a 6-button pad fine), and
+     * gating it on pad_mode_selectable must not change that. */
+    LauncherModel* m = genesis_session(SRC_KEYBOARD, 1);
+    if (!m) return;
+    expect_mode(m, 0, 1, "Genesis keyboard seat keeps 6-Button");
+    free(m);
+
+    m = genesis_session(SRC_KEYBOARD, 0);
+    if (!m) return;
+    expect_mode(m, 0, 0, "Genesis keyboard seat keeps 3-Button");
+    free(m);
+
+    /* An out-of-vocabulary value (e.g. a PSX 2 written by a shared
+     * settings.toml) snaps to the first listed mode, not to D-Pad. */
+    m = genesis_session(SRC_KEYBOARD, PSX_DIGITAL);
+    if (!m) return;
+    expect_mode(m, 0, kGenesisPadModes[0].mode,
+                "an unlisted Genesis mode snaps to the first listed mode");
+    free(m);
+}
+
+int main(void) {
+    test_locked_analog_keyboard_seat();
+    test_locked_analog_poisoned_settings();
+    test_locked_digital_still_digital();
+    test_unlocked_keyboard_presents_dpad();
+    test_unlocked_keyboard_to_pad_self_corrects();
+    test_unlocked_hybrid_migrates();
+    test_genesis_custom_mode_list();
+    if (fails) { fprintf(stderr, "\n%d FAILED\n", fails); return 1; }
+    printf("\nall passed\n");
+    return 0;
+}


### PR DESCRIPTION
## The bug

Ape Escape shipped with the left stick acting as camera and the right stick doing nothing. Its `game.toml` declares `default_mode = "analog"` + `lock_mode = true`, so the pad should be a DualShock — it booted as a plain digital pad instead, and because `lock_mode` hides the pad-mode selector there was no control in the launcher that could put it right.

**This PR is the root cause.** The companion host-side fix is psxrecomp#298.

## Mechanism

`launcher_model_init()`'s pad_mode gate honours the lock at `src/common/launcher_model.c:545-546`:

```c
if (!m->pad_mode_selectable) {
    m->s.pad_mode[p] = m->locked_pad_mode;
} else if (...) { ... }
```

…and then throws it away fifteen lines later, in the same loop body, with no `pad_mode_selectable` gate:

```c
/* Keyboard cannot drive Analog/Hybrid — force D-Pad. */
if (m->s.player_src[p] == 1 && !(pm_spec && pm_spec->modes && ...))
    m->s.pad_mode[p] = 2;
```

A release install of a psxrecomp title defaults Player 1's device to `keyboard`, so `player_src[0] == 1` and `pad_mode[0]` came out `2` (D-Pad) on the first run of every Analog-locked title.

Nothing downstream could repair it, because everything that could is *correctly* refusing to touch a locked mode:

- the selector is hidden (`launcher_imgui.cpp:2149` draws it only when `pad_mode_supported && pad_mode_selectable`),
- `launcher_model_set_pad_mode()` early-returns on `!pad_mode_selectable`,
- `apply_default_pad_mode_for_source()` does too — so assigning a real DualShock did not fix it either.

The host then read the 2 back into `player_mode[]` and persisted it to `settings.toml`, and psxrecomp's `sio.c` answered the pad poll with a 4-byte response carrying no stick bytes (`pad_analog[lp] == 0` → `pad_response_len = 4`). Right stick dead, left stick folded onto the D-pad, and every subsequent launch re-read the poisoned settings.

## The fix

Gate the coercion on `pad_mode_selectable`.

It is a **presentation default, not a hardware clamp**: psxrecomp's `effective_player_mode()` already returns DIGITAL for any seat whose kind is keyboard, whatever the seat's stored mode says, and every consumer of a seat mode goes through it. A keyboard seat behaves as a plain SCPH-1080 either way — the only thing this assignment ever decided was what the selector displays, and a locked title has no selector to display it in.

Gating rather than deleting, because for a **selectable** title the coercion is honest and useful (Analog really is unavailable while the keyboard drives the seat; `launcher_model_set_pad_mode` already refuses an Analog pick there), and picking a device re-defaults the mode through `apply_default_pad_mode_for_source`, so the value never gets stuck. That is exactly why the unlocked equivalent of this bug was survivable and the locked one was not.

Consoles with their own mode vocabulary (Genesis 3-Button/6-Button) were never in scope for the coercion and still are not.

## Test

`tests/launcher_pad_mode_test.c`, registered as `recomp-ui-launcher-pad-mode` (same include-the-model-TU shape as `launcher_discs_test.c`). Covers the reported bug, its durable form (a `settings.toml` already poisoned with DIGITAL), locked-DIGITAL titles, the unlocked behaviour unchanged in both directions, stale-Hybrid migration, and Genesis.

Proven bidirectionally — with the gate removed, four checks go red with the owner's actual symptom:

```
FAIL: locked ANALOG survives a keyboard seat (the reported bug) (pad_mode[0] = 2, want 1)
FAIL: still ANALOG once a gamepad is assigned (pad_mode[0] = 2, want 1)
FAIL: set_pad_mode is refused while locked (pad_mode[0] = 2, want 1)
FAIL: a settings.toml poisoned with DIGITAL is re-clamped to the lock (pad_mode[0] = 2, want 1)
```

With the gate in place, all 10 registered tests build and 9/10 pass:

```
$ cmake -G Ninja -S . -B build -DCMAKE_C_COMPILER=gcc -DCMAKE_CXX_COMPILER=g++
$ cmake --build build && ctest --output-on-failure
 8/10 Test  #8: recomp-ui-launcher-pad-mode ......   Passed    0.05 sec
90% tests passed, 1 tests failed out of 10
	  7 - recomp-ui-launcher-setup-bios (Failed)
```

`recomp-ui-launcher-setup-bios` is **already red on master** (`FAIL: the pick is staged on the model, not discarded` / `FAIL: second pick replaces the first`), confirmed by building and running it from a clean checkout of `9b63084` with this branch's changes stashed. Unrelated to this PR.

## Companion

- psxrecomp#298 — keeps the host-side `lock_mode` re-clamp as defense-in-depth, drops the same destructive keyboard coercion on the host side of the round-trip, and adds coverage there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
