### PR TITLE
NDS: expose Virtual Stylus settings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -185,6 +185,14 @@ if(BUILD_TESTING)
         NAME recomp-ui-psx-profile
         COMMAND $<TARGET_FILE:recomp-ui-psx-profile-test>)
 
+    add_executable(recomp-ui-nds-profile-test
+        tests/nds_profile_test.c)
+    target_include_directories(recomp-ui-nds-profile-test PRIVATE
+        src src/common src/consoles/nds)
+    add_test(
+        NAME recomp-ui-nds-profile
+        COMMAND $<TARGET_FILE:recomp-ui-nds-profile-test>)
+
     add_executable(recomp-runtime-ui-imgui-test
         tests/runtime_ui_imgui_test.cpp
         src/common/recomp_runtime_ui.c

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -2947,15 +2947,18 @@ void panel_audio_draw(LauncherModel* m, const LauncherTheme* th) {
 // for PSX; shown when the title can use multitap seats or the analog hack.
 int avail_input(const LauncherModel* m) {
     return launcher_model_multitap_available(m) ||
-           launcher_model_multitap_analog_available(m);
+           launcher_model_multitap_analog_available(m) ||
+           launcher_model_virtual_stylus_available(m);
 }
 void draw_input_controls(LauncherModel* m, const LauncherTheme& th) {
     eyebrow("INPUT");
+    bool previous_row = false;
     if (launcher_model_multitap_available(m)) {
         bool on = launcher_model_multitap_enabled(m) != 0;
         if (ImGui::Checkbox("Multitap", &on) &&
             (on ? 1 : 0) != launcher_model_multitap_enabled(m))
             launcher_model_toggle_multitap(m);
+        previous_row = true;
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
             ImGui::BeginTooltip();
             ImGui::PushTextWrapPos(px(320));
@@ -2968,12 +2971,13 @@ void draw_input_controls(LauncherModel* m, const LauncherTheme& th) {
         }
     }
     if (launcher_model_multitap_analog_available(m)) {
-        if (launcher_model_multitap_available(m))
+        if (previous_row)
             ImGui::Dummy(ImVec2(0, px(th.spacing_sm)));
         bool on = launcher_model_multitap_analog_enabled(m) != 0;
         if (ImGui::Checkbox("Multitap analog (hack)", &on) &&
             (on ? 1 : 0) != launcher_model_multitap_analog_enabled(m))
             launcher_model_toggle_multitap_analog(m);
+        previous_row = true;
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
             ImGui::BeginTooltip();
             ImGui::PushTextWrapPos(px(320));
@@ -2984,6 +2988,14 @@ void draw_input_controls(LauncherModel* m, const LauncherTheme& th) {
             ImGui::PopTextWrapPos();
             ImGui::EndTooltip();
         }
+    }
+    if (launcher_model_virtual_stylus_available(m)) {
+        if (previous_row)
+            ImGui::Dummy(ImVec2(0, px(th.spacing_sm)));
+        bool on = launcher_model_virtual_stylus_enabled(m) != 0;
+        if (ImGui::Checkbox("Virtual Stylus", &on) &&
+            (on ? 1 : 0) != launcher_model_virtual_stylus_enabled(m))
+            launcher_model_toggle_virtual_stylus(m);
     }
 }
 void panel_input_draw(LauncherModel* m, const LauncherTheme* th) {
@@ -3548,32 +3560,38 @@ void draw_controller_assist_shortcuts(LauncherModel* m,
     ImGui::TextColored(col(th.text_muted),
                        m->has_assist_tools
                            ? "(global; requires Assist Tools)"
-                           : "(button chords supported)");
-    if (ImGui::BeginTable("controller_assist_binds", 2,
-                          ImGuiTableFlags_SizingStretchSame)) {
-        for (int action = 0;
-             action < m->assist_binding_count && action < 2; ++action) {
-            ImGui::TableNextColumn();
+                           : "(keyboard and controller)");
+    if (ImGui::BeginTable("controller_assist_binds", 3,
+                          ImGuiTableFlags_SizingStretchProp |
+                              ImGuiTableFlags_RowBg)) {
+        ImGui::TableSetupColumn("Action", ImGuiTableColumnFlags_WidthStretch,
+                                1.1f);
+        ImGui::TableSetupColumn("Keyboard", ImGuiTableColumnFlags_WidthStretch,
+                                1.0f);
+        ImGui::TableSetupColumn("Controller", ImGuiTableColumnFlags_WidthStretch,
+                                1.0f);
+        ImGui::TableHeadersRow();
+        for (int action = 0; action < m->assist_binding_count; ++action) {
             ImGui::PushID(action);
+            ImGui::TableNextRow();
+            ImGui::TableSetColumnIndex(0);
             ImGui::AlignTextToFramePadding();
             ImGui::TextUnformatted(m->assist_binding_labels[action]);
-            ImGui::SameLine(0, px(8));
-            if (m->has_assist_tools) {
-                bool capture_key = m->capturing && m->capture_assist &&
-                                   !m->capture_pad && m->capture_btn == action;
-                if (ImGui::Button(
-                        capture_key ? "[ key... ]" :
-                            settings_key_label(m->s.assist_key_bind[action]),
-                        ImVec2(px(105), 0)))
-                    launcher_model_begin_assist_capture(m, action, false);
-                ImGui::SameLine(0, px(5));
-            }
+            ImGui::TableSetColumnIndex(1);
+            bool capture_key = m->capturing && m->capture_assist &&
+                               !m->capture_pad && m->capture_btn == action;
+            if (ImGui::Button(
+                    capture_key ? "[ key... ]" :
+                        settings_key_label(m->s.assist_key_bind[action]),
+                    ImVec2(-FLT_MIN, 0)))
+                launcher_model_begin_assist_capture(m, action, false);
+            ImGui::TableSetColumnIndex(2);
             bool capture_pad = m->capturing && m->capture_assist &&
                                m->capture_pad && m->capture_btn == action;
             char pad[48];
             settings_pad_label(m->s.assist_pad_bind[action], pad, sizeof pad);
             if (ImGui::Button(capture_pad ? "[ button... ]" : pad,
-                              ImVec2(px(m->has_assist_tools ? 135 : 170), 0)))
+                              ImVec2(-FLT_MIN, 0)))
                 launcher_model_begin_assist_capture(m, action, true);
             ImGui::PopID();
         }

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -369,6 +369,7 @@ void launcher_model_init(LauncherModel* m,
         m->num_display_layouts = game->num_display_layouts;
         m->has_assist_tools     = game->has_assist_tools != 0;
         m->assist_tools_note    = game->assist_tools_note;
+        m->has_virtual_stylus   = game->has_virtual_stylus != 0;
         m->settings_bindings    = game->settings_bindings != 0;
         m->assist_binding_labels = game->assist_binding_labels;
         m->assist_binding_count =
@@ -453,6 +454,12 @@ void launcher_model_init(LauncherModel* m,
                sizeof m->default_assist_key_bind);
         memcpy(m->default_assist_pad_bind, game->assist_default_pad_bind,
                sizeof m->default_assist_pad_bind);
+        for (int i = 0; i < m->assist_binding_count; ++i) {
+            if (m->s.assist_key_bind[i] == 0)
+                m->s.assist_key_bind[i] = m->default_assist_key_bind[i];
+            if (m->s.assist_pad_bind[i] == 0)
+                m->s.assist_pad_bind[i] = m->default_assist_pad_bind[i];
+        }
     } else {
         memcpy(m->default_assist_key_bind, m->s.assist_key_bind,
                sizeof m->default_assist_key_bind);
@@ -2901,6 +2908,21 @@ void launcher_model_toggle_multitap_analog(LauncherModel* m) {
     m->s.multitap_analog = m->s.multitap_analog ? 0 : 1;
 }
 
+int launcher_model_virtual_stylus_available(const LauncherModel* m) {
+    return m && m->has_virtual_stylus;
+}
+
+int launcher_model_virtual_stylus_enabled(const LauncherModel* m) {
+    return launcher_model_virtual_stylus_available(m) &&
+           m->s.virtual_stylus >= 0;
+}
+
+void launcher_model_toggle_virtual_stylus(LauncherModel* m) {
+    if (!launcher_model_virtual_stylus_available(m)) return;
+    m->s.virtual_stylus =
+        launcher_model_virtual_stylus_enabled(m) ? -1 : 1;
+}
+
 void launcher_model_new_memcard(LauncherModel* m, int slot, const char* path) {
     if (slot < 0 || slot > 1 || !path || !path[0]) return;
     if (recompui_memcard_format_file(path) != 0) return;  // I/O failure: leave as-is
@@ -3658,10 +3680,10 @@ void launcher_model_reset_player_bindings(LauncherModel* m, int player) {
            sizeof m->s.player_pad_bind[player]);
 }
 void launcher_model_reset_assist_bindings(LauncherModel* m) {
-    if (!m || !m->settings_bindings || !m->has_default_settings) return;
-    memcpy(m->s.assist_key_bind, m->default_settings.assist_key_bind,
+    if (!m || !m->settings_bindings) return;
+    memcpy(m->s.assist_key_bind, m->default_assist_key_bind,
            sizeof m->s.assist_key_bind);
-    memcpy(m->s.assist_pad_bind, m->default_settings.assist_pad_bind,
+    memcpy(m->s.assist_pad_bind, m->default_assist_pad_bind,
            sizeof m->s.assist_pad_bind);
 }
 void launcher_model_cancel_capture(LauncherModel* m) {

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -321,6 +321,7 @@ typedef struct {
     int  num_display_layouts;
     bool has_assist_tools;
     const char* assist_tools_note;
+    bool has_virtual_stylus;
     bool settings_bindings;
     const char* const* assist_binding_labels;
     int assist_binding_count;
@@ -801,6 +802,9 @@ int  launcher_model_visible_player_count(const LauncherModel* m);
 int  launcher_model_multitap_analog_available(const LauncherModel* m);
 int  launcher_model_multitap_analog_enabled(const LauncherModel* m);
 void launcher_model_toggle_multitap_analog(LauncherModel* m);
+int  launcher_model_virtual_stylus_available(const LauncherModel* m);
+int  launcher_model_virtual_stylus_enabled(const LauncherModel* m);
+void launcher_model_toggle_virtual_stylus(LauncherModel* m);
 
 // ---- N64 Transfer Pak slots (tpak_slots only; no-op guarded by slot range) ----
 // Adopt a GB cartridge ROM for one port's Transfer Pak. Re-runs the host's

--- a/src/consoles/nds/nds_profile.h
+++ b/src/consoles/nds/nds_profile.h
@@ -21,7 +21,20 @@ static const ButtonDef kNdsPadButtons[] = {
 // bottom-screen pointer mapping; this profile describes Player 1's ordinary
 // buttons and controller assignment.
 static const char* const kPanelsSettingsNds[] = {
-    "video", "audio", NULL
+    "video", "audio", "input", NULL
+};
+
+static const char* const kNdsHostShortcutLabels[] = {
+    "Virtual Stylus",
+    "Virtual Stylus Tap",
+};
+
+// SDL's standard gamepad ABI uses these stable values in SDL2 and SDL3:
+// scancode Tab=43, south face button=0, left trigger axis=4.
+static const int kNdsHostShortcutKeyDefaults[] = { 43, 0 };
+static const int kNdsHostShortcutPadDefaults[] = {
+    RECOMP_LAUNCHER_PAD_AXIS(4, 1),
+    RECOMP_LAUNCHER_PAD_BUTTON(0),
 };
 
 static const char* const kNdsRomPatterns[] = { "*.nds", "*.srl" };
@@ -88,6 +101,12 @@ static inline void launcher_profile_apply_nds(RecompLauncherCGameInfo* gi) {
     // the built-in FreeBIOS + generated firmware. The host's bios_verify
     // explains which mode a given selection produces.
     gi->has_bios = 1;
+    gi->has_virtual_stylus = 1;
+    gi->settings_bindings = 1;
+    gi->assist_binding_labels = kNdsHostShortcutLabels;
+    gi->assist_binding_count = 2;
+    gi->assist_default_key_bind = kNdsHostShortcutKeyDefaults;
+    gi->assist_default_pad_bind = kNdsHostShortcutPadDefaults;
 }
 
 #ifdef __cplusplus

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -47,6 +47,8 @@ extern "C" {
 #define RECOMP_LAUNCHER_HAS_REWIND_ENABLED 1
 /* Host may #ifdef this when reading Settings.vsync. */
 #define RECOMP_LAUNCHER_HAS_VSYNC 1
+/* Host may #ifdef this when reading Settings.virtual_stylus. */
+#define RECOMP_LAUNCHER_HAS_VIRTUAL_STYLUS 1
 #define RECOMP_LAUNCHER_MAX_BINDINGS 24
 #define RECOMP_LAUNCHER_MAX_ASSIST_BINDINGS 8
 
@@ -803,6 +805,12 @@ struct RecompLauncherCSettings {
      * session. 0 = unset: the launcher seeds it by matching initial_rom
      * against the roster, falling back to disc 1. Appended additively. */
     int  disc_index;
+
+    /* NDS virtual stylus overlay. 0 is unset and means the launcher default
+     * for the console, which is enabled; 1 is explicitly enabled, -1 is
+     * explicitly disabled. Bindings live in assist_key_bind/assist_pad_bind so
+     * they appear in the Controller page with the rest of host-owned binds. */
+    int  virtual_stylus;
 };
 
 /* Values for RecompLauncherCSettings.vsync (1-based; 0 = unset). */
@@ -1381,6 +1389,10 @@ typedef struct RecompLauncherCGameInfo {
      * Return 0 on success, like persist_setup. Uses persist_setup_ctx. */
     int (*persist_setup_discs)(void* ctx, const char* const* disc_paths,
                                int disc_count, const char* bios_path);
+
+    /* NDS input convenience setting. When set, Settings shows a Virtual Stylus
+     * opt-out and the Controller page may expose host-owned bindings for it. */
+    int has_virtual_stylus;
 } RecompLauncherCGameInfo;
 
 /* recomp_launcher_run_window return codes */

--- a/tests/nds_profile_test.c
+++ b/tests/nds_profile_test.c
@@ -1,0 +1,25 @@
+#include "recomp_launcher.h"
+#include "consoles/nds/nds_profile.h"
+
+#include <assert.h>
+#include <string.h>
+
+int main(void) {
+    RecompLauncherCGameInfo game;
+    memset(&game, 0, sizeof(game));
+
+    launcher_profile_apply_nds(&game);
+
+    assert(game.has_virtual_stylus == 1);
+    assert(game.settings_bindings == 1);
+    assert(game.assist_binding_count == 2);
+    assert(strcmp(game.assist_binding_labels[0], "Virtual Stylus") == 0);
+    assert(strcmp(game.assist_binding_labels[1], "Virtual Stylus Tap") == 0);
+
+    assert(game.assist_default_key_bind[0] == 43);
+    assert(game.assist_default_key_bind[1] == 0);
+    assert(game.assist_default_pad_bind[0] == RECOMP_LAUNCHER_PAD_AXIS(4, 1));
+    assert(game.assist_default_pad_bind[1] == RECOMP_LAUNCHER_PAD_BUTTON(0));
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add a default-on NDS Virtual Stylus setting surfaced in Settings, not Mods
- expose rebindable host shortcuts on the Controller page for hold and tap actions
- seed NDS defaults to Tab, Pad LT, and Pad A while leaving keyboard tap unbound by default
- add NDS profile coverage and preserve existing PSX profile coverage

## Validation
- built recomp-ui-launcher
- built and ran recomp-ui-nds-profile-test.exe
- built and ran recomp-ui-psx-profile-test.exe
- built MKDS launcher against this branch