### PR TITLE
launcher: draw every host shortcut on the Controller page, not just two

### DIFF
--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -3551,8 +3551,9 @@ void draw_controller_assist_shortcuts(LauncherModel* m,
                            : "(button chords supported)");
     if (ImGui::BeginTable("controller_assist_binds", 2,
                           ImGuiTableFlags_SizingStretchSame)) {
-        for (int action = 0;
-             action < m->assist_binding_count && action < 2; ++action) {
+        /* Every host shortcut the runtime advertises (two-column grid, so a
+         * third row like Fast-forward wraps below the first pair). */
+        for (int action = 0; action < m->assist_binding_count; ++action) {
             ImGui::TableNextColumn();
             ImGui::PushID(action);
             ImGui::AlignTextToFramePadding();


### PR DESCRIPTION
## Summary

`draw_controller_assist_shortcuts` hard-caps the Controller page's Host Shortcuts grid at two actions (`action < 2`). A runtime that advertises a third host shortcut — psxrecomp's new Fast-forward pad binding, [mstan/psxrecomp#307](https://github.com/mstan/psxrecomp/pull/307) — therefore had no row there, even though the Settings › Hotkeys editor (`draw_assist_binding_editor`, uncapped) already listed it.

Iterate `assist_binding_count` instead. The two-column stretch table wraps the extra row below the first pair; with the usual two actions nothing changes.

Independent of #42 (scanlines) — cut straight from `master`, one commit.

## Test plan

- [x] Compiles with the BoF3 title's flags (GCC 16.2 / MinGW); full launcher-in-runtime rebuild clean
- [x] Controller page shows Rewind / Save states / Fast-forward with a psxrecomp build that includes #307; still two rows on a runtime that advertises two

🤖 Generated with [Claude Code](https://claude.com/claude-code)
