### PR TITLE
Show SBI status and accept companion files in the disc picker

### DIFF
--- a/docs/SBI_INPUT.md
+++ b/docs/SBI_INPUT.md
@@ -1,0 +1,19 @@
+# SBI input in the launcher
+
+PSX hosts can supply `RecompLauncherCGameInfo.import_sbi` to attach a selected
+SBI file to the current disc. The callback validates and stages the companion,
+then returns a mounted disc path. It must never return the SBI itself as a disc.
+Return zero with an error message on failure; the model preserves the selection.
+
+When this callback exists, the disc button reads **Browse For Disc / SBI**.
+The PSX filter accepts `.sbi`, and the model recognises its suffix without regard
+to case. Select a disc first. Import errors appear below the browse button.
+
+The host sets `RecompLauncherCDiscVerify.sbi_status` to `RECOMP_SBI_MISSING`,
+`RECOMP_SBI_NA`, or `RECOMP_SBI_OK`. The card displays Missing, N/A, or OK under
+ISO header. The host owns the meaning of applicability and validation.
+Build every launcher consumer with the updated headers because the C structures
+have grown. Other console filters remain unchanged.
+
+`tests/launcher_discs_test.c` covers status refresh, uppercase SBI selection,
+selection preservation on failure, and selection of the imported CUE on success.

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -1129,7 +1129,8 @@ void draw_verdict_block(LauncherModel* m, const LauncherTheme& th, float availw)
     // Checklist: Serial / Region / ISO header. Before a disc is chosen, show
     // em-dashes with no pass/fail marks so the layout still reserves the rows.
     if (ImGui::BeginTable("verdict_checklist", 3, ImGuiTableFlags_SizingStretchProp)) {
-        ImGui::TableSetupColumn("k", ImGuiTableColumnFlags_WidthFixed, px(76));
+        const float label_width = std::max(px(96), ImGui::CalcTextSize(ui_text("ISO header")).x + px(18));
+        ImGui::TableSetupColumn("k", ImGuiTableColumnFlags_WidthFixed, label_width);
         ImGui::TableSetupColumn("v", ImGuiTableColumnFlags_WidthStretch);
         ImGui::TableSetupColumn("m", ImGuiTableColumnFlags_WidthFixed, px(28));
         const char* dash = "\xE2\x80\x94";
@@ -1139,6 +1140,11 @@ void draw_verdict_block(LauncherModel* m, const LauncherTheme& th, float availw)
                th, !pending, v.region[0] != '\0');
         kv_row("ISO header", pending ? dash : (v.iso_ok ? "OK" : "Mismatch"),
                th, !pending, v.iso_ok);
+        const char* sbi_text = v.sbi_status == RECOMP_SBI_OK ? "OK" :
+                              v.sbi_status == RECOMP_SBI_MISSING ? "Missing" : "N/A";
+        kv_row("SBI File", pending ? dash : sbi_text,
+               th, !pending && v.sbi_status != RECOMP_SBI_NA,
+               v.sbi_status == RECOMP_SBI_OK);
         // TOC fingerprinting is a netplay capability, not part of ordinary
         // offline disc identification. Never expose it for offline titles,
         // even if a host accidentally leaves stale netplay fields populated.
@@ -1244,6 +1250,8 @@ void draw_game_panel(LauncherModel* m, const LauncherTheme& th, bool fill_h = fa
     else
         snprintf(change_label, sizeof(change_label), "%s %s",
                  ui_text("Browse For"), ui_text(noun));
+    if (m->import_sbi_cb)
+        std::strncat(change_label, " / SBI", sizeof(change_label) - std::strlen(change_label) - 1);
     if (ImGui::Button(change_label, ImVec2(availw, px(34)))) {
         // Native file dialog filter comes from the active console's
         // SystemProfile.rom_filter — never a hardcoded per-system set. Every
@@ -1256,13 +1264,19 @@ void draw_game_panel(LauncherModel* m, const LauncherTheme& th, bool fill_h = fa
         if (disc_no > 0)
             snprintf(title, sizeof(title), "Select %s %d", noun, disc_no);
         else
-            snprintf(title, sizeof(title), "Select %s", noun);
+            snprintf(title, sizeof(title), "Select %s%s", noun, m->import_sbi_cb ? " / SBI" : "");
         if (prof && prof->rom_filter.patterns && prof->rom_filter.pattern_count > 0)
             request_rom_picker(m, title, prof->rom_filter.patterns,
                                prof->rom_filter.pattern_count,
                                prof->rom_filter.desc, false);
         else
             request_rom_picker(m, title, NULL, 0, NULL, false);
+    }
+
+    if (m->setup_error[0]) {
+        ImGui::PushTextWrapPos();
+        ImGui::TextColored(col(th.warn), "%s", m->setup_error);
+        ImGui::PopTextWrapPos();
     }
 
     // MSU-1 patch-available sub-block: this game ships an IPS patch that

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -929,8 +929,27 @@ static int lm_path_exists(const char* path) {
     return 1;
 }
 
+static bool lm_is_sbi_path(const char* path) {
+    const size_t n = path ? strlen(path) : 0;
+    return n >= 4 && path[n - 4] == '.' &&
+           tolower((unsigned char)path[n - 3]) == 's' &&
+           tolower((unsigned char)path[n - 2]) == 'b' &&
+           tolower((unsigned char)path[n - 1]) == 'i';
+}
+
 void launcher_model_set_disc_path(LauncherModel* m, int idx, const char* path) {
     if (!m || idx < 0 || idx >= m->num_discs) return;
+    char imported[1024] = {0};
+    if (lm_is_sbi_path(path)) {
+        const char* disc = launcher_model_disc_path(m, idx);
+        m->setup_error[0] = '\0';
+        if (!disc || !disc[0] || !m->import_sbi_cb) {
+            safe_copy(m->setup_error, sizeof(m->setup_error), "Select a supported disc first, then select its matching SBI file.");
+            return;
+        }
+        if (!m->import_sbi_cb(disc, path, imported, sizeof(imported), m->setup_error, sizeof(m->setup_error))) return;
+        path = imported;
+    }
     safe_copy(m->disc_path_override[idx], sizeof(m->disc_path_override[idx]),
               (path && path[0]) ? path : "");
     /* Locating the SELECTED disc is also a statement about what is mounted, so
@@ -1064,11 +1083,7 @@ int launcher_model_autofill_sibling_discs(LauncherModel* m) {
 }
 
 void launcher_model_set_rom(LauncherModel* m, const char* path) {
-    const size_t path_len = path ? strlen(path) : 0;
-    if (path_len >= 4 && path[path_len - 4] == '.' &&
-        tolower((unsigned char)path[path_len - 3]) == 's' &&
-        tolower((unsigned char)path[path_len - 2]) == 'b' &&
-        tolower((unsigned char)path[path_len - 1]) == 'i') {
+    if (lm_is_sbi_path(path)) {
         char mounted[1024] = {0};
         m->setup_error[0] = '\0';
         if (!m->rom_present || !m->import_sbi_cb) {

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -13,6 +13,7 @@
 #include "ips_patch.h"
 
 #include <stdio.h>
+#include <ctype.h>
 #include <stdlib.h>
 #include <string.h>
 
@@ -300,6 +301,7 @@ void launcher_model_init(LauncherModel* m,
         m->language_labels      = game->language_labels;
         m->num_languages        = game->num_languages;
         m->disc_verify_cb       = game->disc_verify;      // real disc verdict (PSX), or NULL
+        m->import_sbi_cb        = game->import_sbi;
         m->memcard_inspect_cb   = game->memcard_inspect;  // real memcard summary (PSX), or NULL
         m->bios_verify_cb       = game->bios_verify;
         m->persist_setup_cb     = game->persist_setup;
@@ -1062,6 +1064,24 @@ int launcher_model_autofill_sibling_discs(LauncherModel* m) {
 }
 
 void launcher_model_set_rom(LauncherModel* m, const char* path) {
+    const size_t path_len = path ? strlen(path) : 0;
+    if (path_len >= 4 && path[path_len - 4] == '.' &&
+        tolower((unsigned char)path[path_len - 3]) == 's' &&
+        tolower((unsigned char)path[path_len - 2]) == 'b' &&
+        tolower((unsigned char)path[path_len - 1]) == 'i') {
+        char mounted[1024] = {0};
+        m->setup_error[0] = '\0';
+        if (!m->rom_present || !m->import_sbi_cb) {
+            safe_copy(m->setup_error, sizeof(m->setup_error),
+                      "Select a supported disc first, then select its matching SBI file.");
+            return;
+        }
+        if (!m->import_sbi_cb(m->rom_full, path, mounted, sizeof(mounted),
+                              m->setup_error, sizeof(m->setup_error))) return;
+        launcher_model_set_rom(m, mounted);
+        return;
+    }
+    m->setup_error[0] = '\0';
     m->rom_present = path && path[0] != '\0';
     safe_copy(m->rom_full, sizeof(m->rom_full), m->rom_present ? path : "");
     m->rom_sha1_hex[0] = '\0';
@@ -1176,6 +1196,7 @@ static void run_verify(LauncherModel* m) {
             safe_copy(m->verify.region, sizeof(m->verify.region), dv.region);
             m->verify.iso_ok  = dv.iso_ok != 0;
             m->verify.verdict = dv.verdict;
+            m->verify.sbi_status = dv.sbi_status;
             m->verify.track_count = dv.track_count;
             m->verify.netplay_ok = dv.netplay_ok;
             safe_copy(m->verify.disc_fp, sizeof(m->verify.disc_fp), dv.disc_fp);

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -939,7 +939,7 @@ static bool lm_is_sbi_path(const char* path) {
 
 void launcher_model_set_disc_path(LauncherModel* m, int idx, const char* path) {
     if (!m || idx < 0 || idx >= m->num_discs) return;
-    char imported[1024] = {0};
+    char imported[sizeof(m->disc_path_override[0])] = {0};
     if (lm_is_sbi_path(path)) {
         const char* disc = launcher_model_disc_path(m, idx);
         m->setup_error[0] = '\0';
@@ -1084,7 +1084,7 @@ int launcher_model_autofill_sibling_discs(LauncherModel* m) {
 
 void launcher_model_set_rom(LauncherModel* m, const char* path) {
     if (lm_is_sbi_path(path)) {
-        char mounted[1024] = {0};
+        char mounted[sizeof(m->rom_full)] = {0};
         m->setup_error[0] = '\0';
         if (!m->rom_present || !m->import_sbi_cb) {
             safe_copy(m->setup_error, sizeof(m->setup_error),

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -132,6 +132,7 @@ typedef struct {
     int  netplay_ok;    // 1 = OK for online; 0 = TOC/cue policy failed
     char disc_fp[65];   // TOC fingerprint for lobby peer matching
     char netplay_detail[160];
+    int sbi_status; // RECOMP_SBI_* for the selected disc; zero for legacy hosts.
 } VerifyResult;
 
 typedef struct {
@@ -196,6 +197,7 @@ typedef struct {
     // When non-NULL these drive the REAL disc verdict + memcard block usage
     // (re-run on every disc/card change) instead of the placeholder synthesis.
     int (*disc_verify_cb)(const char* disc_path, RecompLauncherCDiscVerify* out);
+    int (*import_sbi_cb)(const char*, const char*, char*, size_t, char*, size_t);
     int (*memcard_inspect_cb)(const char* card_path, RecompLauncherCMemcard* out);
     int (*bios_verify_cb)(const char* bios_path, RecompLauncherCBiosVerify* out);
     /* Optional host flush for first-run picks (project-root bios.cfg / disc.cfg). */

--- a/src/consoles/psx/psx_profile.h
+++ b/src/consoles/psx/psx_profile.h
@@ -74,6 +74,7 @@ static const char* const kPsxDiscPatterns[] = {
     "*.cue",
     "*.bin",
     "*.car",
+    "*.sbi",
 };
 #define LNG_PSX_DISC_PATTERN_COUNT \
     ((int)(sizeof(kPsxDiscPatterns) / sizeof(kPsxDiscPatterns[0])))
@@ -125,7 +126,7 @@ static const SystemProfile kSystemProfilePsx = {
     /* screen_kind_names */ NULL,   /* legacy Raw/CRT/Composite/Trinitron set */
     /* screen_kind_count */ 0,
     /* rom_filter        */ { kPsxDiscPatterns, LNG_PSX_DISC_PATTERN_COUNT,
-                              "PlayStation disc (.cue/.bin/.car)" },
+                              "PlayStation disc / SBI (.cue/.bin/.car/.sbi)" },
     /* renderer_labels   */ NULL,
     /* hide_audio_freq   */ 0,
     /* brand             */ "brand_psx.tga",

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -831,6 +831,8 @@ struct RecompLauncherCSettings {
 // ---- host verification/inspection results (filled by the callbacks below) ----
 // Plain-C structs so a host can implement the callbacks with zero launcher
 // internal types. Mirror what the legacy launcher computed inline.
+#define RECOMP_LAUNCHER_HAS_SBI_STATUS 1
+enum { RECOMP_SBI_NA = 0, RECOMP_SBI_MISSING = 1, RECOMP_SBI_OK = 2 };
 typedef struct RecompLauncherCDiscVerify {
     char serial[16];   // e.g. "SCUS-94423"; "" = unknown/unread
     char region[8];    // e.g. "NTSC-U"; "" = unknown
@@ -841,6 +843,7 @@ typedef struct RecompLauncherCDiscVerify {
     int  netplay_ok;       // 1 = mount satisfies game.toml [netplay] policy
     char disc_fp[65];      // lowercase hex SHA-256 TOC fingerprint; "" if none
     char netplay_detail[160];
+    int sbi_status; // RECOMP_SBI_*; zero means no requirement recorded by host.
 } RecompLauncherCDiscVerify;
 
 /* Host BIOS check for the first-run setup wizard (has_bios games). */
@@ -1393,6 +1396,10 @@ typedef struct RecompLauncherCGameInfo {
     /* NDS input convenience setting. When set, Settings shows a Virtual Stylus
      * opt-out and the Controller page may expose host-owned bindings for it. */
     int has_virtual_stylus;
+    /* Optional host import: attach user-selected SBI to the current disc.
+     * Return a private mounted-disc path; never replace the disc with the SBI. */
+    int (*import_sbi)(const char* disc, const char* sbi, char* out_disc,
+                      size_t out_cap, char* error, size_t error_cap);
 } RecompLauncherCGameInfo;
 
 /* recomp_launcher_run_window return codes */

--- a/tests/launcher_discs_test.c
+++ b/tests/launcher_discs_test.c
@@ -154,6 +154,19 @@ static void test_sbi_verification_refresh(void) {
     fixture_import_ok = 1;
     launcher_model_set_rom(m, "matching.SBI");
     expect(!strcmp(m->rom_full, "imported.cue") && !m->setup_error[0], "accepted SBI selects its mounted CUE and clears error");
+    RecompLauncherCDisc roster[2] = {{0}};
+    roster[0].path = "selected.cue";
+    roster[1].path = "selected.cue";
+    m->discs = roster;
+    m->num_discs = 2;
+    m->disc_selected = 0;
+    fixture_import_ok = 0;
+    launcher_model_set_disc_path(m, 1, "matching.SBI");
+    expect(!strcmp(launcher_model_disc_path(m, 1), "selected.cue"), "rejected slot SBI preserves roster path");
+    fixture_import_ok = 1;
+    launcher_model_set_disc_path(m, 1, "matching.SBI");
+    expect(!strcmp(launcher_model_disc_path(m, 1), "imported.cue"), "slot SBI stores imported CUE, never the SBI");
+    expect(m->disc_selected == 0, "importing for another slot does not move the mount");
     free(m);
 }
 

--- a/tests/launcher_discs_test.c
+++ b/tests/launcher_discs_test.c
@@ -117,6 +117,15 @@ static int fixture_import_ok;
 static int fixture_import(const char* disc, const char* sbi, char* out, size_t cap, char* error, size_t error_cap) {
     expect(!strcmp(disc, "selected.cue"), "SBI callback receives the selected disc");
     expect(!strcmp(sbi, "matching.SBI"), "SBI suffix accepts uppercase");
+    if (fixture_import_ok == 2) {
+        if (cap <= 600) {
+            safe_copy(error, error_cap, "Imported disc path is too long");
+            return 0;
+        }
+        memset(out, 'x', 600);
+        out[600] = '\0';
+        return 1;
+    }
     if (!fixture_import_ok) {
         safe_copy(error, error_cap, "Wrong companion");
         return 0;
@@ -151,6 +160,10 @@ static void test_sbi_verification_refresh(void) {
     m->import_sbi_cb = fixture_import;
     launcher_model_set_rom(m, "matching.SBI");
     expect(!strcmp(m->rom_full, "selected.cue") && m->setup_error[0], "rejected SBI preserves the selected disc");
+    fixture_import_ok = 1;
+    fixture_import_ok = 2;
+    launcher_model_set_rom(m, "matching.SBI");
+    expect(!strcmp(m->rom_full, "selected.cue") && m->setup_error[0], "oversized imported path is rejected instead of truncated");
     fixture_import_ok = 1;
     launcher_model_set_rom(m, "matching.SBI");
     expect(!strcmp(m->rom_full, "imported.cue") && !m->setup_error[0], "accepted SBI selects its mounted CUE and clears error");

--- a/tests/launcher_discs_test.c
+++ b/tests/launcher_discs_test.c
@@ -104,10 +104,64 @@ static void test_autofill(const char* dir) {
     remove(p[2]);
 }
 
+static int fixture_sbi_status;
+static int fixture_verify(const char* path, RecompLauncherCDiscVerify* out) {
+    (void)path;
+    out->sbi_status = fixture_sbi_status;
+    out->iso_ok = 1;
+    out->verdict = fixture_sbi_status == RECOMP_SBI_MISSING ? 3 : 1;
+    return 1;
+}
+
+static int fixture_import_ok;
+static int fixture_import(const char* disc, const char* sbi, char* out, size_t cap, char* error, size_t error_cap) {
+    expect(!strcmp(disc, "selected.cue"), "SBI callback receives the selected disc");
+    expect(!strcmp(sbi, "matching.SBI"), "SBI suffix accepts uppercase");
+    if (!fixture_import_ok) {
+        safe_copy(error, error_cap, "Wrong companion");
+        return 0;
+    }
+    safe_copy(out, cap, "imported.cue");
+    return 1;
+}
+
+static void test_sbi_verification_refresh(void) {
+    LauncherModel* m = (LauncherModel*)calloc(1, sizeof(LauncherModel));
+    SystemProfile profile = {0};
+    if (!m) { ++fails; return; }
+    profile.verify.mode = 1;
+    m->profile = &profile;
+    m->rom_present = true;
+    m->disc_verify_cb = fixture_verify;
+    for (int status = RECOMP_SBI_MISSING; status <= RECOMP_SBI_OK; ++status) {
+        fixture_sbi_status = status;
+        run_verify(m);
+        expect(m->verify.sbi_status == status, "selected disc carries current SBI status");
+        expect(m->verify.verdict == (status == RECOMP_SBI_MISSING ? 3 : 1), "missing SBI fails disc verification");
+    }
+    fixture_sbi_status = RECOMP_SBI_NA;
+    run_verify(m);
+    expect(m->verify.sbi_status == RECOMP_SBI_NA, "unlisted disc clears previous SBI state");
+    m->rom_present = false;
+    run_verify(m);
+    expect(m->verify.sbi_status == RECOMP_SBI_NA, "empty selection clears SBI state");
+    launcher_model_set_rom(m, "matching.SBI");
+    expect(!m->rom_present && m->setup_error[0], "SBI without disc shows an error and keeps empty selection");
+    launcher_model_set_rom(m, "selected.cue");
+    m->import_sbi_cb = fixture_import;
+    launcher_model_set_rom(m, "matching.SBI");
+    expect(!strcmp(m->rom_full, "selected.cue") && m->setup_error[0], "rejected SBI preserves the selected disc");
+    fixture_import_ok = 1;
+    launcher_model_set_rom(m, "matching.SBI");
+    expect(!strcmp(m->rom_full, "imported.cue") && !m->setup_error[0], "accepted SBI selects its mounted CUE and clears error");
+    free(m);
+}
+
 int main(int argc, char** argv) {
     const char* dir = (argc > 1) ? argv[1] : ".";
     test_token_rewriting();
     test_autofill(dir);
+    test_sbi_verification_refresh();
     if (fails) { fprintf(stderr, "\n%d FAILED\n", fails); return 1; }
     printf("\nall passed\n");
     return 0;


### PR DESCRIPTION
Show SBI File beneath ISO header with Missing, N/A, or OK supplied by the host. Widen the label column so ISO header and its value remain separate. When the host provides the import callback, label the button Browse For Disc / SBI and accept SBI files through the PSX picker.

Selecting an SBI calls the host with the current disc. Success selects the returned mounted CUE; failure preserves the disc and displays the host error. Selecting an SBI before a disc gives a clear error. The callback and status extend the C structures, so consumers must rebuild against the new headers. N/A means the host recorded no requirement; it does not prove an unknown disc needs no subchannel data.

Companion framework PR: https://github.com/mstan/psxrecomp/pull/323. Rebased onto current master 655d77d5858aa677f88e7b19cd70460773a17476, preserving the newly appended NDS virtual-stylus field.

Validation on Windows / MinGW GCC 16.1 / SDL3:

- Standalone launcher and all test targets build.
- Disc-model test passes all 36 assertions, including uppercase SBI suffix, rejected selection preservation, successful imported-CUE selection, status refresh, multi-disc slots, and oversized imported paths.
- CTest: 10/11 tests pass. launcher-setup-bios fails its two path-string expectations identically on unchanged master; this is not introduced by the SBI change.
- Current framework setup host builds with this UI. The operator confirmed the missing-SBI warning, successful SBI selection, spacing, and RE3 gameplay in the separately recorded frozen-game build.

No Linux/macOS UI run is claimed. Host integration is documented in docs/SBI_INPUT.md.

Developed with AI assistance; validated as described (test evidence in PR body). AI writes the code and the PR, but I always test before I send something up. Happy to iterate on this process with your feedback.
