### PR TITLE
Call the host by its current name, Retro Launcher

### DIFF
--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -3407,7 +3407,7 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     //
     // Unlike the legacy NES row above, there is no folder picker here: which
     // pack is active is a per-title decision owned by the host's pack manager
-    // (RetComM's Texture Packs modal), which can list installed packs and show
+    // (Retro Launcher's Texture Packs modal), which can list installed packs and show
     // per-pack coverage. A second, blinder picker in this panel could only
     // fight it — so this panel does the one thing it is better placed to do,
     // which is flip the pack off and on without leaving the game.
@@ -10773,7 +10773,7 @@ static const char* generate_disabled_reason(const LauncherModel* m) {
         m->prepare_with_progress_cb != nullptr || m->prepare_disc_cb != nullptr;
     if (!has_prep) {
         return "Generate is unavailable (project/SDK not found).\n"
-               "Launch from RetComM, or run the game from its source tree "
+               "Launch from Retro Launcher, or run the game from its source tree "
                "(src/current).";
     }
     if (!m->rom_present || !m->rom_full[0])


### PR DESCRIPTION
The hub recomp-ui defers to for project/SDK discovery and pack management was renamed from **RetComM** to **Retro Launcher**, along with the repo it ships from.

Two strings here still used the old name, and one of them is on screen:

```
"Generate is unavailable (project/SDK not found).\n"
"Launch from RetComM, or run the game from its source tree (src/current)."
```

That tells the player to launch from something they cannot find any more. The other is a comment naming the host's Texture Packs modal.

No behaviour change — both are display text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013DpaQqVguHFpBuCmdoFYWY