### PR TITLE
launcher: Discord sign-in, LAN/online split, automatch UI, moderation controls, flash reduction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -76,6 +76,15 @@ if(BUILD_TESTING)
     target_include_directories(recomp-ui-ips-patch-test PRIVATE src/common)
     add_test(NAME recomp-ui-ips-patch COMMAND $<TARGET_FILE:recomp-ui-ips-patch-test>)
 
+    # The photosensitivity flash guard. Pure arithmetic on two ARGB frames --
+    # no SDL, no window, no ROM -- so it runs anywhere the rest of these do.
+    add_executable(recomp-ui-flash-guard-test
+        tests/flash_guard_test.c
+        src/common/recomp_flash_guard.c)
+    target_include_directories(recomp-ui-flash-guard-test PRIVATE src)
+    add_test(NAME recomp-ui-flash-guard
+             COMMAND $<TARGET_FILE:recomp-ui-flash-guard-test>)
+
     add_executable(recomp-ui-rom-patch-tool
         tools/rom_patch_tool.c
         src/common/ips_patch.c

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,6 +160,22 @@ if(BUILD_TESTING)
         COMMAND $<TARGET_FILE:recomp-ui-launcher-discs-test>
                 "${CMAKE_CURRENT_BINARY_DIR}")
 
+    # Renderer / VSync as enumerable lists rather than cycle buttons. Same
+    # include-the-TU shape as the discs test above.
+    add_executable(recomp-ui-launcher-video-pick-test
+        tests/launcher_video_pick_test.c
+        src/common/crc32.c
+        src/common/sha1.c
+        src/common/sha256.c
+        src/common/ips_patch.c
+        src/consoles/psx/memcard_format.c)
+    target_include_directories(recomp-ui-launcher-video-pick-test PRIVATE
+        src src/common src/consoles/psx)
+    target_link_libraries(recomp-ui-launcher-video-pick-test PRIVATE ${RUI_SDL_TARGET})
+    add_test(
+        NAME recomp-ui-launcher-video-pick
+        COMMAND $<TARGET_FILE:recomp-ui-launcher-video-pick-test>)
+
     # First-run wizard: staging a retail BIOS that has no linked backend.
     # Same include-the-TU shape as the discs test above.
     add_executable(recomp-ui-launcher-setup-bios-test

--- a/recomp_ui.cmake
+++ b/recomp_ui.cmake
@@ -159,6 +159,7 @@ function(recomp_target_launcher_ui TGT)
         ${RUI_SRC}/common/launcher_udp_port.c  # host-lobby UDP port probe / auto-pick
         ${RUI_SRC}/common/recomp_runtime_ui.c # renderer-agnostic in-game overlay
         ${RUI_SRC}/common/recomp_runtime_settings.c # shared cross-ecosystem setting catalog
+        ${RUI_SRC}/common/recomp_frame_blend.c # shared presentation blend (Settings.frame_blend)
         ${RUI_SRC}/common/launcher_boot_timing.c  # PSX_LAUNCHER_BOOT_TIMING / LNG_BOOT_TIMING
         ${RUI_SRC}/common/launcher_ng_capi.c   # implements recomp_launcher_run_window()
         ${RUI_SRC}/common/launcher_i18n.cpp

--- a/recomp_ui.cmake
+++ b/recomp_ui.cmake
@@ -160,6 +160,7 @@ function(recomp_target_launcher_ui TGT)
         ${RUI_SRC}/common/recomp_runtime_ui.c # renderer-agnostic in-game overlay
         ${RUI_SRC}/common/recomp_runtime_settings.c # shared cross-ecosystem setting catalog
         ${RUI_SRC}/common/recomp_frame_blend.c # shared presentation blend (Settings.frame_blend)
+        ${RUI_SRC}/common/recomp_flash_guard.c # shared photosensitivity flash filter
         ${RUI_SRC}/common/launcher_boot_timing.c  # PSX_LAUNCHER_BOOT_TIMING / LNG_BOOT_TIMING
         ${RUI_SRC}/common/launcher_ng_capi.c   # implements recomp_launcher_run_window()
         ${RUI_SRC}/common/launcher_i18n.cpp

--- a/recomp_ui.cmake
+++ b/recomp_ui.cmake
@@ -160,6 +160,7 @@ function(recomp_target_launcher_ui TGT)
         ${RUI_SRC}/common/recomp_runtime_ui.c # renderer-agnostic in-game overlay
         ${RUI_SRC}/common/recomp_runtime_settings.c # shared cross-ecosystem setting catalog
         ${RUI_SRC}/common/recomp_frame_blend.c # shared presentation blend (Settings.frame_blend)
+        ${RUI_SRC}/common/recomp_moderation.c # local ignore/block list (moderation.ini)
         ${RUI_SRC}/common/recomp_flash_guard.c # shared photosensitivity flash filter
         ${RUI_SRC}/common/launcher_boot_timing.c  # PSX_LAUNCHER_BOOT_TIMING / LNG_BOOT_TIMING
         ${RUI_SRC}/common/launcher_ng_capi.c   # implements recomp_launcher_run_window()

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -5367,11 +5367,103 @@ static bool np_name_refused(LauncherModel* m, const char* name) {
     return np->name_rejected(np->ctx, name) != 0;
 }
 
+/* Signing in is optional, and this draws the whole of it.
+ *
+ * A build with no account callbacks, a lobby server whose operator never set
+ * Discord up, and a player who simply does not sign in are all ordinary cases:
+ * the section is not drawn, the name field below is the locally-typed player
+ * name, and everything behaves as it did before Discord existed. Guest is not
+ * a lesser state here -- it is the original one.
+ *
+ * Returns true when the player is signed in, which is what decides whether the
+ * name field edits a LOCAL name or the server-owned handle. */
+static bool draw_account_section(LauncherModel* m, const LauncherTheme& th) {
+    const auto* np = np_cb(m);
+    if (!np || !np->account_state || !np->account_available) return false;
+    /* The server answers 503 to a login start when its operator has not
+     * configured Discord. Offering a button that cannot work is worse than
+     * offering none. */
+    if (!np->account_available(np->ctx)) return false;
+
+    const int st = np->account_state(np->ctx);
+    const bool signed_in = st == RECOMP_LAUNCHER_ACCOUNT_SIGNED_IN;
+
+    if (signed_in) {
+        const char* handle = np->account_handle ? np->account_handle(np->ctx) : "";
+        const char* uname = np->account_username ? np->account_username(np->ctx) : "";
+        char disp[128];
+        emoji_display(handle && handle[0] ? handle : "Signed in", disp, sizeof(disp));
+        ImGui::TextColored(col(th.text_muted), "Signed in as");
+        ImGui::SameLine(0, px(6));
+        ImGui::TextColored(col(th.good), "%s", disp);
+        if (uname && uname[0]) {
+            /* Discord display names are NOT unique, so the @handle is what
+             * tells two players with the same name apart. */
+            ImGui::SameLine(0, px(6));
+            ImGui::TextColored(col(th.text_muted), "@%s", uname);
+        }
+        if (ImGui::Button("Sign out", ImVec2(px(120), 0)) && np->account_sign_out) {
+            np->account_sign_out(np->ctx);
+            m->netplay_name_error[0] = '\0';
+        }
+    } else if (st == RECOMP_LAUNCHER_ACCOUNT_WAITING) {
+        ImGui::TextColored(col(th.accent2), "Waiting for Discord…");
+        ImGui::PushTextWrapPos(px(360));
+        ImGui::TextColored(col(th.text_muted),
+                           "Finish signing in on the page that opened in your "
+                           "browser, then come back here.");
+        ImGui::PopTextWrapPos();
+    } else {
+        ImGui::PushTextWrapPos(px(360));
+        ImGui::TextColored(col(th.text_muted),
+                           "Sign in with Discord so your name is yours across "
+                           "sessions. Optional — you can play as a guest.");
+        ImGui::PopTextWrapPos();
+        if (ImGui::Button("Sign in with Discord", ImVec2(px(200), 0)) &&
+            np->account_login_begin) {
+            if (np->account_login_begin(np->ctx) != 0) {
+                const char* e = np->account_error ? np->account_error(np->ctx) : nullptr;
+                std::snprintf(m->netplay_name_error, sizeof(m->netplay_name_error),
+                              "%s", e && e[0] ? e : "Could not start the sign-in.");
+            } else {
+                m->netplay_name_error[0] = '\0';
+            }
+        }
+        if (st == RECOMP_LAUNCHER_ACCOUNT_FAILED && np->account_error) {
+            const char* e = np->account_error(np->ctx);
+            if (e && e[0]) {
+                ImGui::PushTextWrapPos(px(360));
+                ImGui::TextColored(col(th.warn), "%s", e);
+                ImGui::PopTextWrapPos();
+            }
+        }
+    }
+    ImGui::Spacing();
+    ImGui::Separator();
+    ImGui::Spacing();
+    return signed_in;
+}
+
 void draw_netplay_player_modal(LauncherModel* m, const LauncherTheme& th) {
     if (m->netplay_name_modal_open) ImGui::OpenPopup("Player Name");
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
     ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
     if (ImGui::BeginPopupModal("Player Name", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        const bool signed_in = draw_account_section(m, th);
+        /* Signed in, the field edits the handle the SERVER owns; as a guest it
+         * edits the local player name, exactly as before. Seed it from the
+         * server's handle the first time, so the box shows what peers see. */
+        if (signed_in && !m->netplay_handle_seeded) {
+            const auto* npa = np_cb(m);
+            const char* h = (npa && npa->account_handle) ? npa->account_handle(npa->ctx) : "";
+            if (h && h[0])
+                std::snprintf(m->netplay_name_edit, sizeof(m->netplay_name_edit), "%s", h);
+            m->netplay_handle_seeded = true;
+        }
+        if (!signed_in) m->netplay_handle_seeded = false;
+        ImGui::TextColored(col(th.text_muted),
+                           signed_in ? "Display name (other players see this)"
+                                     : "Player name");
         ImGui::SetNextItemWidth(px(320));
         bool save = ImGui::InputText("##player_name", m->netplay_name_edit,
                                      sizeof(m->netplay_name_edit),
@@ -5408,6 +5500,26 @@ void draw_netplay_player_modal(LauncherModel* m, const LauncherTheme& th) {
             if (np_name_refused(m, m->netplay_name_edit)) {
                 std::snprintf(m->netplay_name_error, sizeof(m->netplay_name_error),
                               "That name can't be used. Please pick another one.");
+                ImGui::EndDisabled();
+                ImGui::EndPopup();
+                return;
+            }
+            if (signed_in) {
+                /* The server owns an account's name, so this is a request, not
+                 * a local write: it can be refused for the same reason a typed
+                 * name is, and the player picks another. */
+                const auto* npa = np_cb(m);
+                if (npa && npa->account_set_handle &&
+                    npa->account_set_handle(npa->ctx, m->netplay_name_edit) != 0) {
+                    std::snprintf(m->netplay_name_error, sizeof(m->netplay_name_error),
+                                  "That name can't be used. Please pick another one.");
+                    ImGui::EndDisabled();
+                    ImGui::EndPopup();
+                    return;
+                }
+                m->netplay_name_modal_open = false;
+                m->netplay_name_error[0] = '\0';
+                ImGui::CloseCurrentPopup();
                 ImGui::EndDisabled();
                 ImGui::EndPopup();
                 return;

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -21,6 +21,7 @@
 #include "launcher_panels.h"
 #include "launcher_system.h"
 #include "launcher_i18n.h"
+#include "recomp_moderation.h"   // local ignore/block list (online only)
 #include "consoles/n64/n64_binds.h"   // RUI_N64_FIELD_* for the pad-capture path
 
 #include "launcher_sdlcompat.h"   // pulls the right SDL header + event shim
@@ -867,6 +868,67 @@ static int emoji_input_callback(ImGuiInputTextCallbackData* data) {
  * provider renders as the real flag. Without a color provider the outline
  * font has no flags, so the code is shown in a muted "[JP]" instead of two
  * meaningless letter boxes. Draws nothing for an empty / malformed code. */
+/*
+ * Right-click a player: ignore them, or block them.
+ *
+ * ONLINE ONLY, and that gate is the point rather than a simplification. A LAN
+ * / Direct IP room has no lobby server, so nobody published an account id and
+ * there is nothing durable to key a list on -- a menu there could only offer
+ * to remember a name, which is precisely the thing that blocks the wrong
+ * person later. It is also a room of people who already know each other.
+ *
+ * A guest has no account either. They get the menu disabled with the reason
+ * shown, rather than silently doing nothing: "I clicked Block and it did not
+ * block" is a worse outcome than being told why.
+ *
+ * `account` is the key and `name` is only what to put in the menu header and
+ * store as a label.
+ */
+static void np_player_menu(LauncherModel* m, const LauncherTheme& th,
+                           const char* account, const char* name) {
+    if (m->netplay_mode != 2) return;   /* LAN/Direct IP has no accounts */
+    if (!ImGui::BeginPopupContextItem("##player_menu")) return;
+
+    char disp[96];
+    emoji_display((name && name[0]) ? name : "Player", disp, sizeof(disp));
+    ImGui::TextColored(col(th.text_muted), "%s", disp);
+    ImGui::Separator();
+
+    const bool has_key = account && account[0];
+    if (!has_key) {
+        ImGui::TextColored(col(th.text_muted),
+                           "Signed-out players cannot be ignored:");
+        ImGui::TextColored(col(th.text_muted),
+                           "there is no account to remember.");
+        ImGui::EndPopup();
+        return;
+    }
+
+    const RecompModLevel lvl = recomp_moderation_level(account);
+    bool ignored = lvl != RECOMP_MOD_NONE;
+    bool blocked = lvl == RECOMP_MOD_BLOCKED;
+
+    if (ImGui::MenuItem("Ignore Player", nullptr, ignored, !blocked)) {
+        recomp_moderation_set(account, name,
+                              ignored ? RECOMP_MOD_NONE : RECOMP_MOD_IGNORED);
+    }
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+        ImGui::SetTooltip(blocked ? "Already blocked, which includes this"
+                                  : "Hide their chat. They can still be in "
+                                    "your lobby.");
+    if (ImGui::MenuItem("Block Player", nullptr, blocked)) {
+        recomp_moderation_set(account, name,
+                              blocked ? RECOMP_MOD_NONE : RECOMP_MOD_BLOCKED);
+    }
+    if (ImGui::IsItemHovered())
+        ImGui::SetTooltip("Hide their chat, hide them from the lists, and ask "
+                          "the matchmaker not to pair you.");
+    ImGui::Separator();
+    if (ImGui::MenuItem("Moderation list..."))
+        m->netplay_moderation_modal_open = true;
+    ImGui::EndPopup();
+}
+
 static void np_draw_country_flag(const LauncherTheme& th, const char* cc) {
     if (!cc || !cc[0] || !cc[1]) return;
     const char a = (char)std::toupper((unsigned char)cc[0]);
@@ -5975,6 +6037,69 @@ void draw_netplay_automatch_modal(LauncherModel* m, const LauncherTheme& th) {
     }
 }
 
+/*
+ * The review list. Without it the only way to undo a block is editing a file
+ * by hand, which is not an undo -- and a moderation feature whose effects are
+ * invisible is one you stop trusting.
+ */
+void draw_netplay_moderation_modal(LauncherModel* m, const LauncherTheme& th) {
+    if (m->netplay_moderation_modal_open) ImGui::OpenPopup("Ignored & Blocked");
+    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(ImVec2(px(520), 0), ImGuiCond_Appearing);
+    if (!ImGui::BeginPopupModal("Ignored & Blocked", nullptr,
+                                ImGuiWindowFlags_AlwaysAutoResize))
+        return;
+
+    const int n = recomp_moderation_count();
+    if (n <= 0) {
+        ImGui::TextColored(col(th.text_muted),
+                           "Nobody is ignored or blocked.");
+        ImGui::TextColored(col(th.text_muted),
+                           "Right-click a player's name to add one.");
+    } else {
+        ImGui::TextColored(col(th.text_muted),
+                           "Names are only labels -- the list follows the "
+                           "account, so renaming does not escape it.");
+        ImGui::Spacing();
+        if (ImGui::BeginTable("##mod_list", 3,
+                              ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingStretchProp)) {
+            ImGui::TableSetupColumn("Player", ImGuiTableColumnFlags_WidthStretch, 1.0f);
+            ImGui::TableSetupColumn("State", ImGuiTableColumnFlags_WidthFixed, px(90));
+            ImGui::TableSetupColumn("", ImGuiTableColumnFlags_WidthFixed, px(90));
+            for (int i = 0; i < n; ++i) {
+                char key[RECOMP_MOD_KEY_CAP], name[RECOMP_MOD_NAME_CAP];
+                RecompModLevel lvl = RECOMP_MOD_NONE;
+                if (!recomp_moderation_get(i, key, sizeof(key), name, sizeof(name), &lvl))
+                    continue;
+                ImGui::PushID(i);
+                ImGui::TableNextRow();
+                ImGui::TableSetColumnIndex(0);
+                char disp[96];
+                emoji_display(name[0] ? name : "(unknown)", disp, sizeof(disp));
+                ImGui::TextUnformatted(disp);
+                ImGui::TableSetColumnIndex(1);
+                ImGui::TextColored(col(lvl == RECOMP_MOD_BLOCKED ? th.warn : th.text_muted),
+                                   "%s", lvl == RECOMP_MOD_BLOCKED ? "Blocked" : "Ignored");
+                ImGui::TableSetColumnIndex(2);
+                if (ImGui::Button("Remove", ImVec2(px(84), 0))) {
+                    recomp_moderation_set(key, name, RECOMP_MOD_NONE);
+                    ImGui::PopID();
+                    break;   /* the list shifted under us */
+                }
+                ImGui::PopID();
+            }
+            ImGui::EndTable();
+        }
+    }
+    ImGui::Spacing();
+    if (ImGui::Button("Close", ImVec2(px(120), 0))) {
+        m->netplay_moderation_modal_open = false;
+        ImGui::CloseCurrentPopup();
+    }
+    ImGui::EndPopup();
+}
+
 void draw_netplay_direct_modal(LauncherModel* m, const LauncherTheme& th) {
     if (m->netplay_direct_modal_open) ImGui::OpenPopup("Join Direct");
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
@@ -6945,6 +7070,12 @@ static void draw_lobby_seat_row(LauncherModel* m,
         ImGui::TextUnformatted(occ ? row.display_name
                                    : view.spectator ? "Open seat" : "Open slot");
         if (!occ) ImGui::PopStyleColor();
+        /* The third surface: a seat in the room. Blocked players are NOT
+         * hidden here -- you are already in a lobby with them, and a seat
+         * that silently vanishes is a room you cannot reason about. Their
+         * chat still goes, and the menu is how you get here from a name you
+         * only meet once you are seated. */
+        if (occ && !row.is_local) np_player_menu(m, th, row.account, row.display_name);
         /* Seat 1 (P2) — by seat, not by who hosts: seat 0 is always the sim
          * authority whose cards are the match cards. */
         if (!view.spectator && wire == 1 && occ && np->memcard_offer_set &&
@@ -8197,11 +8328,22 @@ static void draw_chat_panel(LauncherModel* m, const LauncherTheme& th,
                 ImGui::TextColored(col(th.text_muted), "%s", sys_disp);
                 continue;
             }
+            /* An ignored player's line is not drawn at all -- not greyed,
+             * not collapsed to "message hidden". The point of ignoring
+             * somebody is to stop seeing them, and a placeholder per line is
+             * still a conversation you are being made to watch. `newest` is
+             * updated above regardless, so a hidden line does not keep
+             * re-scrolling the log. Never your own. */
+            if (!msg.is_local && recomp_moderation_is_ignored(msg.account))
+                continue;
             char from_disp[128];
             char text_disp[640];
             emoji_display(msg.from[0] ? msg.from : "?", from_disp, sizeof(from_disp));
             emoji_display(msg.text, text_disp, sizeof(text_disp));
             ImGui::TextColored(col(msg.is_local ? th.good : th.accent), "%s", from_disp);
+            /* Right-click the NAME on a chat line, same as in the player
+             * list: it is the thing you point at when you mean "them". */
+            if (!msg.is_local) np_player_menu(m, th, msg.account, msg.from);
             ImGui::SameLine(0, px(6));
             ImGui::TextUnformatted(text_disp);
         }
@@ -8587,6 +8729,9 @@ static void draw_netplay_online_panel(LauncherModel* m, const LauncherTheme& th,
         for (int i = 0; i < n; ++i) {
             RecompLauncherCNetplayOnlinePlayer p{};
             if (!np->online_get(np->ctx, i, &p)) continue;
+            /* Blocked players are not shown at all -- that is what block
+             * means here. Never the local row, whatever the file says. */
+            if (!p.is_local && recomp_moderation_is_blocked(p.account)) continue;
             ImGui::PushID(i);
             ImGui::TableNextRow(ImGuiTableRowFlags_None, row_h);
             ImGui::TableSetColumnIndex(0);
@@ -8601,6 +8746,13 @@ static void draw_netplay_online_panel(LauncherModel* m, const LauncherTheme& th,
                 ImGui::TextColored(col(th.text_muted), "(you)");
             } else {
                 ImGui::TextUnformatted(disp);
+                /* Right-click the NAME, which is the thing a player points at
+                 * when they mean "that person". Never on your own row. */
+                np_player_menu(m, th, p.account, p.display_name);
+                if (recomp_moderation_is_ignored(p.account)) {
+                    ImGui::SameLine(0, px(4));
+                    ImGui::TextColored(col(th.text_muted), "(ignored)");
+                }
             }
             ImGui::TableSetColumnIndex(1);
             table_row_vcenter(row_h, text_h);
@@ -11946,6 +12098,7 @@ void draw_ui(LauncherModel* m, const LauncherTheme& th, int logical_w, int logic
     draw_netplay_password_modal(m, th);
     draw_netplay_direct_modal(m, th);
     draw_netplay_automatch_modal(m, th);
+    draw_netplay_moderation_modal(m, th);
     draw_restore_defaults_modal(m);
     // Transfer Pak config modal (N64): opened by any tile, dashboard or
     // Controller page. Drawn at root so it isn't clipped by a card child.
@@ -12467,6 +12620,11 @@ extern "C" LngAction launcher_backend_run(LauncherPlatform* p,
         asset("assets/fonts/OpenMoji-black-glyf.ttf");
     float applied_scale = 0.0f;
     launcher_debug_init();
+    /* The ignore/block list, from beside the executable. Loaded once here
+     * rather than lazily on the netplay page: the file is the authority for
+     * whether a chat line is drawn, and a page that renders before the first
+     * load would show a line the player has already asked never to see. */
+    recomp_moderation_load(asset("").c_str());
 
     long smoke_frames = 0, frame = 0;
     if (const char* sf = SDL_getenv("LNG_SMOKE_FRAMES")) smoke_frames = SDL_atoi(sf);

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -868,6 +868,8 @@ static int emoji_input_callback(ImGuiInputTextCallbackData* data) {
  * provider renders as the real flag. Without a color provider the outline
  * font has no flags, so the code is shown in a muted "[JP]" instead of two
  * meaningless letter boxes. Draws nothing for an empty / malformed code. */
+const RecompLauncherCNetplayCallbacks* np_cb(LauncherModel* m);   /* fwd */
+
 /*
  * Right-click a player: ignore them, or block them.
  *
@@ -885,7 +887,8 @@ static int emoji_input_callback(ImGuiInputTextCallbackData* data) {
  * store as a label.
  */
 static void np_player_menu(LauncherModel* m, const LauncherTheme& th,
-                           const char* account, const char* name) {
+                           const char* account, const char* name,
+                           const char* mid = nullptr) {
     if (m->netplay_mode != 2) return;   /* LAN/Direct IP has no accounts */
     if (!ImGui::BeginPopupContextItem("##player_menu")) return;
 
@@ -923,6 +926,37 @@ static void np_player_menu(LauncherModel* m, const LauncherTheme& th,
     if (ImGui::IsItemHovered())
         ImGui::SetTooltip("Hide their chat, hide them from the lists, and ask "
                           "the matchmaker not to pair you.");
+
+    /* Chat only, and only with an id.
+     *
+     * Ignoring and blocking are decisions about a PERSON and belong on any
+     * row that names one. A report is about a LINE -- the server records the
+     * words it relayed, not a person -- so it is offered where a line exists
+     * to point at, and nowhere else. Offering it on a seat row would leave
+     * the player choosing which of that person's messages they meant from a
+     * menu that never showed them one.
+     *
+     * A line with no id predates the server's message ids and cannot be
+     * reported at all: there is no referent both sides agree on. */
+    const auto* np_rep = np_cb(m);
+    if (mid && mid[0] && np_rep && np_rep->chat_report) {
+        ImGui::Separator();
+        if (ImGui::MenuItem("Report Message...")) {
+            std::snprintf(m->netplay_report_mid, sizeof(m->netplay_report_mid),
+                          "%s", mid);
+            std::snprintf(m->netplay_report_who, sizeof(m->netplay_report_who),
+                          "%s", (name && name[0]) ? name : "Player");
+            m->netplay_report_note[0] = '\0';
+            m->netplay_report_reason = 0;
+            m->netplay_report_status[0] = '\0';
+            m->netplay_report_modal_open = true;
+        }
+        if (ImGui::IsItemHovered())
+            ImGui::SetTooltip("Send this line to the server's moderation "
+                              "queue. The server records what IT relayed, "
+                              "not text from here.");
+    }
+
     ImGui::Separator();
     if (ImGui::MenuItem("Moderation list..."))
         m->netplay_moderation_modal_open = true;
@@ -6100,6 +6134,107 @@ void draw_netplay_moderation_modal(LauncherModel* m, const LauncherTheme& th) {
     ImGui::EndPopup();
 }
 
+/* The report dialog. A category and an optional sentence -- and NOT the text
+ * of the line, which the server already has and is the only copy that can be
+ * trusted (docs/MODERATION.md, "The one design decision that matters"). */
+void draw_netplay_report_modal(LauncherModel* m, const LauncherTheme& th) {
+    static const struct { const char* id; const char* label; } kReasons[] = {
+        { RECOMP_LAUNCHER_REPORT_HARASSMENT,     "Harassment" },
+        { RECOMP_LAUNCHER_REPORT_HATE_SPEECH,    "Hate speech" },
+        { RECOMP_LAUNCHER_REPORT_THREATS,        "Threats" },
+        { RECOMP_LAUNCHER_REPORT_SEXUAL_CONTENT, "Sexual content" },
+        { RECOMP_LAUNCHER_REPORT_SPAM,           "Spam" },
+        { RECOMP_LAUNCHER_REPORT_CHEATING,       "Cheating claim" },
+        { RECOMP_LAUNCHER_REPORT_OTHER,          "Something else" },
+    };
+    const int kReasonCount = (int)(sizeof(kReasons) / sizeof(kReasons[0]));
+
+    if (m->netplay_report_modal_open) ImGui::OpenPopup("Report Message");
+    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    ImGui::SetNextWindowSize(ImVec2(px(520), 0), ImGuiCond_Appearing);
+    if (!ImGui::BeginPopupModal("Report Message", nullptr,
+                                ImGuiWindowFlags_AlwaysAutoResize))
+        return;
+
+    char who[96];
+    emoji_display(m->netplay_report_who, who, sizeof(who));
+    ImGui::TextColored(col(th.text_muted), "Reporting a message from");
+    ImGui::SameLine(0, px(5));
+    ImGui::TextUnformatted(who);
+    ImGui::Spacing();
+
+    if (m->netplay_report_reason < 0 || m->netplay_report_reason >= kReasonCount)
+        m->netplay_report_reason = 0;
+    ImGui::TextColored(col(th.text_muted), "Reason");
+    ImGui::SetNextItemWidth(px(260));
+    if (ImGui::BeginCombo("##report_reason",
+                          kReasons[m->netplay_report_reason].label)) {
+        for (int i = 0; i < kReasonCount; ++i)
+            if (ImGui::Selectable(kReasons[i].label,
+                                  i == m->netplay_report_reason))
+                m->netplay_report_reason = i;
+        ImGui::EndCombo();
+    }
+
+    ImGui::Spacing();
+    ImGui::TextColored(col(th.text_muted), "Anything to add (optional)");
+    ImGui::SetNextItemWidth(px(460));
+    ImGui::InputTextWithHint("##report_note",
+                             "What happened, in a sentence",
+                             m->netplay_report_note,
+                             sizeof(m->netplay_report_note));
+
+    ImGui::Spacing();
+    /* Said plainly, because a reporter who thinks they are attaching their own
+     * copy of the words will word the note as though the message were not
+     * already in the record. */
+    ImGui::PushTextWrapPos(px(460));
+    ImGui::TextColored(col(th.text_muted),
+                       "The server already has the message and records its own "
+                       "copy, along with a little of the conversation around "
+                       "it. Nothing is sent from here except the reason and "
+                       "your note.");
+    ImGui::PopTextWrapPos();
+
+    if (m->netplay_report_status[0]) {
+        ImGui::Spacing();
+        ImGui::TextColored(col(th.warn), "%s", m->netplay_report_status);
+    }
+
+    ImGui::Spacing();
+    if (ImGui::Button("Cancel", ImVec2(px(120), 0))) {
+        m->netplay_report_modal_open = false;
+        ImGui::CloseCurrentPopup();
+    }
+    ImGui::SameLine();
+    const auto* np = np_cb(m);
+    const bool can_send = np && np->chat_report && m->netplay_report_mid[0];
+    ImGui::BeginDisabled(!can_send);
+    if (ImGui::Button("Send Report", ImVec2(px(150), 0))) {
+        const char* mids[1] = { m->netplay_report_mid };
+        const int rc = np->chat_report(np->ctx, mids, 1,
+                                       kReasons[m->netplay_report_reason].id,
+                                       m->netplay_report_note);
+        if (rc == 0) {
+            /* Handed over, which is not the same as accepted -- the server
+             * still refuses an expired line, a guest's line, your own, and
+             * anything over the rate limit. Saying "sent" rather than
+             * "received" is the honest half of that. */
+            m->netplay_report_modal_open = false;
+            ImGui::CloseCurrentPopup();
+            std::snprintf(m->netplay_status, sizeof(m->netplay_status),
+                          "Report sent to the moderation queue.");
+        } else {
+            std::snprintf(m->netplay_report_status,
+                          sizeof(m->netplay_report_status),
+                          "Could not send the report. Are you still connected?");
+        }
+    }
+    ImGui::EndDisabled();
+    ImGui::EndPopup();
+}
+
 void draw_netplay_direct_modal(LauncherModel* m, const LauncherTheme& th) {
     if (m->netplay_direct_modal_open) ImGui::OpenPopup("Join Direct");
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
@@ -8343,7 +8478,7 @@ static void draw_chat_panel(LauncherModel* m, const LauncherTheme& th,
             ImGui::TextColored(col(msg.is_local ? th.good : th.accent), "%s", from_disp);
             /* Right-click the NAME on a chat line, same as in the player
              * list: it is the thing you point at when you mean "them". */
-            if (!msg.is_local) np_player_menu(m, th, msg.account, msg.from);
+            if (!msg.is_local) np_player_menu(m, th, msg.account, msg.from, msg.mid);
             ImGui::SameLine(0, px(6));
             ImGui::TextUnformatted(text_disp);
         }
@@ -12099,6 +12234,7 @@ void draw_ui(LauncherModel* m, const LauncherTheme& th, int logical_w, int logic
     draw_netplay_direct_modal(m, th);
     draw_netplay_automatch_modal(m, th);
     draw_netplay_moderation_modal(m, th);
+    draw_netplay_report_modal(m, th);
     draw_restore_defaults_modal(m);
     // Transfer Pak config modal (N64): opened by any tile, dashboard or
     // Controller page. Drawn at root so it isn't clipped by a card child.

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -5444,6 +5444,10 @@ static bool draw_account_section(LauncherModel* m, const LauncherTheme& th) {
     return signed_in;
 }
 
+/* Defined with the other account helpers, below; used from here on. */
+static const char* np_effective_name(LauncherModel* m);
+static void np_open_name_modal(LauncherModel* m);
+
 void draw_netplay_player_modal(LauncherModel* m, const LauncherTheme& th) {
     if (m->netplay_name_modal_open) ImGui::OpenPopup("Player Name");
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
@@ -5451,16 +5455,8 @@ void draw_netplay_player_modal(LauncherModel* m, const LauncherTheme& th) {
     if (ImGui::BeginPopupModal("Player Name", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
         const bool signed_in = draw_account_section(m, th);
         /* Signed in, the field edits the handle the SERVER owns; as a guest it
-         * edits the local player name, exactly as before. Seed it from the
-         * server's handle the first time, so the box shows what peers see. */
-        if (signed_in && !m->netplay_handle_seeded) {
-            const auto* npa = np_cb(m);
-            const char* h = (npa && npa->account_handle) ? npa->account_handle(npa->ctx) : "";
-            if (h && h[0])
-                std::snprintf(m->netplay_name_edit, sizeof(m->netplay_name_edit), "%s", h);
-            m->netplay_handle_seeded = true;
-        }
-        if (!signed_in) m->netplay_handle_seeded = false;
+         * edits the local player name. The box is seeded by whoever opened
+         * this (np_open_name_modal), so it always starts on the right one. */
         ImGui::TextColored(col(th.text_muted),
                            signed_in ? "Display name (other players see this)"
                                      : "Player name");
@@ -5533,7 +5529,7 @@ void draw_netplay_player_modal(LauncherModel* m, const LauncherTheme& th) {
                           m->netplay_name_edit);
             if (update_lobby_name)
                 std::snprintf(m->netplay_host_name, sizeof(m->netplay_host_name),
-                              "%s's Lobby", m->s.netplay_player_name);
+                              "%s's Lobby", np_effective_name(m));
             const auto* np = np_cb(m);
             if (np && np->set_player_name) np->set_player_name(np->ctx, m->s.netplay_player_name);
             m->netplay_name_modal_open = false;
@@ -8277,6 +8273,39 @@ static void draw_netplay_online_panel(LauncherModel* m, const LauncherTheme& th,
  * play, so a LAN player is never asked for a Discord account, and neither is
  * anyone whose server offers no logins. */
 
+/* The name other players actually see for THIS client -- and it is not one
+ * value.
+ *
+ * Online it is the handle the SERVER owns, tied to the Discord account and
+ * defaulted from the Discord name; that is what appears in the seat table,
+ * the players-online panel and every chat line, because the server publishes
+ * it rather than trusting whatever the client sent. On LAN there is no
+ * account and no server, so it is the locally typed player name.
+ *
+ * Keeping them apart is the point: signing in must not overwrite the name
+ * somebody uses for LAN games, and renaming for LAN must not rename the
+ * account. The online one is stored server-side rather than here, which is
+ * also what lets it follow the player to another device with their key. */
+static const char* np_effective_name(LauncherModel* m) {
+    const auto* np = np_cb(m);
+    if (np && np->account_state && np->account_handle &&
+        np->account_state(np->ctx) == RECOMP_LAUNCHER_ACCOUNT_SIGNED_IN) {
+        const char* h = np->account_handle(np->ctx);
+        if (h && h[0]) return h;
+    }
+    return m->s.netplay_player_name;
+}
+
+/* Open the name editor seeded from whichever name it is about to edit. The
+ * openers used to stuff the LAN name in unconditionally, so a signed-in
+ * player opening it saw their LAN name over the top of their account. */
+static void np_open_name_modal(LauncherModel* m) {
+    std::snprintf(m->netplay_name_edit, sizeof(m->netplay_name_edit), "%s",
+                  np_effective_name(m));
+    m->netplay_name_error[0] = '\0';
+    m->netplay_name_modal_open = true;
+}
+
 /* True when the player is already signed in, so the sign-in page is skipped. */
 static bool np_account_signed_in(LauncherModel* m) {
     const auto* np = np_cb(m);
@@ -8498,9 +8527,13 @@ void draw_netplay(LauncherModel* m, const LauncherTheme& th) {
         np_load_network_settings(m);
         np_refresh_host_ip(m);
     }
-    if (!m->s.netplay_player_name[0] && !m->netplay_name_modal_open && !m->netplay_name_prompted) {
+    /* Only nag for a name when there is genuinely none. A signed-in player
+     * already has one -- the server's -- so asking them to invent a second is
+     * the bug this used to cause. */
+    if (!np_effective_name(m)[0] && !m->netplay_name_modal_open &&
+        !m->netplay_name_prompted) {
         m->netplay_name_prompted = true;
-        m->netplay_name_modal_open = true;
+        np_open_name_modal(m);
     }
     if (!m->netplay_list_fresh)
         np_refresh_lobby_list(m);
@@ -9896,8 +9929,8 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
                 std::snprintf(m->netplay_status, sizeof(m->netplay_status), "%s", why);
                 return;
             }
-            if (!m->s.netplay_player_name[0]) {
-                m->netplay_name_modal_open = true;
+            if (!np_effective_name(m)[0]) {
+                np_open_name_modal(m);
                 return;
             }
             np_connect_and_list(m);
@@ -9905,7 +9938,7 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
             np_refresh_host_ip(m);
             if (!m->netplay_host_name[0]) {
                 std::snprintf(m->netplay_host_name, sizeof(m->netplay_host_name),
-                              "%s's Lobby", m->s.netplay_player_name);
+                              "%s's Lobby", np_effective_name(m));
             }
             m->netplay_host_password[0] = '\0';
             m->netplay_host_modal_open = true;
@@ -11270,14 +11303,14 @@ void draw_ui(LauncherModel* m, const LauncherTheme& th, int logical_w, int logic
             if ((m->view == LNG_VIEW_NETPLAY ||
                  m->view == LNG_VIEW_NETPLAY_MODE) && m->netplay_supported) {
                 ImGui::SetCursorPos(ImVec2(right - w - name_w - gap, y));
-                const char* player_label = m->s.netplay_player_name[0]
-                    ? m->s.netplay_player_name : ui_text("Set player name");
-                if (ImGui::Button(player_label, ImVec2(name_w, px(34)))) {
-                    std::snprintf(m->netplay_name_edit,
-                                  sizeof(m->netplay_name_edit), "%s",
-                                  m->s.netplay_player_name);
-                    m->netplay_name_modal_open = true;
-                }
+                /* Signed in, this is the account's handle, not the LAN name:
+                 * it is what other players are actually seeing. */
+                const char* eff = np_effective_name(m);
+                char lbl[96];
+                emoji_display(eff && eff[0] ? eff : ui_text("Set player name"),
+                              lbl, sizeof(lbl));
+                if (ImGui::Button(lbl, ImVec2(name_w, px(34))))
+                    np_open_name_modal(m);
             }
             if (m->view == LNG_VIEW_LOBBY) {
                 /* No Back: you are seated, and the only way out of a seat is

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -6199,14 +6199,17 @@ void draw_netplay_host_modal(LauncherModel* m, const LauncherTheme& th) {
                                RECOMP_LAUNCHER_NETPLAY_MAX_SPECTATORS);
         }
         ImGui::Spacing();
-        bool lan = m->netplay_lan_only;
-        if (ImGui::Checkbox("LAN/Direct IP Only", &lan)) {
-            m->netplay_lan_only = lan;
-            /* Keep the enumerated interfaces + selection; only the enabled
-             * state changes. Refresh if we somehow have no list yet. */
-            if (m->netplay_local_address_count == 0)
-                np_refresh_host_ip(m);
-        }
+        /* No LAN/Direct-IP checkbox. The player already answered this question
+         * on the way in -- the mode page is literally "LAN / Direct IP" or
+         * "Online Netplay" -- and asking again inside the dialog offered them
+         * a third answer that contradicts the first. It defaulted to OFF in
+         * both modes, so hosting from the LAN page published an ONLINE room
+         * nobody on the LAN could see. open_host() sets the flag from the mode
+         * now, and this dialog only shows what follows from it.
+         *
+         * Spectators disappear with it in LAN mode, by the gate above: a
+         * peer-to-peer room has no server between the peers to drop a
+         * spectator's packets at, so the control was never honest there. */
         /* Advertised IP/Port: which NIC + port peers should use for LAN RTT /
          * Direct IP. Online still STUNs for a public endpoint; this pick is the
          * preferred LAN advertise / bind address. */
@@ -9003,6 +9006,16 @@ void draw_netplay(LauncherModel* m, const LauncherTheme& th) {
     if (m->netplay_status[0])
         ImGui::TextColored(col(th.warn), "%s", m->netplay_status);
     ImGui::Spacing();
+    /* Tell the backend which fork the player took before asking it anything.
+     * It merges its LAN registry and beacon rows with the server's list and
+     * has no other way to know: a LAN player was being shown online rooms
+     * they had no connection for, and an online player was shown LAN rooms
+     * from their own machine. */
+    if (np->list_scope_set) {
+        np->list_scope_set(np->ctx,
+                           m->netplay_mode == 1 ? RECOMP_LAUNCHER_LIST_SCOPE_LAN
+                                                : RECOMP_LAUNCHER_LIST_SCOPE_ONLINE);
+    }
     int rows = np->list_count ? np->list_count(np->ctx) : 0;
     /* Slim rows: a browser is a list to scan, not a form. The Join button
      * sets the floor. */
@@ -10420,8 +10433,12 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
                 np_open_name_modal(m);
                 return;
             }
-            np_connect_and_list(m);
-            m->netplay_lan_only = false;
+            /* The mode IS the answer: LAN hosts a LAN room, online hosts an
+             * online one. Connecting is online-only -- a LAN host dialling the
+             * lobby server would advertise the same room twice, once in the
+             * file registry and once on the server. */
+            m->netplay_lan_only = (m->netplay_mode == 1);
+            if (!m->netplay_lan_only) np_connect_and_list(m);
             np_refresh_host_ip(m);
             if (!m->netplay_host_name[0]) {
                 std::snprintf(m->netplay_host_name, sizeof(m->netplay_host_name),
@@ -10473,9 +10490,22 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
                  * tooltip: it is the number that says whether waiting is
                  * worth it, and a tooltip is not where you look for that. */
                 if (am_queued) {
-                    ImGui::SetCursorScreenPos(
-                        ImVec2(origin.x + fullw - action_w, cta_y + play_h + px(2)));
-                    ImGui::TextColored(col(th.text_muted), "%d waiting", am_pool);
+                    /* Painted straight onto the draw list rather than placed
+                     * as a widget. The footer is a fixed-height band whose
+                     * controls are positioned by hand, and an ImGui item below
+                     * the button still counts toward the window's content
+                     * size -- so this one line pushed the content past the
+                     * band and the whole page grew a scrollbar for the sake of
+                     * eight characters. There is room to draw it; there was no
+                     * room to lay it out. */
+                    char pool_text[32];
+                    std::snprintf(pool_text, sizeof(pool_text), "%d waiting",
+                                  am_pool);
+                    const float tw = ImGui::CalcTextSize(pool_text).x;
+                    ImGui::GetWindowDrawList()->AddText(
+                        ImVec2(origin.x + fullw - action_w + (action_w - tw) * 0.5f,
+                               cta_y + play_h + px(2)),
+                        imcol(th.text_muted), pool_text);
                 }
             }
         } else {

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -8267,6 +8267,187 @@ static void draw_netplay_online_panel(LauncherModel* m, const LauncherTheme& th,
     ImGui::PopStyleVar();
 }
 
+/* ---- the netplay fork --------------------------------------------------
+ * NETPLAY lands here, not on the lobby browser. The two kinds of netplay
+ * want different things and always did -- a LAN player has no use for a
+ * lobby list, and an online player has no use for a direct-IP box -- but the
+ * page used to show both to everyone and let them work it out.
+ *
+ * Signing in belongs on THIS side of the fork: it is only needed for online
+ * play, so a LAN player is never asked for a Discord account, and neither is
+ * anyone whose server offers no logins. */
+
+/* True when the player is already signed in, so the sign-in page is skipped. */
+static bool np_account_signed_in(LauncherModel* m) {
+    const auto* np = np_cb(m);
+    return np && np->account_state &&
+           np->account_state(np->ctx) == RECOMP_LAUNCHER_ACCOUNT_SIGNED_IN;
+}
+
+/* True when this build and this server can sign anybody in at all. When they
+ * cannot, ONLINE still works -- as a guest, exactly as it always has. */
+static bool np_account_offered(LauncherModel* m) {
+    const auto* np = np_cb(m);
+    return np && np->account_state && np->account_login_begin &&
+           np->account_available && np->account_available(np->ctx);
+}
+
+/* Go to the lobby browser, in the mode the player chose. */
+static void np_enter_netplay(LauncherModel* m, int mode) {
+    m->netplay_mode = mode;
+    m->netplay_list_fresh = false;
+    if (mode == 2) {
+        std::snprintf(m->netplay_status, sizeof(m->netplay_status),
+                      "Connecting to lobby server…");
+    } else {
+        m->netplay_status[0] = '\0';
+    }
+    launcher_model_set_view(m, LNG_VIEW_NETPLAY);
+}
+
+/* One big choice card. Sized to be hit with a controller, not just a mouse. */
+static bool np_mode_card(const LauncherTheme& th, const char* id, const char* title,
+                         const char* body, float w, bool accent) {
+    ImGui::PushID(id);
+    const float h = px(150);
+    const ImVec2 p = ImGui::GetCursorScreenPos();
+    ImDrawList* dl = ImGui::GetWindowDrawList();
+    const bool pressed = ImGui::InvisibleButton("##card", ImVec2(w, h));
+    const bool hot = ImGui::IsItemHovered() || ImGui::IsItemFocused();
+    dl->AddRectFilled(p, ImVec2(p.x + w, p.y + h),
+                      imcol(hot ? th.panel_hovered : th.panel), px(10));
+    dl->AddRect(p, ImVec2(p.x + w, p.y + h),
+                imcol(hot ? (accent ? th.accent : th.focus_ring) : th.border),
+                px(10), 0, hot ? 2.0f : 1.0f);
+    ImGui::SetCursorScreenPos(ImVec2(p.x + px(20), p.y + px(18)));
+    ImGui::PushStyleColor(ImGuiCol_Text, col(accent ? th.accent2 : th.text));
+    ImGui::PushFont(nullptr);
+    ImGui::TextUnformatted(title);
+    ImGui::PopFont();
+    ImGui::PopStyleColor();
+    ImGui::SetCursorScreenPos(ImVec2(p.x + px(20), p.y + px(50)));
+    ImGui::PushTextWrapPos(p.x + w - px(20));
+    ImGui::TextColored(col(th.text_muted), "%s", body);
+    ImGui::PopTextWrapPos();
+    ImGui::SetCursorScreenPos(ImVec2(p.x, p.y + h + px(14)));
+    ImGui::PopID();
+    return pressed;
+}
+
+void draw_netplay_mode_page(LauncherModel* m, const LauncherTheme& th) {
+    const float avail_w = ImGui::GetContentRegionAvail().x;
+    const float card_w = avail_w > px(900) ? px(420) : (avail_w - px(30)) * 0.5f;
+
+    ImGui::TextColored(col(th.accent2), "NETPLAY");
+    ImGui::Spacing();
+    ImGui::PushTextWrapPos(avail_w > px(760) ? px(760) : avail_w);
+    ImGui::TextColored(col(th.text_muted),
+                       "How do you want to play? You can change this any time "
+                       "by coming back here.");
+    ImGui::PopTextWrapPos();
+    ImGui::Dummy(ImVec2(0, px(18)));
+
+    const ImVec2 row = ImGui::GetCursorScreenPos();
+    if (np_mode_card(th, "lan", "LAN / Direct IP",
+                     "Play with someone on your network, or connect straight to "
+                     "an address they give you. No account, no lobby server.",
+                     card_w, false)) {
+        np_enter_netplay(m, 1);
+    }
+
+    ImGui::SetCursorScreenPos(ImVec2(row.x + card_w + px(24), row.y));
+    const bool offered = np_account_offered(m);
+    if (np_mode_card(th, "online", "Online Netplay",
+                     offered
+                       ? "Find players on the lobby server. Sign in with Discord "
+                         "so your name is yours across sessions."
+                       : "Find players on the lobby server. This server does not "
+                         "offer sign-in, so you will play as a guest.",
+                     card_w, true)) {
+        /* Skip the sign-in page when there is nothing to sign in to, or when
+         * this machine is already signed in -- which is the normal case after
+         * the first time, because the stored device key is redeemed silently
+         * at startup. */
+        if (!offered || np_account_signed_in(m)) {
+            np_enter_netplay(m, 2);
+        } else {
+            launcher_model_set_view(m, LNG_VIEW_NETPLAY_SIGNIN);
+        }
+    }
+
+    ImGui::SetCursorScreenPos(ImVec2(row.x, row.y + px(190)));
+    if (offered && np_account_signed_in(m)) {
+        const auto* np = np_cb(m);
+        const char* h = np->account_handle ? np->account_handle(np->ctx) : "";
+        char disp[128];
+        emoji_display(h && h[0] ? h : "", disp, sizeof(disp));
+        ImGui::TextColored(col(th.text_muted), "Signed in as");
+        ImGui::SameLine(0, px(6));
+        ImGui::TextColored(col(th.good), "%s", disp);
+    }
+}
+
+/* The sign-in page. Only ever reached on the way to online play. */
+void draw_netplay_signin_page(LauncherModel* m, const LauncherTheme& th) {
+    const auto* np = np_cb(m);
+    const int st = (np && np->account_state) ? np->account_state(np->ctx)
+                                             : RECOMP_LAUNCHER_ACCOUNT_GUEST;
+    const float wrap = px(640);
+
+    /* Signed in -- by this page, or by the device key redeeming in the
+     * background while the player was reading it. Either way there is nothing
+     * left to do here. */
+    if (st == RECOMP_LAUNCHER_ACCOUNT_SIGNED_IN) {
+        np_enter_netplay(m, 2);
+        return;
+    }
+
+    ImGui::TextColored(col(th.accent2), "SIGN IN");
+    ImGui::Spacing();
+    ImGui::PushTextWrapPos(wrap);
+    ImGui::TextColored(col(th.text),
+                       "Signing in with Discord gives you a name that is yours "
+                       "across sessions and devices, on this server and any "
+                       "other that uses it.");
+    ImGui::Spacing();
+    ImGui::TextColored(col(th.text_muted),
+                       "It is optional. You can play online as a guest and pick "
+                       "a name yourself — you will just get a new identity every "
+                       "time you reconnect.");
+    ImGui::PopTextWrapPos();
+    ImGui::Dummy(ImVec2(0, px(16)));
+
+    if (st == RECOMP_LAUNCHER_ACCOUNT_WAITING) {
+        ImGui::TextColored(col(th.accent2), "Waiting for Discord…");
+        ImGui::PushTextWrapPos(wrap);
+        ImGui::TextColored(col(th.text_muted),
+                           "Finish signing in on the page that opened in your "
+                           "browser. This screen will move on by itself.");
+        ImGui::PopTextWrapPos();
+    } else {
+        if (ImGui::Button("Sign in with Discord", ImVec2(px(240), px(40))) &&
+            np && np->account_login_begin) {
+            np->account_login_begin(np->ctx);
+        }
+        if (st == RECOMP_LAUNCHER_ACCOUNT_FAILED && np && np->account_error) {
+            const char* e = np->account_error(np->ctx);
+            if (e && e[0]) {
+                ImGui::Spacing();
+                ImGui::PushTextWrapPos(wrap);
+                ImGui::TextColored(col(th.warn), "%s", e);
+                ImGui::PopTextWrapPos();
+            }
+        }
+    }
+
+    ImGui::Dummy(ImVec2(0, px(20)));
+    if (ImGui::Button("Continue as guest", ImVec2(px(200), px(34))))
+        np_enter_netplay(m, 2);
+    ImGui::SameLine(0, px(12));
+    if (ImGui::Button("Back", ImVec2(px(120), px(34))))
+        launcher_model_set_view(m, LNG_VIEW_NETPLAY_MODE);
+}
+
 void draw_netplay(LauncherModel* m, const LauncherTheme& th) {
     const auto* np = np_cb(m);
     if (!np) return;
@@ -8302,7 +8483,12 @@ void draw_netplay(LauncherModel* m, const LauncherTheme& th) {
     /* Two columns when the backend reports who is online: the lobby table
      * on the left, the players panel on the right. A LAN-only backend has
      * no presence and keeps the full width. */
-    const bool has_online = np->online_count && np->online_get;
+    /* A LAN player picked LAN. The lobby server's half of this page -- the
+     * players-online panel and the per-game server chat -- is about people on
+     * a server they are not using, so it is not drawn. The lobby list, Host
+     * Lobby and Join Direct stay: those are how a LAN room is made. */
+    const bool lan_mode = m->netplay_mode == 1;
+    const bool has_online = !lan_mode && np->online_count && np->online_get;
     const float avail_w = ImGui::GetContentRegionAvail().x;
     const float side_gap = px(20);
     const float side_w = px(300);
@@ -8310,7 +8496,7 @@ void draw_netplay(LauncherModel* m, const LauncherTheme& th) {
     const float list_w = two_col ? avail_w - side_w - side_gap : avail_w;
     /* The per-game server chat takes a band across the bottom; the list and
      * the players panel share what is above it. */
-    const bool has_schat = np_server_chat_available(np);
+    const bool has_schat = !lan_mode && np_server_chat_available(np);
     const float schat_h = px(230);
     const float schat_gap = px(10);
     const float avail_h = ImGui::GetContentRegionAvail().y;
@@ -9760,12 +9946,10 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
         const float net_w = px(170.0f);
         ImGui::SetCursorScreenPos(ImVec2(play_x - net_w - px(12.0f), cta_y));
         if (ImGui::Button(ui_text("NETPLAY"), ImVec2(net_w, play_h))) {
-            /* Open the page immediately; connect/list runs on first draw
-             * (and continues off-thread) so Windows DNS/TCP never freezes UI. */
-            m->netplay_list_fresh = false;
-            std::snprintf(m->netplay_status, sizeof(m->netplay_status),
-                          "Connecting to lobby server…");
-            launcher_model_set_view(m, LNG_VIEW_NETPLAY);
+            /* The fork first. Connecting used to start here, which meant a LAN
+             * player dialled a lobby server they were never going to use --
+             * np_enter_netplay does it now, and only for online. */
+            launcher_model_set_view(m, LNG_VIEW_NETPLAY_MODE);
         }
     }
     ImGui::SetCursorScreenPos(ImVec2(play_x, cta_y));
@@ -11042,7 +11226,8 @@ void draw_ui(LauncherModel* m, const LauncherTheme& th, int logical_w, int logic
         } else {
             const float w = px(110.0f);
             const float name_w = px(170.0f);
-            if (m->view == LNG_VIEW_NETPLAY && m->netplay_supported) {
+            if ((m->view == LNG_VIEW_NETPLAY ||
+                 m->view == LNG_VIEW_NETPLAY_MODE) && m->netplay_supported) {
                 ImGui::SetCursorPos(ImVec2(right - w - name_w - gap, y));
                 const char* player_label = m->s.netplay_player_name[0]
                     ? m->s.netplay_player_name : ui_text("Set player name");
@@ -11068,8 +11253,16 @@ void draw_ui(LauncherModel* m, const LauncherTheme& th, int logical_w, int logic
                 (void)w;
             } else {
                 ImGui::SetCursorPos(ImVec2(right - w, y));
-                if (ImGui::Button(ui_text("< Back"), ImVec2(w, px(34))))
-                    launcher_model_set_view(m, LNG_VIEW_DASHBOARD);
+                if (ImGui::Button(ui_text("< Back"), ImVec2(w, px(34)))) {
+                    /* Retrace the netplay fork rather than dropping to the
+                     * dashboard from the middle of it: the browser and the
+                     * sign-in page were both reached through the chooser. */
+                    if (m->view == LNG_VIEW_NETPLAY ||
+                        m->view == LNG_VIEW_NETPLAY_SIGNIN)
+                        launcher_model_set_view(m, LNG_VIEW_NETPLAY_MODE);
+                    else
+                        launcher_model_set_view(m, LNG_VIEW_DASHBOARD);
+                }
             }
         }
         // Absolute placement prevents three dashboard buttons from mutating
@@ -11101,6 +11294,8 @@ void draw_ui(LauncherModel* m, const LauncherTheme& th, int logical_w, int logic
         case LNG_VIEW_SETTINGS:   draw_settings(m, th);             break;
         case LNG_VIEW_CONTROLLER: draw_controller(m, th);           break;
         case LNG_VIEW_NETPLAY:    draw_netplay(m, th);              break;
+        case LNG_VIEW_NETPLAY_MODE:   draw_netplay_mode_page(m, th);   break;
+        case LNG_VIEW_NETPLAY_SIGNIN: draw_netplay_signin_page(m, th); break;
         case LNG_VIEW_MODS:       draw_mods(m, th);                 break;
         case LNG_VIEW_ASSIST_TOOLS: draw_assist_tools(m, th);        break;
         case LNG_VIEW_CREDITS:      draw_credits(m, th);             break;

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -8413,13 +8413,45 @@ void draw_netplay_mode_page(LauncherModel* m, const LauncherTheme& th) {
 
     ImGui::SetCursorScreenPos(ImVec2(row.x + card_w + px(24), row.y));
     const bool offered = np_account_offered(m);
-    if (np_mode_card(th, "online", "Online Netplay",
-                     offered
-                       ? "Find players on the lobby server. Sign in with Discord "
-                         "so your name is yours across sessions."
-                       : "Find players on the lobby server. This server does not "
-                         "offer sign-in, so you will play as a guest.",
-                     card_w, true)) {
+    const auto* npa = np_cb(m);
+    const int acct = (npa && npa->account_state) ? npa->account_state(npa->ctx)
+                                                 : RECOMP_LAUNCHER_ACCOUNT_GUEST;
+
+    /* Hold ONLINE until the quiet sign-in has actually answered.
+     *
+     * The pump above redeems a stored netplay_secret in the background, and
+     * that takes a round-trip. Clicking during it read as "not signed in" and
+     * sent the player to the Discord sign-in page -- to sign in again, on a
+     * machine that already had a valid credential and was a moment away from
+     * using it. WAITING is exactly "an answer is coming"; GUEST after the
+     * pump means there was no secret to redeem, and that needs no wait.
+     *
+     * Bounded, because an unanswerable network must not lock anyone out of
+     * netplay entirely. Five seconds is generous for one HTTP round-trip with
+     * nobody in the loop -- unlike the sign-in page's ten, which is waiting on
+     * a human in a browser. After that the card unlocks and says the sign-in
+     * is still going; the player can go on as a guest, and if it lands later
+     * the lobby picks up the name from the pump anyway. */
+    static double quiet_signin_since = 0.0;
+    const double now_t = ImGui::GetTime();
+    const bool awaiting = offered && acct == RECOMP_LAUNCHER_ACCOUNT_WAITING;
+    if (!awaiting) quiet_signin_since = 0.0;
+    else if (quiet_signin_since <= 0.0) quiet_signin_since = now_t;
+    const bool stalled = awaiting && (now_t - quiet_signin_since > 5.0);
+    const bool hold_online = awaiting && !stalled;
+
+    const char* online_body =
+        !offered ? "Find players on the lobby server. This server does not "
+                   "offer sign-in, so you will play as a guest."
+        : hold_online ? "Checking your saved sign-in\u2026"
+        : "Find players on the lobby server. Sign in with Discord "
+          "so your name is yours across sessions.";
+
+    ImGui::BeginDisabled(hold_online);
+    const bool online_hit = np_mode_card(th, "online", "Online Netplay",
+                                         online_body, card_w, true);
+    ImGui::EndDisabled();
+    if (online_hit) {
         /* Skip the sign-in page when there is nothing to sign in to, or when
          * this machine is already signed in -- which is the normal case after
          * the first time, because the stored device key is redeemed silently
@@ -8431,15 +8463,30 @@ void draw_netplay_mode_page(LauncherModel* m, const LauncherTheme& th) {
         }
     }
 
+    /* Say which of the three it is, rather than only the happy one. A player
+     * who is a guest because the redemption FAILED was previously told
+     * nothing at all, and had no way to tell that apart from never having
+     * signed in. */
     ImGui::SetCursorScreenPos(ImVec2(row.x, row.y + px(190)));
-    if (offered && np_account_signed_in(m)) {
-        const auto* np = np_cb(m);
-        const char* h = np->account_handle ? np->account_handle(np->ctx) : "";
+    if (offered && acct == RECOMP_LAUNCHER_ACCOUNT_SIGNED_IN) {
+        const char* h = npa->account_handle ? npa->account_handle(npa->ctx) : "";
         char disp[128];
         emoji_display(h && h[0] ? h : "", disp, sizeof(disp));
         ImGui::TextColored(col(th.text_muted), "Signed in as");
         ImGui::SameLine(0, px(6));
         ImGui::TextColored(col(th.good), "%s", disp);
+    } else if (awaiting) {
+        ImGui::TextColored(col(th.text_muted),
+                           stalled ? "Still checking your saved sign-in \u2014 you can "
+                                     "continue as a guest."
+                                   : "Checking your saved sign-in\u2026");
+    } else if (offered && acct == RECOMP_LAUNCHER_ACCOUNT_FAILED) {
+        const char* err = npa->account_error ? npa->account_error(npa->ctx) : "";
+        ImGui::PushTextWrapPos(px(760));
+        ImGui::TextColored(col(th.warn), "Not signed in%s%s",
+                           (err && err[0]) ? " \u2014 " : "",
+                           (err && err[0]) ? err : "");
+        ImGui::PopTextWrapPos();
     }
 }
 

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -1324,11 +1324,21 @@ void kv(const char* k, const char* v, const LauncherTheme& th,
         ImGui::TextUnformatted(b); ImGui::PopStyleColor();
     }
 }
-void stepper(const char* id, int value, const char* suffix, int* out_delta) {
+// `total_w` > 0 stretches the value field so the whole widget measures exactly
+// that — which is what lets a right-anchored stepper line its LEFT edge up
+// with the dropdowns above it instead of floating a few pixels inside them.
+// 0 keeps the natural width every other caller has always had.
+void stepper(const char* id, int value, const char* suffix, int* out_delta,
+             float total_w = 0.0f) {
     ImGui::PushID(id);
-    const float bh = px(30), fw = px(58);
-    if (ImGui::Button("-", ImVec2(px(32), bh))) *out_delta = -5;
-    ImGui::SameLine(0, px(6));
+    const float bh = px(30), bw = px(32), gap = px(6);
+    float fw = px(58);
+    if (total_w > 0.0f) {
+        const float want = total_w - bw * 2.0f - gap * 2.0f;
+        if (want > fw) fw = want;
+    }
+    if (ImGui::Button("-", ImVec2(bw, bh))) *out_delta = -5;
+    ImGui::SameLine(0, gap);
     // value centered in a fixed-width field so "+" never shifts with the digits
     char buf[32]; snprintf(buf, sizeof(buf), "%d%s", value, suffix);
     float cx = ImGui::GetCursorPosX();
@@ -1337,8 +1347,8 @@ void stepper(const char* id, int value, const char* suffix, int* out_delta) {
     ImGui::AlignTextToFramePadding();
     ImGui::TextUnformatted(buf);
     ImGui::SameLine(0, 0);
-    ImGui::SetCursorPosX(cx + fw + px(6));
-    if (ImGui::Button("+", ImVec2(px(32), bh))) *out_delta = +5;
+    ImGui::SetCursorPosX(cx + fw + gap);
+    if (ImGui::Button("+", ImVec2(bw, bh))) *out_delta = +5;
     ImGui::PopID();
 }
 
@@ -1357,6 +1367,130 @@ void row_label(const char* text, const LauncherTheme& th, float col_w = 0.0f) {
     } else {
         ImGui::SameLine(0.0f, px(th.spacing_md));  // flow from label width (no fixed-x overlap)
     }
+}
+
+/*
+ * "Label ....................... [control]" — the label at the card's left
+ * edge, the control pushed out to its RIGHT edge.
+ *
+ * The settings cards used to align on the LEFT of the control column
+ * (row_label's col_w), which meant the caller had to measure every label in
+ * the card first and pass the widest, and a card's controls then floated in
+ * the middle with dead space to their right. Anchoring to the right edge
+ * needs no measuring pass at all -- it reads off the card's own width -- and
+ * a card whose rows all use the same control width comes out flush on BOTH
+ * sides, which is the grid the col_w pass was trying to build.
+ *
+ * `ctrl_w` is the width the caller is about to draw: px(SETTINGS_CTRL_W) for
+ * the shared button/dropdown width, ImGui::GetFrameHeight() for a checkbox
+ * (they are square), or a bespoke width for a row that needs one. A label too
+ * long to leave room keeps a minimum gap and lets its control run wide rather
+ * than colliding with the text.
+ */
+void row_label_right(const char* text, const LauncherTheme& th, float ctrl_w) {
+    ImGui::AlignTextToFramePadding();
+    ImGui::TextColored(col(th.text_muted), "%s", ui_text(text));
+    ImGui::SameLine(0.0f, 0.0f);
+    float shift = ImGui::GetContentRegionAvail().x - ctrl_w;
+    const float min_gap = px(th.spacing_md);
+    if (shift < min_gap) shift = min_gap;
+    ImGui::SetCursorPosX(ImGui::GetCursorPosX() + shift);
+}
+
+/* One width for every button and dropdown in the Display and Audio cards, so
+ * right-anchoring also lines their left edges up. Wide enough for the longest
+ * value any of them shows ("Borderless", "Adaptive", "2 frames", "32000 Hz").
+ * Rows whose value cannot fit -- a screen model, a file path -- pass their own
+ * width to row_label_right instead. */
+#define SETTINGS_CTRL_W 150.0f
+
+/*
+ * False while the window is too narrow to run DISPLAY and AUDIO side by side,
+ * so the settings cards stack in one column. draw_settings sets it each frame;
+ * the card drawers read it, because a STACKED card must hug its content — the
+ * legacy fixed band exists only to make two side-by-side cards the same
+ * height, and pinning it in one column leaves a tall empty region under a
+ * short card.
+ *
+ * A file-scope flag rather than a parameter: the panel registry's draw
+ * signature is the generic (model, theme) shared by every view, and threading
+ * one layout bit through all of it to reach two call sites would be worse.
+ */
+bool g_settings_two_col = true;
+
+/* One entry of a settings dropdown: the stored value and what it reads as. */
+struct SettingsChoice { int value; const char* label; };
+
+/*
+ * A labelled dropdown row: right-anchored combo over a fixed list of choices.
+ * Returns the value the player picked this frame, or `current` when they
+ * picked nothing, so the caller commits through its own model setter.
+ *
+ * Cycle buttons were fine when a setting had two or three states, but the
+ * player cannot see what the other states ARE without pressing through them,
+ * and a wrap-around list has no "back". A dropdown shows the whole set and
+ * puts every entry one click away -- which is what Renderer and VSync already
+ * did, so this is the control the card was already half using.
+ */
+int settings_combo_row(const char* label, const LauncherTheme& th,
+                       const char* id, const SettingsChoice* choices,
+                       int count, int current) {
+    const char* current_label = "";
+    for (int i = 0; i < count; ++i)
+        if (choices[i].value == current) { current_label = choices[i].label; break; }
+
+    row_label_right(label, th, px(SETTINGS_CTRL_W));
+    ImGui::SetNextItemWidth(px(SETTINGS_CTRL_W));
+    int picked = current;
+    if (ImGui::BeginCombo(id, ui_text(current_label))) {
+        for (int i = 0; i < count; ++i)
+            if (ImGui::Selectable(ui_text(choices[i].label),
+                                  choices[i].value == current))
+                picked = choices[i].value;
+        ImGui::EndCombo();
+    }
+    return picked;
+}
+
+/* Window scale reads as "1x".."6x". Spelled out rather than formatted per
+ * frame so the list is plain data, like every other choice list here. */
+static const SettingsChoice kScaleChoices[LNG_WINDOW_SCALE_MAX] = {
+    {1, "1x"}, {2, "2x"}, {3, "3x"}, {4, "4x"}, {5, "5x"}, {6, "6x"}
+};
+static const SettingsChoice kFullscreenChoices[] = {
+    {0, "Off"}, {1, "Borderless"}, {2, "Exclusive"}
+};
+static const SettingsChoice kRunAheadChoices[RECOMP_LAUNCHER_RUN_AHEAD_MAX + 1] = {
+    {0, "Off"}, {1, "1 frame"}, {2, "2 frames"}, {3, "3 frames"}, {4, "4 frames"}
+};
+
+/* The three rows those lists drive, so the legacy and deep Display surfaces
+ * cannot drift apart in what they offer. */
+void row_window_scale(LauncherModel* m, const LauncherTheme& th) {
+    launcher_model_set_scale(
+        m, settings_combo_row("Window scale", th, "##window_scale",
+                              kScaleChoices, LNG_WINDOW_SCALE_MAX,
+                              m->s.window_scale < 1 ? 1 : m->s.window_scale));
+}
+
+void row_fullscreen(LauncherModel* m, const LauncherTheme& th) {
+    launcher_model_set_fullscreen(
+        m, settings_combo_row("Fullscreen", th, "##fullscreen",
+                              kFullscreenChoices, 3, m->s.fullscreen));
+}
+
+void row_run_ahead(LauncherModel* m, const LauncherTheme& th) {
+    launcher_model_set_run_ahead(
+        m, settings_combo_row("Run-ahead", th, "##run_ahead", kRunAheadChoices,
+                              RECOMP_LAUNCHER_RUN_AHEAD_MAX + 1,
+                              m->s.run_ahead));
+    if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal))
+        ImGui::SetTooltip(
+            "Emulate ahead and show a frame from the future, so\n"
+            "the game's own input lag is hidden. Each frame of depth\n"
+            "costs one extra emulated frame -- start at 1.\n\n"
+            "Local only: the runtime turns it off during netplay,\n"
+            "where a peer's input cannot be predicted.");
 }
 
 // ---- views -----------------------------------------------------------------
@@ -2804,6 +2938,7 @@ bool video_card_grows(const LauncherModel* m) {
     if (m->has_shader) return true;
     if (m->has_sharp_filter || m->has_affine_filter) return true;
     if (m->has_frame_blend || m->has_vsync) return true;
+    if (m->has_run_ahead) return true;
     if (m->num_display_layouts > 0) return true;
     // NES legacy-surface additions (Integer scaling row, HD texture pack block)
     // add extra rows the fixed no_scroll band wasn't sized for.
@@ -2880,41 +3015,18 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     eyebrow("DISPLAY");
 
     if (!any_deep_display(m)) {
-        // ---- legacy minimal surface (SNES/NES etc.) — aligned label grid -------
-        float cw = ImGui::CalcTextSize("Linear filtering").x;
-        if (m->has_sharp_filter) {
-            float t = ImGui::CalcTextSize("Scaling filter").x;
-            if (t > cw) cw = t;
-        }
-        if (m->has_affine_filter) {
-            float t = ImGui::CalcTextSize("Affine background smoothing").x;
-            if (t > cw) cw = t;
-        }
-        if (m->has_frame_blend) {
-            float t = ImGui::CalcTextSize("Frame blending").x;
-            if (t > cw) cw = t;
-        }
-        if (m->has_shader) {
-            float t = ImGui::CalcTextSize("Shader").x;
-            if (t > cw) cw = t;
-        }
-        if (m->has_integer_scale) { float t = ImGui::CalcTextSize("Integer scaling").x; if (t > cw) cw = t; }
-        cw += px(18.0f);
-        row_label("Window scale", th, cw);
-        ImGui::PushID("window_scale");
-        if (ImGui::Button(ui_text(launcher_model_scale_label(m)), ImVec2(px(120), px(30))))
-            launcher_model_cycle_scale(m);
-        ImGui::PopID();
-        // Universal fullscreen row (every console; tri-state cycle restoring
-        // the legacy launcher's Off/Borderless/Exclusive vocabulary). Sits
-        // right under Window scale, matching the old Display panel order.
-        row_label("Fullscreen", th, cw);
-        ImGui::PushID("fullscreen");
-        if (ImGui::Button(ui_text(launcher_model_fullscreen_label(m)), ImVec2(px(120), px(30))))
-            launcher_model_cycle_fullscreen(m);
-        ImGui::PopID();
+        // ---- legacy minimal surface (SNES/NES etc.) ---------------------------
+        // Labels at the left edge, controls at the right (row_label_right), so
+        // no measuring pass over the labels is needed and the card reads as a
+        // grid flush on both sides.
+        const float cb = ImGui::GetFrameHeight();   // a checkbox is square
+        row_window_scale(m, th);
+        // Universal fullscreen row (every console; Off/Borderless/Exclusive,
+        // the legacy launcher's vocabulary). Sits right under Window scale,
+        // matching the old Display panel order.
+        row_fullscreen(m, th);
         if (m->num_display_layouts > 0) {
-            row_label("Screen layout", th, cw);
+            row_label_right("Screen layout", th, px(180));
             ImGui::PushID("screen_layout");
             if (ImGui::Button(ui_text(launcher_model_display_layout_label(m)),
                               ImVec2(px(180), px(30))))
@@ -2922,29 +3034,29 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
             ImGui::PopID();
         }
         if (m->has_integer_scale) {   // NES module: snap the image to integer multiples
-            row_label("Integer scaling", th, cw);
+            row_label_right("Integer scaling", th, cb);
             bool is = m->s.integer_scale != 0;
             if (ImGui::Checkbox("##intscale", &is)) launcher_model_toggle_integer_scale(m);
         }
         if (m->has_sharp_filter) {
-            row_label("Scaling filter", th, cw);
+            row_label_right("Scaling filter", th, px(180));
             if (ImGui::Button(ui_text(launcher_model_scaling_filter_label(m)),
                               ImVec2(px(180), px(30))))
                 launcher_model_cycle_scaling_filter(m);
         } else {
-            row_label("Linear filtering", th, cw);
+            row_label_right("Linear filtering", th, cb);
             bool filter = m->s.linear_filter != 0;
             if (ImGui::Checkbox("##filter", &filter))
                 launcher_model_toggle_filter(m);
         }
         if (m->has_affine_filter) {
-            row_label("Affine background smoothing", th, cw);
+            row_label_right("Affine background smoothing", th, cb);
             bool affine = m->s.affine_filter != 0;
             if (ImGui::Checkbox("##affine_filter", &affine))
                 launcher_model_toggle_affine_filter(m);
         }
         if (m->has_frame_blend) {
-            row_label("Frame blending", th, cw);
+            row_label_right("Frame blending", th, cb);
             bool fb = m->s.frame_blend != 0;
             if (ImGui::Checkbox("##frame_blend", &fb))
                 launcher_model_toggle_frame_blend(m);
@@ -2955,11 +3067,12 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
                     "(thrusters, explosions) as a CRT would; costs a\n"
                     "little motion ghosting.");
         }
-        // On/Off checkbox rather than the deep surface's tri-state cycle:
+        if (m->has_run_ahead) row_run_ahead(m, th);
+        // On/Off checkbox rather than the deep surface's tri-state dropdown:
         // legacy-surface hosts map this onto a boolean renderer flag, so
         // offering "Adaptive" here would promise what they cannot deliver.
         if (m->has_vsync) {
-            row_label("VSync", th, cw);
+            row_label_right("VSync", th, cb);
             bool vs = m->s.vsync != RECOMP_LAUNCHER_VSYNC_OFF;
             if (ImGui::Checkbox("##vsync", &vs))
                 launcher_model_toggle_vsync(m);
@@ -2971,7 +3084,10 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
                     "The runtime still paces frames to the console's own "
                     "rate either way, so Off does not run the game fast.");
         }
-        draw_shader_row(m, th, cw);
+        // The shader row is a compound control (combo + Browse/Folder/Clear)
+        // that already fills to the card's right edge, so it flows from its
+        // label rather than reserving a fixed control width.
+        draw_shader_row(m, th);
         // HD texture packs (NES module, Mesen hires.txt format): one line —
         //   [x] HD texture pack   …folder tail   [Browse]
         // Mirrors the MSU-1 row in Audio (same enable + folder pattern).
@@ -3002,23 +3118,21 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     // Supersampling, Aspect ratio, Texture filtering, Antialiasing, Screen
     // model, Frame interpolation (+Presentation target), Skip FMVs, Turbo
     // loads, Fullscreen.
+    // Labels left, controls right (row_label_right), same as the legacy card.
+    const float cb = ImGui::GetFrameHeight();   // a checkbox is square
     if (m->has_window_size) {
-        row_label("Window size", th);
-        if (ImGui::Button(ui_text(launcher_model_window_size_label(m)), ImVec2(px(150), px(30))))
+        row_label_right("Window size", th, px(SETTINGS_CTRL_W));
+        if (ImGui::Button(ui_text(launcher_model_window_size_label(m)), ImVec2(px(SETTINGS_CTRL_W), px(30))))
             launcher_model_cycle_window_size(m);
     } else {
-        row_label("Window scale", th);
-        ImGui::PushID("window_scale");
-        if (ImGui::Button(ui_text(launcher_model_scale_label(m)), ImVec2(px(120), px(30))))
-            launcher_model_cycle_scale(m);
-        ImGui::PopID();
+        row_window_scale(m, th);
     }
 
     // NES module rows can appear on this branch too (has_renderer puts NES
     // on the deep surface): integer scaling right under the window row,
     // mirroring the legacy branch's ordering.
     if (m->has_integer_scale) {
-        row_label("Integer scaling", th);
+        row_label_right("Integer scaling", th, cb);
         bool is = m->s.integer_scale != 0;
         if (ImGui::Checkbox("##intscale", &is)) launcher_model_toggle_integer_scale(m);
     }
@@ -3028,8 +3142,8 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
          * hosts that supply their own (Auto / D3D11 / D3D9 / OpenGL /
          * Software), and reaching the last one by clicking through the other
          * four is not a choice a player should have to count out. */
-        row_label("Renderer", th);
-        ImGui::SetNextItemWidth(px(220));
+        row_label_right("Renderer", th, px(SETTINGS_CTRL_W));
+        ImGui::SetNextItemWidth(px(SETTINGS_CTRL_W));
         if (ImGui::BeginCombo("##renderer",
                               ui_text(launcher_model_renderer_label(m)))) {
             const int n = launcher_model_renderer_count(m);
@@ -3044,9 +3158,9 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     }
 
     if (m->has_supersampling) {
-        row_label("Supersampling", th);
+        row_label_right("Supersampling", th, px(SETTINGS_CTRL_W));
         ImGui::PushID("supersampling");
-        if (ImGui::Button(ui_text(launcher_model_supersampling_label(m)), ImVec2(px(120), px(30))))
+        if (ImGui::Button(ui_text(launcher_model_supersampling_label(m)), ImVec2(px(SETTINGS_CTRL_W), px(30))))
             launcher_model_cycle_supersampling(m);
         ImGui::PopID();
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
@@ -3059,15 +3173,15 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     }
 
     // Universal fullscreen row (every console — no longer gated on the
-    // vestigial has_fullscreen_toggle). Tri-state cycle replaces the old
-    // binary checkbox so Exclusive mode is reachable again.
-    row_label("Fullscreen", th);
-    ImGui::PushID("fullscreen");
-        if (ImGui::Button(ui_text(launcher_model_fullscreen_label(m)), ImVec2(px(120), px(30))))
-        launcher_model_cycle_fullscreen(m);
-    ImGui::PopID();
+    // vestigial has_fullscreen_toggle). A tri-state dropdown, so Exclusive is
+    // both reachable and visible without pressing through the other two.
+    row_fullscreen(m, th);
     if (m->num_display_layouts > 0) {
-        row_label("Screen layout", th);
+        /* Wider than the shared column: these labels come from the HOST, not
+         * from a vocabulary this file owns, and a button (unlike a combo) does
+         * not elide -- so it keeps the room the widest stock layout name
+         * needs. Right-anchored like every other row regardless. */
+        row_label_right("Screen layout", th, px(180));
         ImGui::PushID("screen_layout");
         if (ImGui::Button(ui_text(launcher_model_display_layout_label(m)),
                           ImVec2(px(180), px(30))))
@@ -3076,22 +3190,22 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     }
 
     if (m->has_sharp_filter) {
-        row_label("Scaling filter", th);
+        row_label_right("Scaling filter", th, px(SETTINGS_CTRL_W));
         if (ImGui::Button(ui_text(launcher_model_scaling_filter_label(m)),
-                          ImVec2(px(180), px(30))))
+                          ImVec2(px(SETTINGS_CTRL_W), px(30))))
             launcher_model_cycle_scaling_filter(m);
     } else if (m->has_texture_filter) {
-        row_label("Texture filtering", th);
-        if (ImGui::Button(ui_text(launcher_model_texture_filter_label(m)), ImVec2(px(120), px(30))))
+        row_label_right("Texture filtering", th, px(SETTINGS_CTRL_W));
+        if (ImGui::Button(ui_text(launcher_model_texture_filter_label(m)), ImVec2(px(SETTINGS_CTRL_W), px(30))))
             launcher_model_toggle_texture_filter(m);
     } else {
-        row_label("Linear filtering", th);
+        row_label_right("Linear filtering", th, cb);
         bool filter = m->s.linear_filter != 0;
         if (ImGui::Checkbox("##filter", &filter)) launcher_model_toggle_filter(m);
     }
 
     if (m->has_frame_blend) {
-        row_label("Frame blending", th);
+        row_label_right("Frame blending", th, cb);
         bool fb = m->s.frame_blend != 0;
         if (ImGui::Checkbox("##frame_blend", &fb))
             launcher_model_toggle_frame_blend(m);
@@ -3104,9 +3218,9 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     }
 
     if (m->has_antialiasing) {
-        row_label("Antialiasing", th);
+        row_label_right("Antialiasing", th, px(SETTINGS_CTRL_W));
         ImGui::PushID("antialiasing");
-        if (ImGui::Button(ui_text(launcher_model_aa_label(m)), ImVec2(px(90), px(30))))
+        if (ImGui::Button(ui_text(launcher_model_aa_label(m)), ImVec2(px(SETTINGS_CTRL_W), px(30))))
             launcher_model_cycle_aa(m);
         ImGui::PopID();
     }
@@ -3116,13 +3230,13 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
      * window, and the good answer differs between the two. Antialiasing off
      * means nearest everywhere, so the row has nothing to say then. */
     if (m->has_fmv_filter) {
-        row_label("FMV filtering", th);
+        row_label_right("FMV filtering", th, px(SETTINGS_CTRL_W));
         ImGui::PushID("fmv_filter");
         const bool aa_off = m->has_antialiasing && m->s.antialiasing == 0;
         if (aa_off) ImGui::BeginDisabled();
         if (ImGui::Button(ui_text(aa_off ? "Nearest"
                                          : launcher_model_fmv_filter_label(m)),
-                          ImVec2(px(120), px(30))))
+                          ImVec2(px(SETTINGS_CTRL_W), px(30))))
             launcher_model_cycle_fmv_filter(m);
         if (aa_off) {
             ImGui::EndDisabled();
@@ -3134,7 +3248,7 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     }
 
     if (m->has_affine_filter) {
-        row_label("Affine background smoothing", th);
+        row_label_right("Affine background smoothing", th, cb);
         bool affine = m->s.affine_filter != 0;
         if (ImGui::Checkbox("##affine_filter", &affine))
             launcher_model_toggle_affine_filter(m);
@@ -3155,7 +3269,7 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
         // Perspective textures are unaffected by that problem: they only change
         // UV interpolation inside a polygon whose provenance is already proven,
         // so no vertex moves and adjacent polygons cannot disagree about an edge.
-        row_label("Perspective textures", th);
+        row_label_right("Perspective textures", th, cb);
         bool persp = m->s.perspective_texturing != 0;
         if (ImGui::Checkbox("##persptex", &persp))
             launcher_model_toggle_perspective_texturing(m);
@@ -3168,7 +3282,7 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     }
 
     if (m->has_screen_kind) {
-        row_label("Screen model", th);
+        row_label_right("Screen model", th, px(220));
         // Wide enough for the longest label ("Super Game Boy (No Border)");
         // shorter models (e.g. "DMG") center within the same fixed box.
         if (ImGui::Button(ui_text(launcher_model_screen_kind_label(m)), ImVec2(px(220), px(30))))
@@ -3179,12 +3293,12 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     // interpolation pass); Presentation target only matters once frame
     // interpolation is actually on.
     if (m->has_frame_interp && m->s.renderer) {
-        row_label("Frame interpolation", th);
+        row_label_right("Frame interpolation", th, cb);
         bool fi = m->s.frame_interp != 0;
         if (ImGui::Checkbox("##fi", &fi)) launcher_model_toggle_frame_interp(m);
         if (m->s.frame_interp) {
-            row_label("Presentation target", th);
-            if (ImGui::Button(ui_text(launcher_model_interp_fps_label(m)), ImVec2(px(150), px(30))))
+            row_label_right("Presentation target", th, px(SETTINGS_CTRL_W));
+            if (ImGui::Button(ui_text(launcher_model_interp_fps_label(m)), ImVec2(px(SETTINGS_CTRL_W), px(30))))
                 launcher_model_cycle_interp_fps(m);
         }
     }
@@ -3192,8 +3306,8 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     // VSync sits with frame interpolation because both decide how a finished
     // frame reaches the panel, not how it is drawn.
     if (m->has_vsync) {
-        row_label("VSync", th);
-        ImGui::SetNextItemWidth(px(120));
+        row_label_right("VSync", th, px(SETTINGS_CTRL_W));
+        ImGui::SetNextItemWidth(px(SETTINGS_CTRL_W));
         if (ImGui::BeginCombo("##vsync_mode",
                               ui_text(launcher_model_vsync_label(m)))) {
             static const struct { int v; const char* label; } kVsync[] = {
@@ -3218,13 +3332,13 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     }
 
     if (m->has_skip_fmv) {
-        row_label("Skip FMVs", th);
+        row_label_right("Skip FMVs", th, cb);
         bool sk = m->s.auto_skip_fmv != 0;
         if (ImGui::Checkbox("##skipfmv", &sk)) launcher_model_toggle_skip_fmv(m);
     }
 
     if (m->has_rewind_depth) {
-        row_label("Rewind", th);
+        row_label_right("Rewind", th, cb);
         bool rewind_on = m->s.rewind_enabled != 0;
         if (ImGui::Checkbox("##rewind_enabled", &rewind_on))
             launcher_model_toggle_rewind_enabled(m);
@@ -3237,8 +3351,8 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
         }
         /* The two tuning rows only mean anything once it is on. */
         ImGui::BeginDisabled(!rewind_on);
-        row_label("Rewind buffer", th);
-        if (ImGui::Button(ui_text(launcher_model_rewind_depth_label(m)), ImVec2(px(100), px(30))))
+        row_label_right("Rewind buffer", th, px(SETTINGS_CTRL_W));
+        if (ImGui::Button(ui_text(launcher_model_rewind_depth_label(m)), ImVec2(px(SETTINGS_CTRL_W), px(30))))
             launcher_model_cycle_rewind_depth(m);
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
             ImGui::SetTooltip(
@@ -3246,8 +3360,8 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
                 "Each one is a few MB of machine state.\n"
                 "Takes effect on the next launch.");
         }
-        row_label("Rewind interval", th);
-        if (ImGui::Button(ui_text(launcher_model_rewind_interval_label(m)), ImVec2(px(100), px(30))))
+        row_label_right("Rewind interval", th, px(SETTINGS_CTRL_W));
+        if (ImGui::Button(ui_text(launcher_model_rewind_interval_label(m)), ImVec2(px(SETTINGS_CTRL_W), px(30))))
             launcher_model_cycle_rewind_interval(m);
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
             ImGui::SetTooltip(
@@ -3257,6 +3371,11 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
         }
         ImGui::EndDisabled();
     }
+
+    /* Run-ahead sits with Rewind rather than with the filters: both spend
+     * machine snapshots to move the player in time, and neither changes how
+     * a frame is drawn. */
+    if (m->has_run_ahead) row_run_ahead(m, th);
 
     /* Turbo loads is deliberately NOT a Display row on any console. Load
      * acceleration is owned by the framework's Mods catalog (Fast Loading /
@@ -3308,7 +3427,7 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
 void panel_video_draw(LauncherModel* m, const LauncherTheme* th) {
     // video_card_grows() folds in NES's legacy-surface additions (Integer
     // scaling row, HD texture pack block) alongside the deep/widescreen surfaces.
-    if (video_card_grows(m)) {
+    if (video_card_grows(m) || !g_settings_two_col) {
         if (begin_panel("disp", 0, false)) draw_display_controls(m, *th);
         end_panel();
     } else {
@@ -3319,27 +3438,30 @@ void panel_video_draw(LauncherModel* m, const LauncherTheme* th) {
 
 void draw_audio_controls(LauncherModel* m, const LauncherTheme& th) {
     eyebrow("AUDIO");
-    // Fixed label column so the sample-rate button, the volume stepper's "-",
-    // and the SPU toggle all share the same left edge (aligned grid).
-    float cw = ImGui::CalcTextSize("Sample rate").x;
-    if (m->has_spu_hq) { float t = ImGui::CalcTextSize("High-quality SPU").x; if (t > cw) cw = t; }
-    cw += px(18.0f);
+    // Labels at the card's left edge, controls at its right (row_label_right),
+    // matching DISPLAY. Every control is SETTINGS_CTRL_W wide -- including the
+    // volume stepper, which stretches its value field to reach it -- so the
+    // column is flush on both sides.
+    const float cb = ImGui::GetFrameHeight();   // a checkbox is square
     // Sample rate: hidden for consoles whose runtime has no audio-frequency
     // setting (SystemProfile.hide_audio_freq — NES has Volume only).
     const SystemProfile* audio_prof = (const SystemProfile*)m->profile;
     if (!audio_prof || !audio_prof->hide_audio_freq) {
-        row_label("Sample rate", th, cw);
-        if (ImGui::Button(ui_text(launcher_model_freq_label(m)), ImVec2(px(120), px(30))))
+        row_label_right("Sample rate", th, px(SETTINGS_CTRL_W));
+        if (ImGui::Button(ui_text(launcher_model_freq_label(m)),
+                          ImVec2(px(SETTINGS_CTRL_W), px(30))))
             launcher_model_cycle_freq(m);
     }
-    row_label("Volume", th, cw);
-    int dv = 0; stepper("vol", m->s.volume, "%", &dv);
+    row_label_right("Volume", th, px(SETTINGS_CTRL_W));
+    int dv = 0; stepper("vol", m->s.volume, "%", &dv, px(SETTINGS_CTRL_W));
     if (dv) launcher_model_volume_delta(m, dv);
 
     // Output-device pick (host-enumerated names; N64/RT64 hosts) — "(system
     // default)" first, committing "" so an unplugged device degrades sanely.
+    // A device name is far longer than a setting value, so this row keeps the
+    // full-width combo on its own rather than squeezing into the column.
     if (m->num_audio_devices > 0 && m->audio_device_labels) {
-        row_label("Output device", th, cw);
+        row_label("Output device", th);
         ImGui::SetNextItemWidth(ImGui::GetContentRegionAvail().x);
         if (ImGui::BeginCombo("##audiodev", ui_text(launcher_model_audio_device_label(m)))) {
             if (ImGui::Selectable(ui_text("(system default)"), m->s.audio_device[0] == '\0'))
@@ -3356,7 +3478,7 @@ void draw_audio_controls(LauncherModel* m, const LauncherTheme& th) {
     }
 
     if (m->has_spu_hq) {
-        row_label("High-quality SPU", th, cw);
+        row_label_right("High-quality SPU", th, cb);
         bool hq = m->s.spu_hq != 0;
         if (ImGui::Checkbox("##spuhq", &hq)) launcher_model_toggle_spu_hq(m);
     }
@@ -3403,8 +3525,8 @@ void draw_audio_controls(LauncherModel* m, const LauncherTheme& th) {
     if (m->num_languages > 0) {
         ImGui::Dummy(ImVec2(0, px(6)));
         eyebrow("LOCALIZATION");
-        row_label("Language", th);
-        if (ImGui::Button(ui_text(launcher_model_language_label(m)), ImVec2(px(140), px(30))))
+        row_label_right("Language", th, px(SETTINGS_CTRL_W));
+        if (ImGui::Button(ui_text(launcher_model_language_label(m)), ImVec2(px(SETTINGS_CTRL_W), px(30))))
             launcher_model_cycle_language(m);
     }
 }
@@ -3414,7 +3536,7 @@ void draw_audio_controls(LauncherModel* m, const LauncherTheme& th) {
 // to compute inline.
 void panel_audio_draw(LauncherModel* m, const LauncherTheme* th) {
     const bool deep_audio = m->has_spu_hq || m->num_languages > 0 || m->num_audio_devices > 0;   /* deadzone moved to controller card */
-    if (deep_audio) {
+    if (deep_audio || !g_settings_two_col) {
         if (begin_panel("audio", 0, false)) draw_audio_controls(m, *th);
         end_panel();
     } else {
@@ -3806,10 +3928,30 @@ void draw_settings(LauncherModel* m, const LauncherTheme& th) {
     // never has to be threaded through the generic draw(model,theme) signature.)
     const SystemProfile* prof = (const SystemProfile*)m->profile;
     const float gap  = px(th.spacing_md);
-    const float half = (ImGui::GetContentRegionAvail().x - gap) * 0.5f;
     const float row_h = px(240.0f);   // legacy fixed band height (4 rows: the
                                       // universal Fullscreen row joined scale/
                                       // filter/widescreen on the legacy surface)
+
+    /*
+     * Two columns, until half the window is too narrow to hold a settings row.
+     *
+     * A row is a label plus a control anchored to the card's right edge, so
+     * the card has a real floor: below it the label and the control collide
+     * (row_label_right's minimum gap wins and the control overhangs), which
+     * is worse than reading the same rows one column at a time. Past that
+     * floor AUDIO drops to a full-width card UNDER DISPLAY rather than being
+     * squeezed beside it, and every SIDE card follows it down the same
+     * single column.
+     *
+     * The floor is measured, not guessed: the longest label the shared cards
+     * draw, plus the control column, plus the card's own padding.
+     */
+    const float full_w = ImGui::GetContentRegionAvail().x;
+    const float col_floor = ImGui::CalcTextSize("Affine background smoothing").x +
+                            px(SETTINGS_CTRL_W) + px(th.spacing_md) * 3.0f;
+    const bool two_col = (full_w - gap) * 0.5f >= col_floor;
+    const float half = two_col ? (full_w - gap) * 0.5f : full_w;
+    g_settings_two_col = two_col;   // read by panel_video_draw/panel_audio_draw
 
     const bool deep_display = video_card_grows(m);   // superset of any_deep_display: folds in NES + widescreen (N64 covered too)
     const bool deep_audio   = m->has_spu_hq || m->num_languages > 0 || m->num_audio_devices > 0;   /* deadzone moved to controller card */
@@ -3823,23 +3965,34 @@ void draw_settings(LauncherModel* m, const LauncherTheme& th) {
     // full-width content (HOTKEYS) below both columns must resume.
     const float content_left_x = ImGui::GetCursorScreenPos().x;
 
+    /* The legacy fixed band exists ONLY so the two side-by-side cards share a
+     * height. Stacked, there is nothing to line up with, and pinning the band
+     * would leave a tall empty region under a two-row AUDIO card — so in one
+     * column both cards hug their content instead. */
+    const bool pin_band = two_col;
     float left_bottom = 0.0f;   // DISPLAY's bottom edge (screen space)
     if (video_p) {
-        if (deep_display) begin_container("set_l", ImVec2(half, 0), ImGuiChildFlags_AutoResizeY);
+        if (deep_display || !pin_band) begin_container("set_l", ImVec2(half, 0), ImGuiChildFlags_AutoResizeY);
         else               begin_container("set_l", ImVec2(half, row_h));
         video_p->draw(m, &th);
         end_container();
         left_bottom = ImGui::GetItemRectMax().y;
     }
-    if (video_p && audio_p) ImGui::SameLine(0, gap);
-    // Capture the right column's SCREEN x BEFORE opening AUDIO's child, so
-    // additional SIDE cards (INPUT/SYSTEM/…) can reopen at the same x once
-    // AUDIO's child ends (a finished child returns the cursor to the LEFT
-    // edge of the row on the next line, not to its own column).
+    if (video_p && audio_p) {
+        if (two_col) ImGui::SameLine(0, gap);
+        // One column: put AUDIO under DISPLAY with the same gap the columns
+        // would have had, instead of leaving it to item spacing.
+        else ImGui::SetCursorScreenPos(ImVec2(content_left_x, left_bottom + gap));
+    }
+    // Capture the column's SCREEN x BEFORE opening AUDIO's child, so additional
+    // SIDE cards (INPUT/SYSTEM/…) can reopen at the same x once AUDIO's child
+    // ends (a finished child returns the cursor to the LEFT edge of the row on
+    // the next line, not to its own column). In one-column mode this is simply
+    // the content's left edge, so the stacking code below needs no second case.
     const float right_x = ImGui::GetCursorScreenPos().x;
     float audio_bottom = 0.0f;   // AUDIO's bottom edge (screen space)
     if (audio_p) {
-        if (deep_audio) begin_container("set_r", ImVec2(half, 0), ImGuiChildFlags_AutoResizeY);
+        if (deep_audio || !pin_band) begin_container("set_r", ImVec2(half, 0), ImGuiChildFlags_AutoResizeY);
         else             begin_container("set_r", ImVec2(half, row_h));
         audio_p->draw(m, &th);
         end_container();
@@ -10149,7 +10302,18 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
          * online-only way to reach a room without picking one. */
         const bool lan_mode = m->netplay_mode == 1;
         const auto* np_am = np_cb(m);
-        const bool automatch_ok = np_am && np_am->automatch_available &&
+        /* Two different "no", and the button must not confuse them.
+         *
+         * A NULL automatch_available means THIS BUILD has no automatch
+         * backend wired -- the launcher never asks the server anything, and
+         * would answer the same way against a server running the feature
+         * perfectly. Reporting that as "the server does not offer automatch"
+         * sends whoever reads it to go and check a server that was never
+         * consulted. A present callback answering 0 is the real server
+         * answer: reachable, asked, and it has no rulesets loaded for this
+         * title. */
+        const bool am_wired = np_am && np_am->automatch_available != NULL;
+        const bool automatch_ok = am_wired &&
                                   np_am->automatch_available(np_am->ctx);
         const int am_state = np_automatch_state(np_am);
         const bool am_queued = am_state == RECOMP_LAUNCHER_AUTOMATCH_QUEUED;
@@ -10197,6 +10361,7 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
             np_automatch_queue(m, "");
         };
         auto automatch_tip = [&]() {
+            if (!am_wired)    return "This build has no automatch support yet";
             if (!automatch_ok) return "This lobby server does not offer automatch";
             if (am_gated)     return "Answer the match offer to continue";
             if (am_queued)    return am_pool > 0

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -5944,9 +5944,14 @@ void draw_netplay_automatch_modal(LauncherModel* m, const LauncherTheme& th) {
                                "If they decline you go back to the front of the "
                                "queue, not the back.");
         } else {
+            /* "Accepting in 15s" said the opposite of what happens. Letting
+             * this lapse DECLINES -- and takes the same cooldown strike a
+             * click on Decline does -- so a player who read it as "it will
+             * accept for me" and walked away was told the machine would do
+             * the one thing it will not. Say which way it falls. */
             if (have)
                 ImGui::TextColored(f.accept_secs_left <= 5 ? col(th.warn) : col(th.text),
-                                   "Accepting in %ds", f.accept_secs_left);
+                                   "Auto-declines in %ds", f.accept_secs_left);
             ImGui::Spacing();
             if (ImGui::Button("Accept", ImVec2(px(140), px(34)))) {
                 if (np->automatch_accept) np->automatch_accept(np->ctx, 1);
@@ -6575,7 +6580,19 @@ static void np_ingest_last_error(LauncherModel* m, const RecompLauncherCNetplayC
         std::snprintf(m->netplay_status, sizeof(m->netplay_status),
                       "Too many mods installed to announce to the lobby. "
                       "Remove some and try again.");
-    else
+    else if (std::strcmp(err, "cooldown") == 0) {
+        /* A matchmaking cooldown is not a lobby fault, and "Lobby error:
+         * cooldown" reads as one -- a bare protocol code in front of a player
+         * who declined a match thirty seconds ago and has no way to connect
+         * the two. The automatch layer has already phrased it WITH the
+         * server's own retry_secs in it, so prefer that over anything
+         * reconstructed here; the fallback only covers a server that sent no
+         * number. */
+        const char* am = np->automatch_error ? np->automatch_error(np->ctx) : "";
+        std::snprintf(m->netplay_status, sizeof(m->netplay_status),
+                      "Matchmaking: %s",
+                      (am && am[0]) ? am : "Cooldown For Declining");
+    } else
         std::snprintf(m->netplay_status, sizeof(m->netplay_status),
                       "Lobby error: %s", err);
     if (np->clear_last_error) np->clear_last_error(np->ctx);

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -8411,9 +8411,9 @@ void draw_netplay_signin_page(LauncherModel* m, const LauncherTheme& th) {
                        "other that uses it.");
     ImGui::Spacing();
     ImGui::TextColored(col(th.text_muted),
-                       "It is optional. You can play online as a guest and pick "
-                       "a name yourself — you will just get a new identity every "
-                       "time you reconnect.");
+                       "Online play on this server needs an account. LAN and "
+                       "Direct IP do not — go back and pick those to play "
+                       "without signing in.");
     ImGui::PopTextWrapPos();
     ImGui::Dummy(ImVec2(0, px(16)));
 
@@ -8441,9 +8441,10 @@ void draw_netplay_signin_page(LauncherModel* m, const LauncherTheme& th) {
     }
 
     ImGui::Dummy(ImVec2(0, px(20)));
-    if (ImGui::Button("Continue as guest", ImVec2(px(200), px(34))))
-        np_enter_netplay(m, 2);
-    ImGui::SameLine(0, px(12));
+    /* No "continue as guest". Online play means signing in, when this server
+     * offers sign-in at all -- a server with no Discord configured never
+     * reaches this page, because the chooser sends it straight through. Back
+     * is the way out, and it leads to LAN, which needs no account. */
     if (ImGui::Button("Back", ImVec2(px(120), px(34))))
         launcher_model_set_view(m, LNG_VIEW_NETPLAY_MODE);
 }

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -8398,6 +8398,10 @@ void draw_netplay_mode_page(LauncherModel* m, const LauncherTheme& th) {
 }
 
 /* The sign-in page. Only ever reached on the way to online play. */
+/* When the current "waiting for Discord" began, so the page can offer a way
+ * out if it drags. Zero means "not waiting". */
+static double s_signin_waiting_since = 0.0;
+
 void draw_netplay_signin_page(LauncherModel* m, const LauncherTheme& th) {
     const auto* np = np_cb(m);
     /* Same reason as the chooser, plus this page needs the backend live to
@@ -8431,13 +8435,36 @@ void draw_netplay_signin_page(LauncherModel* m, const LauncherTheme& th) {
     ImGui::Dummy(ImVec2(0, px(16)));
 
     if (st == RECOMP_LAUNCHER_ACCOUNT_WAITING) {
+        /* Offer a way out after a few seconds, but keep waiting underneath:
+         * a person needs longer than this to actually sign in, so the button
+         * is an escape from a login that went wrong, not a deadline. */
+        const double now = ImGui::GetTime();
+        if (s_signin_waiting_since <= 0.0) s_signin_waiting_since = now;
+        const bool stalled = now - s_signin_waiting_since > 10.0;
+
         ImGui::TextColored(col(th.accent2), "Waiting for Discord…");
         ImGui::PushTextWrapPos(wrap);
         ImGui::TextColored(col(th.text_muted),
                            "Finish signing in on the page that opened in your "
                            "browser. This screen will move on by itself.");
+        if (stalled) {
+            ImGui::Spacing();
+            ImGui::TextColored(col(th.text_muted),
+                               "Still waiting. If the browser never opened, or "
+                               "you closed the page, start again:");
+        }
         ImGui::PopTextWrapPos();
+        if (stalled) {
+            ImGui::Spacing();
+            if (ImGui::Button("Retry Discord Sign In", ImVec2(px(240), px(36))) &&
+                np && np->account_login_begin) {
+                s_signin_waiting_since = now; /* the new attempt gets its own clock */
+                np->account_login_begin(np->ctx);
+            }
+        }
     } else {
+        /* Not waiting: reset the clock so the next attempt starts fresh. */
+        s_signin_waiting_since = 0.0;
         if (ImGui::Button("Sign in with Discord", ImVec2(px(240), px(40))) &&
             np && np->account_login_begin) {
             np->account_login_begin(np->ctx);

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -5475,9 +5475,16 @@ void draw_netplay_player_modal(LauncherModel* m, const LauncherTheme& th) {
         }
         ImGui::Spacing();
         if (ImGui::Button("Cancel", ImVec2(px(120), 0))) {
-            const bool required_name = m->s.netplay_player_name[0] == '\0';
+            /* "Do they still have no name?" must ask the EFFECTIVE name. A
+             * signed-in player's name is the account handle; s.netplay_player_name
+             * is only the guest/LAN fallback and is routinely empty for them. Asking
+             * the fallback made Cancel read as "no name yet, netplay is not usable"
+             * and bounce them to the dashboard — losing the lobby page behind the
+             * modal — even though they were signed in as someone. */
+            const char* effective = np_effective_name(m);
+            const bool required_name = !effective || effective[0] == '\0';
             std::snprintf(m->netplay_name_edit, sizeof(m->netplay_name_edit), "%s",
-                          m->s.netplay_player_name);
+                          effective ? effective : "");
             m->netplay_name_modal_open = false;
             m->netplay_name_error[0] = '\0';
             if (required_name) {
@@ -5513,6 +5520,16 @@ void draw_netplay_player_modal(LauncherModel* m, const LauncherTheme& th) {
                     ImGui::EndPopup();
                     return;
                 }
+                /* Tell the lobby too. account_set_handle only changes what the
+                 * ACCOUNT server holds; the players-online list is lobby presence,
+                 * which keeps the name from the first hello until something
+                 * re-announces it. snes_lobby_set_display_name re-queues hello
+                 * exactly for this, but nothing on this path ever called it, so a
+                 * signed-in rename showed the new name in this dialog and the old
+                 * one in the list beside it until reconnect. The guest branch below
+                 * has always done this; only the signed-in early-return skipped it. */
+                if (npa && npa->set_player_name)
+                    npa->set_player_name(npa->ctx, m->netplay_name_edit);
                 m->netplay_name_modal_open = false;
                 m->netplay_name_error[0] = '\0';
                 ImGui::CloseCurrentPopup();

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -5671,6 +5671,147 @@ static int np_clamp_host_max_players(LauncherModel* m) {
     return n;
 }
 
+/* Join the queue. A refusal lands in netplay_status the way every other
+ * lobby op's does -- the server's own line when it gave one (need_account,
+ * cooldown, mods_not_pooled), because it says more than "failed" can. */
+static void np_automatch_queue(LauncherModel* m, const char* ruleset_id) {
+    const auto* np = np_cb(m);
+    if (!np || !np->automatch_queue) return;
+    if (np->automatch_queue(np->ctx, ruleset_id ? ruleset_id : "") == 0) {
+        m->netplay_status[0] = '\0';
+        return;
+    }
+    const char* why = np->automatch_error ? np->automatch_error(np->ctx) : nullptr;
+    std::snprintf(m->netplay_status, sizeof(m->netplay_status), "%s",
+                  why && why[0] ? why : "Could not join the automatch queue.");
+}
+
+static int np_automatch_state(const RecompLauncherCNetplayCallbacks* np) {
+    return (np && np->automatch_state) ? np->automatch_state(np->ctx)
+                                       : RECOMP_LAUNCHER_AUTOMATCH_IDLE;
+}
+
+/* The accept gate, and the queue-type picker when a server offers more than
+ * one. Both live here rather than in the footer so they draw at root and are
+ * not clipped by the page's child windows. */
+void draw_netplay_automatch_modal(LauncherModel* m, const LauncherTheme& th) {
+    const auto* np = np_cb(m);
+    if (!np) return;
+
+    /* ---- queue-type picker ---------------------------------------------- */
+    if (m->netplay_automatch_picker_open) ImGui::OpenPopup("Automatch");
+    ImVec2 center = ImGui::GetMainViewport()->GetCenter();
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    if (ImGui::BeginPopupModal("Automatch", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        ImGui::TextWrapped(
+            "Pick a queue. The server owns these settings for the whole match "
+            "-- both players agreed to them by queueing here, so neither side "
+            "can change them once a pair is found.");
+        ImGui::Spacing();
+        const int n = np->automatch_ruleset_count ? np->automatch_ruleset_count(np->ctx) : 0;
+        for (int i = 0; i < n; ++i) {
+            RecompLauncherCNetplayRuleset r;
+            std::memset(&r, 0, sizeof(r));
+            if (!np->automatch_ruleset_get || !np->automatch_ruleset_get(np->ctx, i, &r))
+                continue;
+            ImGui::PushID(i);
+            if (ImGui::Button(r.label[0] ? r.label : r.id, ImVec2(px(280), px(34)))) {
+                np_automatch_queue(m, r.id);
+                m->netplay_automatch_picker_open = false;
+                ImGui::CloseCurrentPopup();
+            }
+            if (r.caps_summary[0])
+                ImGui::TextColored(col(th.text_muted), "%s", r.caps_summary);
+            if (r.game_version[0])
+                ImGui::TextColored(col(th.text_muted), "Release %s", r.game_version);
+            ImGui::PopID();
+            ImGui::Spacing();
+        }
+        if (n == 0)
+            ImGui::TextColored(col(th.warn), "This server has no automatch queues.");
+        if (ImGui::Button("Cancel", ImVec2(px(120), 0))) {
+            m->netplay_automatch_picker_open = false;
+            ImGui::CloseCurrentPopup();
+        }
+        ImGui::EndPopup();
+    }
+
+    /* ---- accept gate ----------------------------------------------------
+     * Opened and closed by automatch_state, not by a click: a peer that
+     * declines, or a deadline that lapses, has to take this down on its own.
+     * The flag only stops OpenPopup being called every frame. */
+    const int st = np_automatch_state(np);
+    const bool gate = st == RECOMP_LAUNCHER_AUTOMATCH_FOUND ||
+                      st == RECOMP_LAUNCHER_AUTOMATCH_ACCEPTED;
+    if (gate && !m->netplay_automatch_gate_open) {
+        m->netplay_automatch_gate_open = true;
+        ImGui::OpenPopup("Match found");
+    }
+    if (!gate) m->netplay_automatch_gate_open = false;
+
+    ImGui::SetNextWindowPos(center, ImGuiCond_Appearing, ImVec2(0.5f, 0.5f));
+    if (ImGui::BeginPopupModal("Match found", nullptr, ImGuiWindowFlags_AlwaysAutoResize)) {
+        if (!gate) {
+            ImGui::CloseCurrentPopup();
+            ImGui::EndPopup();
+            return;
+        }
+        RecompLauncherCNetplayFound f;
+        std::memset(&f, 0, sizeof(f));
+        const bool have = np->automatch_found_get &&
+                          np->automatch_found_get(np->ctx, &f);
+
+        if (have) {
+            np_draw_country_flag(th, f.country);
+            ImGui::TextUnformatted(f.handle[0] ? f.handle : "Opponent");
+            /* Discord display names are not unique. The @handle is the
+             * disambiguator, which is the whole reason it is carried. */
+            if (f.username[0])
+                ImGui::TextColored(col(th.text_muted), "@%s", f.username);
+            ImGui::Spacing();
+            if (f.ruleset_label[0])
+                ImGui::TextColored(col(th.text_muted), "Queue: %s", f.ruleset_label);
+            /* An estimate, and labelled as one: it is each peer's round trip
+             * to the relay added together, not a measured peer-to-peer ping. */
+            if (f.est_rtt_ms >= 0)
+                ImGui::TextColored(col(th.text_muted), "Estimated latency: ~%d ms",
+                                   f.est_rtt_ms);
+            else
+                ImGui::TextColored(col(th.text_muted), "Estimated latency: unknown");
+        } else {
+            ImGui::TextUnformatted("An opponent is ready.");
+        }
+        ImGui::Spacing();
+
+        if (st == RECOMP_LAUNCHER_AUTOMATCH_ACCEPTED) {
+            ImGui::TextColored(col(th.accent2), "Waiting for %s to accept...",
+                               have && f.handle[0] ? f.handle : "the other player");
+            ImGui::Spacing();
+            ImGui::TextColored(col(th.text_muted),
+                               "If they decline you go back to the front of the "
+                               "queue, not the back.");
+        } else {
+            if (have)
+                ImGui::TextColored(f.accept_secs_left <= 5 ? col(th.warn) : col(th.text),
+                                   "Accepting in %ds", f.accept_secs_left);
+            ImGui::Spacing();
+            if (ImGui::Button("Accept", ImVec2(px(140), px(34)))) {
+                if (np->automatch_accept) np->automatch_accept(np->ctx, 1);
+            }
+            ImGui::SameLine();
+            if (ImGui::Button("Decline", ImVec2(px(140), px(34)))) {
+                if (np->automatch_accept) np->automatch_accept(np->ctx, 0);
+            }
+            /* Say the cost before it is paid. Declining is allowed; being
+             * surprised by the cooldown afterwards is what is not. */
+            ImGui::TextColored(col(th.text_muted),
+                               "Declining or letting this lapse puts you on a "
+                               "short queue cooldown.");
+        }
+        ImGui::EndPopup();
+    }
+}
+
 void draw_netplay_direct_modal(LauncherModel* m, const LauncherTheme& th) {
     if (m->netplay_direct_modal_open) ImGui::OpenPopup("Join Direct");
     ImVec2 center = ImGui::GetMainViewport()->GetCenter();
@@ -10002,6 +10143,67 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
         return;
     }
     if (m->view == LNG_VIEW_NETPLAY) {
+        /* Same split as draw_netplay's page body (netplay_mode: 1 = LAN /
+         * Direct IP, 2 = online). Join Direct is how a LAN room is reached
+         * and stays there; online replaces it with Automatch, which is the
+         * online-only way to reach a room without picking one. */
+        const bool lan_mode = m->netplay_mode == 1;
+        const auto* np_am = np_cb(m);
+        const bool automatch_ok = np_am && np_am->automatch_available &&
+                                  np_am->automatch_available(np_am->ctx);
+        const int am_state = np_automatch_state(np_am);
+        const bool am_queued = am_state == RECOMP_LAUNCHER_AUTOMATCH_QUEUED;
+        /* While the accept gate is up the modal owns the interaction; the
+         * footer must not offer a second way to leave underneath it. */
+        const bool am_gated = am_state == RECOMP_LAUNCHER_AUTOMATCH_FOUND ||
+                              am_state == RECOMP_LAUNCHER_AUTOMATCH_ACCEPTED;
+        const int am_pool = (np_am && np_am->automatch_pool)
+                                ? np_am->automatch_pool(np_am->ctx) : 0;
+        const int am_secs = (np_am && np_am->automatch_queued_secs)
+                                ? np_am->automatch_queued_secs(np_am->ctx) : 0;
+        /* The label owns text the launcher itself writes, so the ⚡ goes
+         * through the atlas the same way a chat line's emoji does -- without
+         * this it draws as the merged OpenMoji outline. The emoji is kept out
+         * of the translated string so a translator carries words, not a
+         * codepoint. */
+        char automatch_label[80];
+        {
+            char raw[64];
+            if (am_queued) {
+                /* The elapsed time IS the button: a queue with no visible
+                 * clock reads as a hang, and this is also the only control
+                 * that leaves the queue. */
+                std::snprintf(raw, sizeof(raw), "⚡ %s %d:%02d", ui_text("Queued"),
+                              am_secs / 60, am_secs % 60);
+            } else {
+                std::snprintf(raw, sizeof(raw), "⚡ %s", ui_text("Automatch"));
+            }
+            emoji_display(raw, automatch_label, sizeof(automatch_label));
+        }
+        /* Queued: leave. Otherwise pick a queue when there is a choice, and
+         * skip straight past the picker when there is only one. */
+        auto automatch_click = [&]() {
+            if (!np_am) return;
+            if (am_queued) {
+                if (np_am->automatch_cancel) np_am->automatch_cancel(np_am->ctx);
+                return;
+            }
+            const int n = np_am->automatch_ruleset_count
+                              ? np_am->automatch_ruleset_count(np_am->ctx) : 0;
+            if (n > 1) {
+                m->netplay_automatch_picker_open = true;
+                return;
+            }
+            np_automatch_queue(m, "");
+        };
+        auto automatch_tip = [&]() {
+            if (!automatch_ok) return "This lobby server does not offer automatch";
+            if (am_gated)     return "Answer the match offer to continue";
+            if (am_queued)    return am_pool > 0
+                                  ? "Others are waiting in this queue - click to leave"
+                                  : "Nobody else is waiting yet - click to leave";
+            return "Queue for a match against anyone else waiting";
+        };
         const float action_w = px(190.0f);
         const float settings_w = px(170.0f);
         const float refresh_w = px(120.0f);
@@ -10054,8 +10256,25 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
             if (ImGui::IsItemHovered())
                 ImGui::SetTooltip("Reload server lobbies and rescan LAN/Direct IP");
             ImGui::SetCursorScreenPos(ImVec2(origin.x + fullw - action_w, cta_y));
-            if (ImGui::Button(ui_text("Join Direct"), ImVec2(action_w, play_h)))
-                m->netplay_direct_modal_open = true;
+            if (lan_mode) {
+                if (ImGui::Button(ui_text("Join Direct"), ImVec2(action_w, play_h)))
+                    m->netplay_direct_modal_open = true;
+            } else {
+                ImGui::BeginDisabled(!automatch_ok || am_gated);
+                if (ImGui::Button(automatch_label, ImVec2(action_w, play_h)))
+                    automatch_click();
+                ImGui::EndDisabled();
+                if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+                    ImGui::SetTooltip("%s", automatch_tip());
+                /* The population sits under the button rather than in the
+                 * tooltip: it is the number that says whether waiting is
+                 * worth it, and a tooltip is not where you look for that. */
+                if (am_queued) {
+                    ImGui::SetCursorScreenPos(
+                        ImVec2(origin.x + fullw - action_w, cta_y + play_h + px(2)));
+                    ImGui::TextColored(col(th.text_muted), "%d waiting", am_pool);
+                }
+            }
         } else {
             /* Narrow window: collapse into a scrollable Actions menu. */
             const float menu_btn_w = px(160.0f);
@@ -10080,8 +10299,16 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
                     if (ImGui::IsItemHovered())
                         ImGui::SetTooltip(
                             "Reload server lobbies and rescan LAN/Direct IP");
-                    if (ImGui::Selectable(ui_text("Join Direct"))) {
-                        m->netplay_direct_modal_open = true;
+                    if (lan_mode) {
+                        if (ImGui::Selectable(ui_text("Join Direct"))) {
+                            m->netplay_direct_modal_open = true;
+                        }
+                    } else {
+                        ImGui::BeginDisabled(!automatch_ok || am_gated);
+                        if (ImGui::Selectable(automatch_label)) automatch_click();
+                        ImGui::EndDisabled();
+                        if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+                            ImGui::SetTooltip("%s", automatch_tip());
                     }
                 }
                 ImGui::EndChild();
@@ -11479,6 +11706,7 @@ void draw_ui(LauncherModel* m, const LauncherTheme& th, int logical_w, int logic
     draw_netplay_host_modal(m, th);
     draw_netplay_password_modal(m, th);
     draw_netplay_direct_modal(m, th);
+    draw_netplay_automatch_modal(m, th);
     draw_restore_defaults_modal(m);
     // Transfer Pak config modal (N64): opened by any tile, dashboard or
     // Controller page. Drawn at root so it isn't clipped by a card child.

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -871,6 +871,37 @@ static int emoji_input_callback(ImGuiInputTextCallbackData* data) {
 const RecompLauncherCNetplayCallbacks* np_cb(LauncherModel* m);   /* fwd */
 
 /*
+ * Push the block list to the server when it changes, and again on a fresh
+ * connection.
+ *
+ * Sent rather than merely applied here because only one of a block's three
+ * effects can be done client-side. Hiding somebody's chat is ours. Not being
+ * PAIRED with them, and their not seeing or joining our room, are the
+ * server's -- and the second of those is the direction a client cannot do at
+ * all, because it cannot know it was blocked.
+ *
+ * Resent on reconnect: the server holds the list for the life of a connection
+ * and never persists it, so a dropped socket would otherwise silently leave
+ * the player unprotected on the next one.
+ */
+static void np_push_blocks(LauncherModel* m) {
+    const auto* np = np_cb(m);
+    if (!np || !np->set_blocks) return;
+    char list[256 * 41];
+    recomp_moderation_blocked_list(list, sizeof(list));
+
+    static char s_last[sizeof(list)];
+    static bool s_was_connected;
+    const bool connected = np->connected && np->connected(np->ctx);
+    if (!connected) { s_was_connected = false; return; }
+    /* A reconnect counts as a change even when the list did not move. */
+    if (s_was_connected && std::strcmp(s_last, list) == 0) return;
+    s_was_connected = true;
+    std::snprintf(s_last, sizeof(s_last), "%s", list);
+    np->set_blocks(np->ctx, list);
+}
+
+/*
  * Right-click a player: ignore them, or block them.
  *
  * ONLINE ONLY, and that gate is the point rather than a simplification. A LAN
@@ -9293,6 +9324,7 @@ void draw_netplay(LauncherModel* m, const LauncherTheme& th) {
     if (m->netplay_status[0])
         ImGui::TextColored(col(th.warn), "%s", m->netplay_status);
     ImGui::Spacing();
+    np_push_blocks(m);
     /* Tell the backend which fork the player took before asking it anything.
      * It merges its LAN registry and beacon rows with the server's list and
      * has no other way to know: a LAN player was being shown online rooms

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -3024,9 +3024,23 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     }
 
     if (m->has_renderer) {
+        /* A list, not a cycle button. The vocabulary is up to five entries on
+         * hosts that supply their own (Auto / D3D11 / D3D9 / OpenGL /
+         * Software), and reaching the last one by clicking through the other
+         * four is not a choice a player should have to count out. */
         row_label("Renderer", th);
-        if (ImGui::Button(ui_text(launcher_model_renderer_label(m)), ImVec2(px(220), px(30))))
-            launcher_model_toggle_renderer(m);
+        ImGui::SetNextItemWidth(px(220));
+        if (ImGui::BeginCombo("##renderer",
+                              ui_text(launcher_model_renderer_label(m)))) {
+            const int n = launcher_model_renderer_count(m);
+            for (int i = 0; i < n; ++i) {
+                const char* lbl = launcher_model_renderer_label_at(m, i);
+                if (!lbl || !lbl[0]) continue;
+                if (ImGui::Selectable(ui_text(lbl), m->s.renderer == i))
+                    launcher_model_set_renderer(m, i);
+            }
+            ImGui::EndCombo();
+        }
     }
 
     if (m->has_supersampling) {
@@ -3179,8 +3193,19 @@ void draw_display_controls(LauncherModel* m, const LauncherTheme& th) {
     // frame reaches the panel, not how it is drawn.
     if (m->has_vsync) {
         row_label("VSync", th);
-        if (ImGui::Button(ui_text(launcher_model_vsync_label(m)), ImVec2(px(120), px(30))))
-            launcher_model_cycle_vsync(m);
+        ImGui::SetNextItemWidth(px(120));
+        if (ImGui::BeginCombo("##vsync_mode",
+                              ui_text(launcher_model_vsync_label(m)))) {
+            static const struct { int v; const char* label; } kVsync[] = {
+                { RECOMP_LAUNCHER_VSYNC_OFF,      "Off" },
+                { RECOMP_LAUNCHER_VSYNC_ON,       "On" },
+                { RECOMP_LAUNCHER_VSYNC_ADAPTIVE, "Adaptive" },
+            };
+            for (const auto& o : kVsync)
+                if (ImGui::Selectable(ui_text(o.label), m->s.vsync == o.v))
+                    launcher_model_set_vsync(m, o.v);
+            ImGui::EndCombo();
+        }
         if (ImGui::IsItemHovered(ImGuiHoveredFlags_DelayNormal)) {
             ImGui::SetTooltip(
                 "On: the swap waits for the panel — no tearing.\n"

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -1167,7 +1167,11 @@ void draw_dot(bool on, const LngColor& good, const LngColor& off) {
 }
 // The primary neon CTA (PLAY): glow + violet gradient + play triangle. Fully
 // custom-drawn over an InvisibleButton so it looks nothing like a stock button.
-bool neon_cta(const char* id, const char* label, ImVec2 size, bool enabled = true) {
+// `arrow` draws the ▶. PLAY wants it; a primary action that is not "start the
+// game" does not -- an Automatch button that already carries ⚡ would show two
+// glyphs arguing about what it does.
+bool neon_cta(const char* id, const char* label, ImVec2 size, bool enabled = true,
+              bool arrow = true) {
     const LauncherTheme& th = *g_th;
     ImVec2 p = ImGui::GetCursorScreenPos();
     // EnableNav is REQUIRED: ImGui::InvisibleButton() adds ImGuiItemFlags_NoNav by
@@ -1198,12 +1202,13 @@ bool neon_cta(const char* id, const char* label, ImVec2 size, bool enabled = tru
     // centered "▶ label"
     float th_h = ImGui::GetTextLineHeight();
     float tw = ImGui::CalcTextSize(label).x;
-    float tri = px(11.0f), gap = px(10.0f);
+    float tri = arrow ? px(11.0f) : 0.0f, gap = arrow ? px(10.0f) : 0.0f;
     float total = tri + gap + tw;
     float cx = p.x + (size.x - total) * 0.5f, cy = p.y + size.y * 0.5f;
     ImU32 fg = imcol(th.accent_text);
-    dl->AddTriangleFilled(ImVec2(cx, cy - tri*0.55f), ImVec2(cx, cy + tri*0.55f),
-                          ImVec2(cx + tri, cy), fg);
+    if (arrow)
+        dl->AddTriangleFilled(ImVec2(cx, cy - tri*0.55f), ImVec2(cx, cy + tri*0.55f),
+                              ImVec2(cx + tri, cy), fg);
     dl->AddText(ImVec2(cx + tri + gap, cy - th_h*0.5f), fg, label);
     if (!enabled) ImGui::EndDisabled();
     return clk && enabled;
@@ -8708,7 +8713,16 @@ static bool np_mode_card(const LauncherTheme& th, const char* id, const char* ti
     ImGui::PopFont();
     ImGui::PopStyleColor();
     ImGui::SetCursorScreenPos(ImVec2(p.x + px(20), p.y + px(50)));
-    ImGui::PushTextWrapPos(p.x + w - px(20));
+    /* PushTextWrapPos takes a WINDOW-LOCAL x, and this was handing it a screen
+     * one (p.x is from GetCursorScreenPos). The two differ by the window's
+     * origin, so the wrap boundary sat that many pixels to the RIGHT of the
+     * card and the body text ran to the border and past it.
+     *
+     * Derived from the cursor instead, which is already local, so it cannot
+     * drift from where the text actually starts. The right inset is a little
+     * wider than the left on purpose: a wrap point is where a word may still
+     * begin, so the last glyph of a long word lands beyond it. */
+    ImGui::PushTextWrapPos(ImGui::GetCursorPosX() + (w - px(20) - px(28)));
     ImGui::TextColored(col(th.text_muted), "%s", body);
     ImGui::PopTextWrapPos();
     ImGui::SetCursorScreenPos(ImVec2(p.x, p.y + h + px(14)));
@@ -10426,7 +10440,14 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
 
         if (!compact) {
             ImGui::SetCursorScreenPos(ImVec2(origin.x, cta_y));
-            if (ImGui::Button(ui_text("Host Lobby"), ImVec2(action_w, play_h)))
+            /* Host Lobby and Automatch carry the CTA treatment: on this page
+             * they ARE the two ways to get into a game, and drawing them in
+             * the same neutral grey as Refresh made the screen read as four
+             * equal utilities with no obvious way in. Network Settings and
+             * Refresh stay neutral, which is what gives the other two their
+             * weight -- accenting everything would say nothing. */
+            if (neon_cta("##np_host", ui_text("Host Lobby"),
+                         ImVec2(action_w, play_h), true, /*arrow*/false))
                 open_host();
             ImGui::SetCursorScreenPos(ImVec2(origin.x + action_w + gap, cta_y));
             if (ImGui::Button(ui_text("Network Settings"), ImVec2(settings_w, play_h)))
@@ -10442,10 +10463,10 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
                 if (ImGui::Button(ui_text("Join Direct"), ImVec2(action_w, play_h)))
                     m->netplay_direct_modal_open = true;
             } else {
-                ImGui::BeginDisabled(!automatch_ok || am_gated);
-                if (ImGui::Button(automatch_label, ImVec2(action_w, play_h)))
+                if (neon_cta("##np_automatch", automatch_label,
+                             ImVec2(action_w, play_h),
+                             automatch_ok && !am_gated, /*arrow*/false))
                     automatch_click();
-                ImGui::EndDisabled();
                 if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
                     ImGui::SetTooltip("%s", automatch_tip());
                 /* The population sits under the button rather than in the
@@ -10524,6 +10545,12 @@ void draw_footer(LauncherModel* m, const LauncherTheme& th, float footer_h) {
             launcher_model_set_view(m, LNG_VIEW_NETPLAY_MODE);
         }
     }
+    /* The netplay MODE picker is a fork in the road, not a launch screen: the
+     * player is answering "LAN or online?", and a PLAY button there offers to
+     * start the game instead of answering it -- which is both the wrong action
+     * and the most prominent thing on the page. Every other view keeps it. */
+    if (m->view == LNG_VIEW_NETPLAY_MODE) return;
+
     ImGui::SetCursorScreenPos(ImVec2(play_x, cta_y));
     const bool can_play = launcher_model_can_launch(m);
     const bool bios_block = launcher_model_bios_blocks_play(m);

--- a/src/common/backends/imgui/launcher_imgui.cpp
+++ b/src/common/backends/imgui/launcher_imgui.cpp
@@ -8335,6 +8335,16 @@ static bool np_mode_card(const LauncherTheme& th, const char* id, const char* ti
 }
 
 void draw_netplay_mode_page(LauncherModel* m, const LauncherTheme& th) {
+    /* Pump here too, not only on the browser page. The backend does its own
+     * lazy setup from the pump -- parsing the lobby host, loading a stored
+     * device key, redeeming it -- and this page asks it questions ("is
+     * sign-in offered?", "are we signed in?") before the browser page has
+     * ever been drawn. Without this the first visit answered from an
+     * uninitialised backend. */
+    {
+        const auto* npp = np_cb(m);
+        if (npp && npp->pump) npp->pump(npp->ctx);
+    }
     const float avail_w = ImGui::GetContentRegionAvail().x;
     const float card_w = avail_w > px(900) ? px(420) : (avail_w - px(30)) * 0.5f;
 
@@ -8390,6 +8400,9 @@ void draw_netplay_mode_page(LauncherModel* m, const LauncherTheme& th) {
 /* The sign-in page. Only ever reached on the way to online play. */
 void draw_netplay_signin_page(LauncherModel* m, const LauncherTheme& th) {
     const auto* np = np_cb(m);
+    /* Same reason as the chooser, plus this page needs the backend live to
+     * notice the sign-in completing. */
+    if (np && np->pump) np->pump(np->ctx);
     const int st = (np && np->account_state) ? np->account_state(np->ctx)
                                              : RECOMP_LAUNCHER_ACCOUNT_GUEST;
     const float wrap = px(640);

--- a/src/common/launcher_debug.c
+++ b/src/common/launcher_debug.c
@@ -171,6 +171,11 @@ void launcher_debug_step(LauncherPlatform* p, LauncherModel* m) {
         else if (strcmp(v, "controller") == 0) launcher_model_set_view(m, LNG_VIEW_CONTROLLER);
         else if (strcmp(v, "assist_tools") == 0) launcher_model_set_view(m, LNG_VIEW_ASSIST_TOOLS);
         else if (strcmp(v, "credits") == 0) launcher_model_set_view(m, LNG_VIEW_CREDITS);
+        /* The LAN-vs-online fork. Reachable only by clicking NETPLAY on the
+         * dashboard, which made it the one netplay page a screenshot script
+         * could not open. */
+        else if (strcmp(v, "netplay_mode") == 0)
+            launcher_model_set_view(m, LNG_VIEW_NETPLAY_MODE);
         else if (strcmp(v, "netplay") == 0) {
             m->netplay_list_fresh = false;
             launcher_model_set_view(m, LNG_VIEW_NETPLAY);

--- a/src/common/launcher_i18n.cpp
+++ b/src/common/launcher_i18n.cpp
@@ -56,6 +56,8 @@ static const LauncherI18nEntry kItalian[] = {
     {"Network Settings", "Impostazioni rete"},
     {"Refresh", "Aggiorna"},
     {"Join Direct", "Connessione diretta"},
+    {"Automatch", "Partita rapida"},
+    {"Queued", "In coda"},
     {"Actions##np_footer", "Azioni##np_footer"},
     {"Browse For", "Sfoglia"},
     {"Browse", "Sfoglia"},

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -1277,7 +1277,7 @@ bool launcher_model_rom_verified(const LauncherModel* m) {
 }
 
 void launcher_model_set_view(LauncherModel* m, LngView v) {
-    if (v < 0 || v > LNG_VIEW_LOBBY) return;
+    if (v < 0 || v >= LNG_VIEW__COUNT) return;
     /* Re-entering Netplay should rescan server + LAN lists. */
     if (m->view == LNG_VIEW_NETPLAY && v != LNG_VIEW_NETPLAY)
         m->netplay_list_fresh = false;

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -403,6 +403,7 @@ void launcher_model_init(LauncherModel* m,
         m->has_sharp_filter     = game->has_sharp_filter != 0;
         m->has_affine_filter    = game->has_affine_filter != 0;
         m->has_frame_blend      = game->has_frame_blend != 0;
+        m->has_run_ahead        = game->has_run_ahead != 0;
         m->has_shader           = game->has_shader != 0;
         m->netplay_supported    = game->netplay_supported != 0 && game->netplay != NULL;
         m->netplay              = game->netplay;
@@ -485,6 +486,14 @@ void launcher_model_init(LauncherModel* m,
     }
     if (m->has_frame_blend)
         m->s.frame_blend = m->s.frame_blend ? 1 : 0;
+    /* A host may seed a depth its build predates, or a negative from a
+     * malformed config; clamp to what the control can actually show rather
+     * than drawing a value no press can return to. */
+    if (m->has_run_ahead) {
+        if (m->s.run_ahead < 0) m->s.run_ahead = 0;
+        if (m->s.run_ahead > RECOMP_LAUNCHER_RUN_AHEAD_MAX)
+            m->s.run_ahead = RECOMP_LAUNCHER_RUN_AHEAD_MAX;
+    }
     memset(&m->s.netplay_launch, 0, sizeof(m->s.netplay_launch));
     if (!m->s.netplay_player_name[0] && m->netplay && m->netplay->player_name) {
         safe_copy(m->s.netplay_player_name, sizeof(m->s.netplay_player_name),
@@ -1308,6 +1317,9 @@ void launcher_model_restore_defaults(LauncherModel* m) {
         int iv = m->s.rewind_interval;
         if (iv != 1 && iv != 4 && iv != 8 && iv != 12 && iv != 15)
             m->s.rewind_interval = 15;
+        if (m->s.run_ahead < 0) m->s.run_ahead = 0;
+        if (m->s.run_ahead > RECOMP_LAUNCHER_RUN_AHEAD_MAX)
+            m->s.run_ahead = RECOMP_LAUNCHER_RUN_AHEAD_MAX;
     }
     m->defaults_modal_open = false;
 }
@@ -1317,8 +1329,14 @@ void launcher_model_cancel_restore_defaults(LauncherModel* m) {
 }
 
 void launcher_model_cycle_scale(LauncherModel* m) {
-    m->s.window_scale = (m->s.window_scale >= 6) ? 1 : m->s.window_scale + 1;
+    m->s.window_scale = (m->s.window_scale >= LNG_WINDOW_SCALE_MAX)
+                            ? 1 : m->s.window_scale + 1;
     if (m->s.window_scale < 1) m->s.window_scale = 1;
+}
+
+void launcher_model_set_scale(LauncherModel* m, int scale) {
+    if (!m) return;
+    m->s.window_scale = clampi(scale, 1, LNG_WINDOW_SCALE_MAX);
 }
 
 void launcher_model_toggle_filter(LauncherModel* m) {
@@ -1355,6 +1373,11 @@ void launcher_model_toggle_affine_filter(LauncherModel* m) {
 void launcher_model_toggle_frame_blend(LauncherModel* m) {
     if (!m || !m->has_frame_blend) return;
     m->s.frame_blend = !m->s.frame_blend;
+}
+
+void launcher_model_set_run_ahead(LauncherModel* m, int frames) {
+    if (!m || !m->has_run_ahead) return;
+    m->s.run_ahead = clampi(frames, 0, RECOMP_LAUNCHER_RUN_AHEAD_MAX);
 }
 
 void launcher_model_toggle_widescreen(LauncherModel* m) {
@@ -1821,6 +1844,11 @@ void launcher_model_cycle_fullscreen(LauncherModel* m) {
 const char* launcher_model_fullscreen_label(const LauncherModel* m) {
     static const char* const kNames[3] = { "Off", "Borderless", "Exclusive" };
     return kNames[clampi(m->s.fullscreen, 0, 2)];
+}
+
+void launcher_model_set_fullscreen(LauncherModel* m, int mode) {
+    if (!m) return;
+    m->s.fullscreen = clampi(mode, 0, 2);
 }
 
 void launcher_model_toggle_fullscreen(LauncherModel* m) {

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -1540,6 +1540,49 @@ void launcher_model_toggle_renderer(LauncherModel* m) {
     m->s.renderer = !m->s.renderer;
 }
 
+/*
+ * Enumerate the renderer vocabulary, so a host can present it as a LIST
+ * rather than a button that has to be clicked N-1 times to reach the last
+ * entry. Same three-way precedence the label getter uses: game-supplied
+ * labels, then the console profile's pair, then the legacy pair.
+ */
+int launcher_model_renderer_count(const LauncherModel* m) {
+    if (!m) return 0;
+    if (m->renderer_labels && m->num_renderers > 0) return m->num_renderers;
+    return 2;
+}
+
+const char* launcher_model_renderer_label_at(const LauncherModel* m, int i) {
+    if (!m) return "";
+    if (m->renderer_labels && m->num_renderers > 0) {
+        if (i < 0 || i >= m->num_renderers) return "";
+        return m->renderer_labels[i];
+    }
+    {
+        const SystemProfile* prof = (const SystemProfile*)m->profile;
+        if (prof && prof->renderer_labels)
+            return prof->renderer_labels[i ? 1 : 0];
+    }
+    return i ? "OpenGL" : "Software";
+}
+
+void launcher_model_set_renderer(LauncherModel* m, int index) {
+    if (!m || !m->has_renderer) return;
+    m->s.renderer = clampi(index, 0, launcher_model_renderer_count(m) - 1);
+}
+
+/* Set rather than cycle. The values are the RECOMP_LAUNCHER_VSYNC_* constants,
+ * not an index, because that is what Settings.vsync holds and what a host
+ * reads back. */
+void launcher_model_set_vsync(LauncherModel* m, int value) {
+    if (!m || !m->has_vsync) return;
+    if (value != RECOMP_LAUNCHER_VSYNC_OFF &&
+        value != RECOMP_LAUNCHER_VSYNC_ON &&
+        value != RECOMP_LAUNCHER_VSYNC_ADAPTIVE)
+        return;
+    m->s.vsync = value;
+}
+
 const char* launcher_model_renderer_label(const LauncherModel* m) {
     if (m->renderer_labels && m->num_renderers > 0) {
         int i = clampi(m->s.renderer, 0, m->num_renderers - 1);

--- a/src/common/launcher_model.c
+++ b/src/common/launcher_model.c
@@ -784,31 +784,49 @@ void launcher_model_init(LauncherModel* m,
     }
     launcher_model_refresh_bios_status(m);
 
-    /* Soft-return from a match: land on Netplay; the frame then switches to
-     * the full-screen lobby view because the backend still reports us
-     * seated (see LNG_VIEW_LOBBY). */
-    if (game && game->resume_netplay_room && m->netplay_supported && m->netplay &&
-        m->netplay->in_lobby && m->netplay->in_lobby(m->netplay->ctx)) {
+    /* Soft-return from a match: land on Netplay.
+     *
+     * Still seated (a hosted room that outlived the match) => the frame then
+     * switches to the full-screen lobby view, because the backend reports us
+     * in a room (see LNG_VIEW_LOBBY).
+     *
+     * NOT seated => the netplay page draws its lobby LIST, which is the whole
+     * point for a host that left the room on the way out. An automatch room
+     * is the server's and is gone the moment the match ends, so there is
+     * nothing to return to; the in_lobby test used to gate the whole hint and
+     * such a host landed on the dashboard instead, a page away from the queue
+     * it was trying to rejoin. */
+    if (game && game->resume_netplay_room && m->netplay_supported && m->netplay) {
+        const bool seated = m->netplay->in_lobby &&
+                            m->netplay->in_lobby(m->netplay->ctx);
         m->view = LNG_VIEW_NETPLAY;
         m->netplay_list_fresh = true;
-        if (game->resume_netplay_endpoint && game->resume_netplay_endpoint[0]) {
-            m->netplay_local_room = true;
-            safe_copy(m->netplay_host_endpoint, sizeof(m->netplay_host_endpoint),
-                      game->resume_netplay_endpoint);
-        } else {
+        if (!seated) {
+            /* No room, so none of the room-shaped state below applies. */
             m->netplay_local_room = false;
             m->netplay_host_endpoint[0] = '\0';
-        }
-        /* Mirror engine match caps — UI default rollback=true must not flip a
-         * delay-sync Cable Club rematch on ▶ Play without opening Settings. */
-        if (m->netplay->rollback_get)
-            m->netplay_rollback =
-                m->netplay->rollback_get(m->netplay->ctx) != 0;
-        if (m->netplay->input_delay_get) {
-            m->netplay_lobby_input_delay =
-                m->netplay->input_delay_get(m->netplay->ctx);
-            if (m->netplay_lobby_input_delay < 2)
-                m->netplay_lobby_input_delay = 6;
+        } else {
+            if (game->resume_netplay_endpoint && game->resume_netplay_endpoint[0]) {
+                m->netplay_local_room = true;
+                safe_copy(m->netplay_host_endpoint,
+                          sizeof(m->netplay_host_endpoint),
+                          game->resume_netplay_endpoint);
+            } else {
+                m->netplay_local_room = false;
+                m->netplay_host_endpoint[0] = '\0';
+            }
+            /* Mirror engine match caps — UI default rollback=true must not
+             * flip a delay-sync Cable Club rematch on ▶ Play without opening
+             * Settings. */
+            if (m->netplay->rollback_get)
+                m->netplay_rollback =
+                    m->netplay->rollback_get(m->netplay->ctx) != 0;
+            if (m->netplay->input_delay_get) {
+                m->netplay_lobby_input_delay =
+                    m->netplay->input_delay_get(m->netplay->ctx);
+                if (m->netplay_lobby_input_delay < 2)
+                    m->netplay_lobby_input_delay = 6;
+            }
         }
     }
 

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -758,6 +758,12 @@ void launcher_model_cycle_window_size(LauncherModel* m);       // {960,1280,1600
 const char* launcher_model_window_size_label(const LauncherModel* m);  // "1280 x 960" (H follows aspect)
 void launcher_model_toggle_renderer(LauncherModel* m);         // Software/OpenGL
 const char* launcher_model_renderer_label(const LauncherModel* m);
+/* List form of the same vocabulary, for hosts that draw a dropdown instead of
+ * a cycle button. count/label_at follow the same precedence as the label
+ * getter above; set_renderer clamps. */
+int         launcher_model_renderer_count(const LauncherModel* m);
+const char* launcher_model_renderer_label_at(const LauncherModel* m, int i);
+void        launcher_model_set_renderer(LauncherModel* m, int index);
 void launcher_model_cycle_supersampling(LauncherModel* m);     // 1x..4x wrap
 const char* launcher_model_supersampling_label(const LauncherModel* m);
 void launcher_model_cycle_aa(LauncherModel* m);            // Off/2x/4x/8x (MSAA sample count)
@@ -793,7 +799,10 @@ const char* launcher_model_rewind_interval_label(const LauncherModel* m);
 void launcher_model_cycle_vsync(LauncherModel* m);
 // Binary On/Off flip for the legacy-surface checkbox (Adaptive counts as On).
 void launcher_model_toggle_vsync(LauncherModel* m);
-const char* launcher_model_vsync_label(const LauncherModel* m);  // "On"/"Off"/"Adaptive"
+const char* launcher_model_vsync_label(const LauncherModel* m);
+/* Set the exact state rather than cycling to it. Takes a
+ * RECOMP_LAUNCHER_VSYNC_* value, not an index. */
+void launcher_model_set_vsync(LauncherModel* m, int value);  // "On"/"Off"/"Adaptive"
 void launcher_model_toggle_skip_fmv(LauncherModel* m);
 void launcher_model_toggle_turbo_loads(LauncherModel* m);
 void launcher_model_cycle_fullscreen(LauncherModel* m);        // Off -> Borderless -> Exclusive, wraps

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -50,6 +50,19 @@ typedef enum {
      * local player seated in a lobby, and back to Netplay when it does not.
      * Every profile that opens a lobby goes through it. */
     LNG_VIEW_LOBBY,
+    /* The fork the NETPLAY button lands on: LAN / Direct IP, or online. Its
+     * own view rather than a modal because the choice decides what the whole
+     * netplay page then means, and because a controller has to be able to
+     * make it. */
+    LNG_VIEW_NETPLAY_MODE,
+    /* Signing in, full screen. Only reached on the way to ONLINE play, and
+     * skipped entirely when this client is already signed in or when the
+     * server offers no logins -- see draw_netplay_mode_page. */
+    LNG_VIEW_NETPLAY_SIGNIN,
+    /* Keep last. launcher_model_set_view validates against this rather than
+     * against the last real view, which is what silently swallowed the two
+     * views above when they were first added. */
+    LNG_VIEW__COUNT,
 } LngView;
 
 typedef enum {
@@ -508,6 +521,11 @@ typedef struct {
     bool      netplay_network_modal_open;
     bool      netplay_password_modal_open;
     bool      netplay_local_room;
+    /* Which kind of netplay the player picked on LNG_VIEW_NETPLAY_MODE.
+     * 0 = not chosen yet, 1 = LAN / Direct IP, 2 = online. The netplay page
+     * reads it to decide whether the lobby-server half of itself is drawn at
+     * all: a LAN player should not be looking at an online lobby list. */
+    int       netplay_mode;
     int       netplay_selected_lobby;
     char      netplay_name_edit[64];
     char      netplay_lobby_url[256];

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -311,6 +311,7 @@ typedef struct {
     bool has_sharp_filter;
     bool has_affine_filter;
     bool has_frame_blend;
+    bool has_run_ahead;
     bool has_shader;
     bool netplay_supported;
     /* Host opted into first-run wizard + Generate & rebuild (GameInfo). */
@@ -718,12 +719,23 @@ void launcher_model_restore_defaults(LauncherModel* m);
 void launcher_model_cancel_restore_defaults(LauncherModel* m);
 
 // ---- display settings ----
-void launcher_model_cycle_scale(LauncherModel* m);   // 1..6 wrap
+// Window scale, in whole native-size steps. LNG_WINDOW_SCALE_MAX bounds both
+// the cycle's wrap and the dropdown's list, so the two can never offer
+// different sets.
+#define LNG_WINDOW_SCALE_MAX 6
+void launcher_model_cycle_scale(LauncherModel* m);   // 1..LNG_WINDOW_SCALE_MAX wrap
+void launcher_model_set_scale(LauncherModel* m, int scale);  // clamped
 void launcher_model_toggle_filter(LauncherModel* m);
 void launcher_model_cycle_scaling_filter(LauncherModel* m);
 const char* launcher_model_scaling_filter_label(const LauncherModel* m);
 void launcher_model_toggle_affine_filter(LauncherModel* m);
 void launcher_model_toggle_frame_blend(LauncherModel* m);  // gated has_frame_blend
+// Run-ahead depth, 0 (Off) .. RECOMP_LAUNCHER_RUN_AHEAD_MAX. Off by default:
+// each frame of depth is a whole extra emulated frame plus a snapshot/restore,
+// so it is opt-in rather than a cost every host pays. Set, not cycled -- the
+// UI draws it as a dropdown, and the labels for each depth live with that
+// control alongside every other choice list.
+void launcher_model_set_run_ahead(LauncherModel* m, int frames);  // clamped, gated has_run_ahead
 void launcher_model_toggle_widescreen(LauncherModel* m);  // gated
 void launcher_model_toggle_adaptive_view(LauncherModel* m);  // gated; fixed aspect is retained
 /* Unified Native / fixed widescreen / Adaptive control. Compatibility fields
@@ -815,6 +827,7 @@ void launcher_model_toggle_skip_fmv(LauncherModel* m);
 void launcher_model_toggle_turbo_loads(LauncherModel* m);
 void launcher_model_cycle_fullscreen(LauncherModel* m);        // Off -> Borderless -> Exclusive, wraps
 const char* launcher_model_fullscreen_label(const LauncherModel* m);  // "Off"/"Borderless"/"Exclusive"
+void launcher_model_set_fullscreen(LauncherModel* m, int mode);  // 0/1/2, clamped
 void launcher_model_toggle_fullscreen(LauncherModel* m);       // binary on/off; kept for bool-style hosts
 void launcher_model_cycle_language(LauncherModel* m);          // wraps over num_languages
 const char* launcher_model_language_label(const LauncherModel* m);

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -519,6 +519,14 @@ typedef struct {
     bool      netplay_network_modal_open;
     bool      netplay_password_modal_open;
     bool      netplay_moderation_modal_open;
+    /* The report dialog: which line, who said it, and what the reporter
+     * chose. The mid is the whole referent -- the text is never carried. */
+    bool      netplay_report_modal_open;
+    char      netplay_report_mid[40];
+    char      netplay_report_who[64];
+    int       netplay_report_reason;
+    char      netplay_report_note[512];
+    char      netplay_report_status[160];
     bool      netplay_local_room;
     /* Which kind of netplay the player picked on LNG_VIEW_NETPLAY_MODE.
      * 0 = not chosen yet, 1 = LAN / Direct IP, 2 = online. The netplay page

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -518,6 +518,7 @@ typedef struct {
     bool      netplay_host_modal_open;
     bool      netplay_network_modal_open;
     bool      netplay_password_modal_open;
+    bool      netplay_moderation_modal_open;
     bool      netplay_local_room;
     /* Which kind of netplay the player picked on LNG_VIEW_NETPLAY_MODE.
      * 0 = not chosen yet, 1 = LAN / Direct IP, 2 = online. The netplay page

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -497,6 +497,9 @@ typedef struct {
      * cleared as soon as the player edits the field. Set by the local check
      * (np->name_rejected) or by the server's `name_rejected` error. */
     char      netplay_name_error[128];
+    /* The name box has been seeded from the server-owned handle for this
+     * sign-in. Reset on sign-out so the next sign-in re-seeds. */
+    bool      netplay_handle_seeded;
     /* The same, for the room title in the Host Lobby modal: a lobby name sits
      * in the browser in front of everyone shopping for a game, so it is
      * refused like a player name rather than masked. */

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -510,9 +510,6 @@ typedef struct {
      * cleared as soon as the player edits the field. Set by the local check
      * (np->name_rejected) or by the server's `name_rejected` error. */
     char      netplay_name_error[128];
-    /* The name box has been seeded from the server-owned handle for this
-     * sign-in. Reset on sign-out so the next sign-in re-seeds. */
-    bool      netplay_handle_seeded;
     /* The same, for the room title in the Host Lobby modal: a lobby name sits
      * in the browser in front of everyone shopping for a game, so it is
      * refused like a player name rather than masked. */

--- a/src/common/launcher_model.h
+++ b/src/common/launcher_model.h
@@ -538,6 +538,14 @@ typedef struct {
     bool      netplay_lan_only;   /* "LAN/Direct IP Only"; false = online / ICE path */
     bool      netplay_list_fresh; /* false → refresh lobby list on next Netplay draw */
     bool      netplay_direct_modal_open;
+    /* Automatch. The accept gate is NOT a flag the UI owns -- it opens and
+     * closes off automatch_state, so a peer's decline or a lapsed deadline
+     * takes the modal down without the launcher having to be told twice.
+     * This only tracks whether the popup has been opened for the current
+     * gate, so ImGui::OpenPopup is called once rather than every frame. */
+    bool      netplay_automatch_gate_open;
+    /* The queue-type picker, drawn only when the server offers more than one. */
+    bool      netplay_automatch_picker_open;
     char      netplay_direct_ip[64];
     char      netplay_direct_port[16];
     char      netplay_password[64];

--- a/src/common/recomp_flash_guard.c
+++ b/src/common/recomp_flash_guard.c
@@ -1,0 +1,311 @@
+/* recomp_flash_guard.c — see recomp_flash_guard.h. */
+
+#include "recomp_flash_guard.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/* How many consecutive limited frames before the guard gives up and lets the
+ * frame through as drawn. This is what keeps a scene cut from becoming a
+ * fade: two frames of ramp at 60 Hz is ~33 ms, which reads as a hard cut.
+ *
+ * It is deliberately short, because it is not the thing protecting against a
+ * strobe — the reversal hold below is. Release is disabled entirely while
+ * that hold is live, so shortening this cannot let a flash through. */
+enum { kReleaseFrames = 2 };
+
+/* How long a detected reversal keeps release disabled, in frames. 45 at
+ * 60 Hz is 0.75 s.
+ *
+ * Sized from the far side of the problem: the risk band starts at 3 Hz, so
+ * two flashes that matter can be a third of a second apart, and a hold that
+ * expired between them would release exactly in the gap and then have to
+ * re-detect on the next one — passing a full-amplitude frame each time. The
+ * cost of holding too long is that the first scene cut within 0.75 s of a
+ * flash ramps over two frames instead of cutting. That is not a cost worth
+ * optimising against. */
+enum { kHoldFrames = 45 };
+
+/* Subsampling stride for the frame mean. The mean is a measure of the whole
+ * picture's brightness, not a checksum: on a 342x224 frame a stride of 4 in x
+ * and 2 in y still averages ~9,500 pixels, which pins the mean to well under
+ * one 255th. Costs an eighth of the reads a full pass would.
+ *
+ * Strides are coprime with nothing in particular on purpose — a SNES frame is
+ * built from 8-pixel tiles, and a stride of 8 would sample the same column of
+ * every tile and could sit entirely on, say, a sprite outline. 4 and 2 both
+ * divide 8, so they sample several positions within each tile. */
+enum { kStrideX = 4, kStrideY = 2 };
+
+struct RecompFlashGuard {
+    uint32_t *prev;      /* the previously PRESENTED frame, tightly packed */
+    size_t    capacity;  /* pixels prev can hold (kept, never shrunk) */
+    int       width;
+    int       height;
+    int       valid;     /* 0 => prev holds nothing to mix with */
+
+    int limit;           /* presented step limit, 1..255 */
+
+    /* Frame means of the last PRESENTED frame, and of the last INCOMING one.
+     * Both are needed and they are not the same number once the guard starts
+     * limiting: the presented mean is what the next step is measured against,
+     * the incoming mean is what tells a reversal from a continuing move. */
+    int out_mean[3];
+    int in_mean[3];
+
+    int run;             /* consecutive limited frames */
+    int last_sign;       /* -1/0/+1: direction of the last significant step */
+    int hold;            /* frames left of the reversal hold */
+
+    uint64_t frames;
+    uint64_t limited;
+    uint64_t events;
+    int      peak_step;
+};
+
+RecompFlashGuard *recomp_flash_guard_create(void) {
+    RecompFlashGuard *guard =
+        (RecompFlashGuard *)calloc(1, sizeof(RecompFlashGuard));
+    if (guard) guard->limit = kRecompFlashGuardStandard;
+    return guard;
+}
+
+void recomp_flash_guard_destroy(RecompFlashGuard *guard) {
+    if (!guard) return;
+    free(guard->prev);
+    free(guard);
+}
+
+void recomp_flash_guard_set_limit(RecompFlashGuard *guard, int limit) {
+    if (!guard) return;
+    if (limit < 0)   limit = 0;
+    if (limit > 255) limit = 255;
+    guard->limit = limit;
+}
+
+int recomp_flash_guard_get_limit(const RecompFlashGuard *guard) {
+    return guard ? guard->limit : 0;
+}
+
+void recomp_flash_guard_reset(RecompFlashGuard *guard) {
+    if (!guard) return;
+    guard->valid = 0;
+    guard->run = 0;
+    guard->last_sign = 0;
+    guard->hold = 0;
+}
+
+/* Grows (never shrinks) the kept frame to width*height, resetting whenever the
+ * geometry changes: prev is indexed by the width it was captured at, so a kept
+ * frame from a different width would mix misaligned rows. Same contract as
+ * recomp_frame_blend's ensure_prev, for the same reason. */
+static int ensure_prev(RecompFlashGuard *guard, int width, int height) {
+    size_t want;
+    if (guard->width == width && guard->height == height && guard->prev)
+        return 1;
+    want = (size_t)width * (size_t)height;
+    if (want > guard->capacity) {
+        uint32_t *grown = (uint32_t *)realloc(guard->prev,
+                                              want * sizeof(*grown));
+        if (!grown) return 0;
+        guard->prev = grown;
+        guard->capacity = want;
+    }
+    guard->width  = width;
+    guard->height = height;
+    guard->valid  = 0;
+    guard->run = 0;
+    guard->last_sign = 0;
+    guard->hold = 0;
+    return 1;
+}
+
+/* Mean B, G, R of the frame, subsampled. Gamma-space, not linearised: the
+ * comparison that matters is between two means measured the same way, and a
+ * linear-light mean would make the filter markedly more aggressive in the
+ * shadows for no benefit the player can see. Stated because "WCAG relative
+ * luminance" is linear, and someone will reasonably expect this to be too. */
+static void frame_mean(const unsigned char *base, int width, int height,
+                       size_t pitch_bytes, int out_mean[3]) {
+    uint32_t sum[3] = { 0, 0, 0 };
+    uint32_t n = 0;
+    int y;
+
+    for (y = 0; y < height; y += kStrideY) {
+        const unsigned char *row = base + (size_t)y * pitch_bytes;
+        int x;
+        for (x = 0; x < width; x += kStrideX) {
+            const unsigned char *px = row + (size_t)x * 4u;
+            sum[0] += px[0];
+            sum[1] += px[1];
+            sum[2] += px[2];
+            ++n;
+        }
+    }
+    if (!n) n = 1;
+    out_mean[0] = (int)(sum[0] / n);
+    out_mean[1] = (int)(sum[1] / n);
+    out_mean[2] = (int)(sum[2] / n);
+}
+
+/* The step between two frame means, as the largest per-channel difference.
+ *
+ * Per-channel rather than luminance because an equal-luminance colour strobe
+ * is still a strobe — the ISO/IEC and ITU guidance singles out saturated red
+ * transitions specifically, and a luminance-only metric scores those near
+ * zero. Taking the max over channels costs nothing extra (the means are
+ * already per-channel) and cannot score a flash LOWER than a luminance metric
+ * would, which is the direction an accessibility filter should err in. */
+static int mean_step(const int a[3], const int b[3], int *sign_out) {
+    int i;
+    int step = 0;
+    int signed_sum = 0;
+    for (i = 0; i < 3; ++i) {
+        const int d = a[i] - b[i];
+        const int m = d < 0 ? -d : d;
+        if (m > step) step = m;
+        signed_sum += d;
+    }
+    if (sign_out)
+        *sign_out = signed_sum > 0 ? 1 : (signed_sum < 0 ? -1 : 0);
+    return step;
+}
+
+int recomp_flash_guard_apply(RecompFlashGuard *guard, void *frame,
+                             int width, int height, size_t pitch_bytes) {
+    unsigned char *base = (unsigned char *)frame;
+    int in_mean[3];
+    int step, sign;
+    int alpha;      /* 0..256, the weight given to the incoming frame */
+    int y;
+
+    if (!guard || !frame || width <= 0 || height <= 0) return 0;
+    if (pitch_bytes < (size_t)width * 4u) return 0;
+    if (guard->limit <= 0) return 0;
+    if (!ensure_prev(guard, width, height)) return 0;
+
+    ++guard->frames;
+    frame_mean(base, width, height, pitch_bytes, in_mean);
+
+    /* Detection runs against the INCOMING frames, so that what is being
+     * classified is what the game drew — not what this filter has already
+     * softened. Feeding the decision its own output is how a limiter talks
+     * itself out of limiting. */
+    if (guard->valid) {
+        int in_sign = 0;
+        const int in_step = mean_step(in_mean, guard->in_mean, &in_sign);
+        if (in_step > guard->peak_step)
+            guard->peak_step = in_step;
+        if (in_step >= guard->limit && in_sign != 0) {
+            if (guard->last_sign != 0 && in_sign != guard->last_sign) {
+                /* A reversal: the picture has moved a long way and come back.
+                 * That is the definition of a flash, and one is enough — the
+                 * guard does not wait to count three per second the way the
+                 * standard does, because the cost of engaging on something
+                 * that turns out not to be a flash is one softened frame
+                 * nobody notices. */
+                if (!guard->hold)
+                    ++guard->events;
+                guard->hold = kHoldFrames;
+            }
+            guard->last_sign = in_sign;
+        }
+    }
+    if (guard->hold > 0)
+        --guard->hold;
+    memcpy(guard->in_mean, in_mean, sizeof(in_mean));
+
+    /* First frame after a reset or a resize: nothing to mix with. Capture and
+     * present as drawn. */
+    if (!guard->valid) {
+        for (y = 0; y < height; ++y)
+            memcpy(guard->prev + (size_t)y * (size_t)width,
+                   base + (size_t)y * pitch_bytes, (size_t)width * 4u);
+        memcpy(guard->out_mean, in_mean, sizeof(in_mean));
+        guard->valid = 1;
+        guard->run = 0;
+        return 0;
+    }
+
+    step = mean_step(in_mean, guard->out_mean, &sign);
+
+    if (step <= guard->limit) {
+        /* The ordinary case, and the one that has to be free: the picture is
+         * moving no faster than the limit, so it is presented exactly as
+         * drawn — not mixed, not rounded, byte-identical. */
+        guard->run = 0;
+        goto pass_through;
+    }
+
+    if (guard->run >= kReleaseFrames && guard->hold == 0) {
+        /* A cut, not a flash: a large step, sustained in one direction, with
+         * no reversal recently. Snap to it rather than fading into it. */
+        guard->run = 0;
+        goto pass_through;
+    }
+
+    /* Limit. alpha = limit/step in 1/256ths, so the presented mean moves by
+     * exactly the limit and no further. Clamped to at least 1 so a colossal
+     * step still advances the picture instead of freezing it. */
+    alpha = (guard->limit * 256) / step;
+    if (alpha < 1)   alpha = 1;
+    if (alpha > 255) alpha = 255;   /* step > limit, so this is a guard only */
+
+    for (y = 0; y < height; ++y) {
+        uint32_t *row  = (uint32_t *)(void *)(base + (size_t)y * pitch_bytes);
+        uint32_t *prev = guard->prev + (size_t)y * (size_t)width;
+        int x;
+        for (x = 0; x < width; ++x) {
+            const uint32_t cur = row[x];
+            const uint32_t old = prev[x];
+            /* Per channel: old + alpha*(cur - old), in 1/256ths. Done on the
+             * three colour bytes only; the top byte is carried from the
+             * incoming pixel untouched (see the header — it is padding, and
+             * on at least one PPU it is zero). */
+            const int b = (int)((old >>  0) & 0xFFu) +
+                          (((int)((cur >>  0) & 0xFFu) -
+                            (int)((old >>  0) & 0xFFu)) * alpha >> 8);
+            const int g = (int)((old >>  8) & 0xFFu) +
+                          (((int)((cur >>  8) & 0xFFu) -
+                            (int)((old >>  8) & 0xFFu)) * alpha >> 8);
+            const int r = (int)((old >> 16) & 0xFFu) +
+                          (((int)((cur >> 16) & 0xFFu) -
+                            (int)((old >> 16) & 0xFFu)) * alpha >> 8);
+            const uint32_t out = (cur & 0xFF000000u) |
+                                 ((uint32_t)r << 16) |
+                                 ((uint32_t)g <<  8) |
+                                 (uint32_t)b;
+            row[x] = out;
+            prev[x] = out;
+        }
+    }
+
+    /* The kept frame is the PRESENTED one, not the incoming one — the
+     * opposite of recomp_frame_blend, which keeps the unblended frame so its
+     * mix cannot feed back on itself. Here the feedback IS the mechanism: the
+     * limit is on the step the display shows, so the next step has to be
+     * measured from what was actually shown. */
+    frame_mean(base, width, height, pitch_bytes, guard->out_mean);
+    ++guard->run;
+    ++guard->limited;
+    return 1;
+
+pass_through:
+    for (y = 0; y < height; ++y)
+        memcpy(guard->prev + (size_t)y * (size_t)width,
+               base + (size_t)y * pitch_bytes, (size_t)width * 4u);
+    memcpy(guard->out_mean, in_mean, sizeof(in_mean));
+    return 0;
+}
+
+void recomp_flash_guard_get_stats(const RecompFlashGuard *guard,
+                                  RecompFlashGuardStats *out) {
+    if (!out) return;
+    memset(out, 0, sizeof(*out));
+    if (!guard) return;
+    out->frames    = guard->frames;
+    out->limited   = guard->limited;
+    out->events    = guard->events;
+    out->peak_step = guard->peak_step;
+    out->holding   = guard->hold > 0;
+}

--- a/src/common/recomp_frame_blend.c
+++ b/src/common/recomp_frame_blend.c
@@ -1,0 +1,83 @@
+/* recomp_frame_blend.c — see recomp_frame_blend.h. */
+
+#include "recomp_frame_blend.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+struct RecompFrameBlend {
+    uint32_t *prev;      /* the previous frame, UNBLENDED, tightly packed */
+    size_t    capacity;  /* pixels prev can hold (kept, never shrunk) */
+    int       width;
+    int       height;
+    int       valid;     /* 0 => prev holds nothing to blend with */
+};
+
+RecompFrameBlend *recomp_frame_blend_create(void) {
+    return (RecompFrameBlend *)calloc(1, sizeof(RecompFrameBlend));
+}
+
+void recomp_frame_blend_destroy(RecompFrameBlend *blend) {
+    if (!blend) return;
+    free(blend->prev);
+    free(blend);
+}
+
+void recomp_frame_blend_reset(RecompFrameBlend *blend) {
+    if (blend) blend->valid = 0;
+}
+
+/* Grows (never shrinks) the kept frame to width*height, resetting whenever
+ * the geometry changes: prev is indexed by the width it was captured at, so
+ * a kept frame from a different width would blend misaligned rows. */
+static int ensure_prev(RecompFrameBlend *blend, int width, int height) {
+    size_t want;
+    if (blend->width == width && blend->height == height && blend->prev)
+        return 1;
+    want = (size_t)width * (size_t)height;
+    if (want > blend->capacity) {
+        uint32_t *grown = (uint32_t *)realloc(blend->prev,
+                                              want * sizeof(*grown));
+        if (!grown) return 0;
+        blend->prev = grown;
+        blend->capacity = want;
+    }
+    blend->width  = width;
+    blend->height = height;
+    blend->valid  = 0;
+    return 1;
+}
+
+int recomp_frame_blend_apply(RecompFrameBlend *blend, void *frame,
+                             int width, int height, size_t pitch_bytes) {
+    unsigned char *base = (unsigned char *)frame;
+    int blended;
+    int y;
+
+    if (!blend || !frame || width <= 0 || height <= 0) return 0;
+    if (pitch_bytes < (size_t)width * 4u) return 0;
+    if (!ensure_prev(blend, width, height)) return 0;
+
+    /* prev keeps the UNBLENDED frame, so the mix never feeds back on itself
+     * and the source buffer the host drew from stays pure for thumbnails and
+     * captures. Both are read and written in one pass. */
+    blended = blend->valid;
+    for (y = 0; y < height; ++y) {
+        uint32_t *row  = (uint32_t *)(void *)(base + (size_t)y * pitch_bytes);
+        uint32_t *prev = blend->prev + (size_t)y * (size_t)width;
+        int x;
+        for (x = 0; x < width; ++x) {
+            uint32_t cur = row[x];
+            /* Per-byte average without widening: (a&b) + ((a^b)>>1) is the
+             * mean of each byte, and masking the shift with 0x7F7F7F7F drops
+             * the bit that crossed a byte boundary. Each byte result is at
+             * most 255, so the add cannot carry between bytes either. */
+            if (blended)
+                row[x] = (cur & prev[x]) +
+                         (((cur ^ prev[x]) >> 1) & 0x7F7F7F7Fu);
+            prev[x] = cur;
+        }
+    }
+    blend->valid = 1;
+    return blended;
+}

--- a/src/common/recomp_moderation.c
+++ b/src/common/recomp_moderation.c
@@ -1,0 +1,199 @@
+/* recomp_moderation.c — see recomp_moderation.h. */
+
+#include "recomp_moderation.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#define MOD_MAX_ENTRIES 512
+
+typedef struct {
+    char key[RECOMP_MOD_KEY_CAP];
+    char name[RECOMP_MOD_NAME_CAP];
+    RecompModLevel level;
+} ModEntry;
+
+static ModEntry g_entries[MOD_MAX_ENTRIES];
+static int      g_count;
+static char     g_path[1024];
+static int      g_loaded;
+
+static void trim(char *s)
+{
+    size_t n;
+    char *p = s;
+    while (*p == ' ' || *p == '\t') ++p;
+    if (p != s) memmove(s, p, strlen(p) + 1);
+    n = strlen(s);
+    while (n && (s[n - 1] == '\n' || s[n - 1] == '\r' ||
+                 s[n - 1] == ' '  || s[n - 1] == '\t'))
+        s[--n] = '\0';
+}
+
+static ModEntry *find(const char *account)
+{
+    int i;
+    if (!account || !account[0]) return NULL;
+    for (i = 0; i < g_count; ++i)
+        if (strcmp(g_entries[i].key, account) == 0) return &g_entries[i];
+    return NULL;
+}
+
+void recomp_moderation_load(const char *exe_dir)
+{
+    FILE *f;
+    char line[512];
+    RecompModLevel section = RECOMP_MOD_NONE;
+
+    g_count = 0;
+    g_loaded = 1;
+    snprintf(g_path, sizeof(g_path), "%s/moderation.ini",
+             (exe_dir && exe_dir[0]) ? exe_dir : ".");
+    f = fopen(g_path, "rb");
+    if (!f) return;   /* nothing blocked yet is the overwhelmingly common case */
+
+    while (fgets(line, sizeof(line), f)) {
+        char *eq;
+        trim(line);
+        if (!line[0] || line[0] == '#' || line[0] == ';') continue;
+        if (line[0] == '[') {
+            if (!strcmp(line, "[ignored]"))      section = RECOMP_MOD_IGNORED;
+            else if (!strcmp(line, "[blocked]")) section = RECOMP_MOD_BLOCKED;
+            else                                 section = RECOMP_MOD_NONE;
+            continue;
+        }
+        if (section == RECOMP_MOD_NONE) continue;
+        if (g_count >= MOD_MAX_ENTRIES) break;
+        eq = strchr(line, '=');
+        if (eq) { *eq = '\0'; ++eq; } else { eq = (char *)""; }
+        trim(line);
+        trim(eq);
+        /* A key longer than the field is not one of ours -- a hand-edited
+         * file, or a different format. Skipped rather than truncated: a
+         * truncated key would silently match nobody, or worse, somebody. */
+        if (!line[0] || strlen(line) >= sizeof(g_entries[g_count].key)) continue;
+        memcpy(g_entries[g_count].key, line, strlen(line) + 1);
+        snprintf(g_entries[g_count].name, sizeof(g_entries[g_count].name), "%s", eq);
+        g_entries[g_count].level = section;
+        ++g_count;
+    }
+    fclose(f);
+}
+
+int recomp_moderation_save(void)
+{
+    FILE *f;
+    int i;
+    if (!g_loaded) return -1;
+    f = fopen(g_path, "wb");
+    if (!f) return -1;
+    fprintf(f,
+        "# Players you have chosen not to hear from, or not to meet.\n"
+        "#\n"
+        "# The key on the left is an opaque account id from the lobby server.\n"
+        "# The name on the right is only a LABEL, so this file is readable --\n"
+        "# it is never matched on, and it is whatever the player was last\n"
+        "# called. Renaming does not escape this list, and nobody inherits an\n"
+        "# entry by taking a name.\n"
+        "#\n"
+        "#   [ignored]  their chat is hidden\n"
+        "#   [blocked]  hidden everywhere, and the matchmaker is asked not to\n"
+        "#              pair you\n"
+        "#\n"
+        "# Written by the launcher; safe to edit by hand while it is closed.\n");
+    for (i = 0; i < 2; ++i) {
+        const RecompModLevel want = i == 0 ? RECOMP_MOD_IGNORED : RECOMP_MOD_BLOCKED;
+        int j, any = 0;
+        for (j = 0; j < g_count; ++j) {
+            if (g_entries[j].level != want) continue;
+            if (!any) {
+                fprintf(f, "\n[%s]\n", want == RECOMP_MOD_IGNORED ? "ignored" : "blocked");
+                any = 1;
+            }
+            fprintf(f, "%s = %s\n", g_entries[j].key, g_entries[j].name);
+        }
+    }
+    fclose(f);
+    return 0;
+}
+
+RecompModLevel recomp_moderation_level(const char *account)
+{
+    const ModEntry *e = find(account);
+    return e ? e->level : RECOMP_MOD_NONE;
+}
+
+/* Block implies ignore, so every "should I hide this line?" caller asks one
+ * question instead of remembering to ask two. */
+int recomp_moderation_is_ignored(const char *account)
+{
+    return recomp_moderation_level(account) != RECOMP_MOD_NONE;
+}
+
+int recomp_moderation_is_blocked(const char *account)
+{
+    return recomp_moderation_level(account) == RECOMP_MOD_BLOCKED;
+}
+
+void recomp_moderation_set(const char *account, const char *last_seen_name,
+                           RecompModLevel level)
+{
+    ModEntry *e;
+    if (!account || !account[0]) return;   /* a guest has no durable identity */
+    e = find(account);
+    if (level == RECOMP_MOD_NONE) {
+        if (!e) return;
+        *e = g_entries[--g_count];         /* order is not meaningful here */
+        recomp_moderation_save();
+        return;
+    }
+    if (!e) {
+        if (g_count >= MOD_MAX_ENTRIES) return;
+        e = &g_entries[g_count++];
+        memset(e, 0, sizeof(*e));
+        snprintf(e->key, sizeof(e->key), "%s", account);
+    }
+    if (last_seen_name && last_seen_name[0])
+        snprintf(e->name, sizeof(e->name), "%s", last_seen_name);
+    e->level = level;
+    /* Saved on every change, not at exit: the launcher hands the process to
+     * the game, and a block that only reached memory would be lost there. */
+    recomp_moderation_save();
+}
+
+int recomp_moderation_count(void) { return g_count; }
+
+int recomp_moderation_get(int index, char *account_out, size_t account_cap,
+                          char *name_out, size_t name_cap,
+                          RecompModLevel *level_out)
+{
+    if (index < 0 || index >= g_count) return 0;
+    if (account_out && account_cap)
+        snprintf(account_out, account_cap, "%s", g_entries[index].key);
+    if (name_out && name_cap)
+        snprintf(name_out, name_cap, "%s", g_entries[index].name);
+    if (level_out) *level_out = g_entries[index].level;
+    return 1;
+}
+
+int recomp_moderation_blocked_list(char *out, size_t cap)
+{
+    int i;
+    size_t n = 0;
+    if (out && cap) out[0] = '\0';
+    for (i = 0; i < g_count; ++i) {
+        size_t need;
+        if (g_entries[i].level != RECOMP_MOD_BLOCKED) continue;
+        need = strlen(g_entries[i].key) + (n ? 1u : 0u);
+        if (out && n + need + 1 <= cap) {
+            if (n) out[n++] = ';';
+            memcpy(out + n, g_entries[i].key, strlen(g_entries[i].key));
+            n += strlen(g_entries[i].key);
+            out[n] = '\0';
+        } else {
+            n += need;
+        }
+    }
+    return (int)n;
+}

--- a/src/consoles/snes/snes_profile.h
+++ b/src/consoles/snes/snes_profile.h
@@ -82,7 +82,16 @@ static const SystemProfile kSystemProfileSnes = {
                                     * LoadState slots on SNES), so this row
                                     * shows "(unbound)" until a player picks a
                                     * key or a port's config.ini names one. */
-                                   (1u << LNG_HK_SAVE_STATE_MENU)),
+                                   (1u << LNG_HK_SAVE_STATE_MENU) |
+                                   /* Rewind: added now that snes_rewind.c
+                                    * exists behind it. It was deliberately
+                                    * withheld while there was nothing to
+                                    * bind, on the same principle as
+                                    * n64_profile.h's debug-tools note -- a
+                                    * control that does nothing is worse than
+                                    * an absent one. Unbound by default here
+                                    * too: F8 is LoadState slot 8. */
+                                   (1u << LNG_HK_REWIND)),
     /* panels_dashboard  */ kPanelsDashboardCommon,
     /* panels_settings   */ kPanelsSettingsSnes,
     /* panels_controller */ kPanelsControllerCommon,

--- a/src/consoles/snes/snes_profile.h
+++ b/src/consoles/snes/snes_profile.h
@@ -71,7 +71,18 @@ static const SystemProfile kSystemProfileSnes = {
         /*bios*/0, /*deadzone*/0,
     },
     /* verify */  { 0, NULL },
-    /* hotkeys_mask */ LNG_HOTKEYS_ALL,
+    /* hotkeys_mask */ (uint32_t)(LNG_HOTKEYS_ALL |
+                                   /* Save-state slot browser: the SNES runner
+                                    * has had snes_savestate_menu.c for a while,
+                                    * but the bind was unreachable here because
+                                    * LNG_HOTKEYS_ALL stops at bit 10 and this
+                                    * one is bit 15 — ports hardcoded a key
+                                    * instead. Note the framework leaves it
+                                    * UNBOUND by default (F1..F10 are the ten
+                                    * LoadState slots on SNES), so this row
+                                    * shows "(unbound)" until a player picks a
+                                    * key or a port's config.ini names one. */
+                                   (1u << LNG_HK_SAVE_STATE_MENU)),
     /* panels_dashboard  */ kPanelsDashboardCommon,
     /* panels_settings   */ kPanelsSettingsSnes,
     /* panels_controller */ kPanelsControllerCommon,

--- a/src/proto_main.c
+++ b/src/proto_main.c
@@ -170,7 +170,14 @@ static int  dl_spectator_slot(void* c, int index) { (void)c; return DEMO_SPEC_BA
 static int  dl_connected(void* c) { (void)c; return 1; }
 static void dl_pump(void* c) { (void)c; demo_lobby_pump(); }
 static void dl_set_player_name(void* c, const char* n) { (void)c; (void)n; }
-static const char* dl_player_name(void* c) { (void)c; return demo_lobby_host ? "Alex" : "Marisa"; }
+static int demo_acct_preview = 0; /* LNG_DEMO_ACCOUNT set: leave the name empty
+                                   * so the Player Name modal opens by itself
+                                   * and the sign-in section is screenshottable */
+static const char* dl_player_name(void* c) {
+    (void)c;
+    if (demo_acct_preview) return "";
+    return demo_lobby_host ? "Alex" : "Marisa";
+}
 static void dl_request_list(void* c) { (void)c; }
 static int  dl_list_count(void* c) { (void)c; return 1; }
 static int  dl_list_get(void* c, int i, RecompLauncherCNetplayLobby* o) {
@@ -308,6 +315,41 @@ static int dl_chat_get(void* c, int i, RecompLauncherCNetplayChatMessage* out) {
     out->seq = (uint32_t)(i + 1);
     return 1;
 }
+/* ---- LNG_DEMO_ACCOUNT: preview the Discord sign-in states -----------------
+ * guest | waiting | in | failed | off  (off = server offers no logins, so no
+ * sign-in affordance is drawn at all). No network: the launcher never does the
+ * HTTP itself, so a fake host is enough to exercise every state. */
+static int  demo_acct_state = RECOMP_LAUNCHER_ACCOUNT_GUEST;
+static int  demo_acct_avail = 1;
+static char demo_acct_handle[64] = "Reimu";
+static int  dl_account_available(void* c) { (void)c; return demo_acct_avail; }
+static int  dl_account_state(void* c) { (void)c; return demo_acct_state; }
+static const char* dl_account_handle(void* c) { (void)c; return demo_acct_handle; }
+static const char* dl_account_username(void* c) { (void)c; return "reimu_h"; }
+static const char* dl_account_error(void* c) {
+    (void)c;
+    return "Discord did not complete the sign-in. Try again.";
+}
+static int dl_account_login_begin(void* c) {
+    (void)c;
+    demo_acct_state = RECOMP_LAUNCHER_ACCOUNT_WAITING;
+    fprintf(stderr, "[demo] would open the browser at the server's authorize URL\n");
+    return 0;
+}
+static int dl_account_sign_out(void* c) {
+    (void)c;
+    demo_acct_state = RECOMP_LAUNCHER_ACCOUNT_GUEST;
+    return 0;
+}
+static int dl_account_set_handle(void* c, const char* h) {
+    (void)c;
+    /* The real host asks the server, which refuses a name on the word list. */
+    if (!h || !h[0]) return -1;
+    snprintf(demo_acct_handle, sizeof(demo_acct_handle), "%s", h);
+    fprintf(stderr, "[demo] handle -> %s\n", demo_acct_handle);
+    return 0;
+}
+
 static RecompLauncherCNetplayCallbacks demo_lobby_cb;
 
 static void demo_lobby_install(RecompLauncherCGameInfo* gi, const char* mode) {
@@ -330,6 +372,24 @@ static void demo_lobby_install(RecompLauncherCGameInfo* gi, const char* mode) {
     demo_lobby_cb.server_chat_send = dl_schat_send;
     demo_lobby_cb.server_chat_count = dl_schat_count;
     demo_lobby_cb.server_chat_get = dl_schat_get;
+    {
+        const char* a = SDL_getenv("LNG_DEMO_ACCOUNT");
+        if (a && a[0]) {
+            demo_acct_preview = 1;
+            if (strcmp(a, "in") == 0) demo_acct_state = RECOMP_LAUNCHER_ACCOUNT_SIGNED_IN;
+            else if (strcmp(a, "waiting") == 0) demo_acct_state = RECOMP_LAUNCHER_ACCOUNT_WAITING;
+            else if (strcmp(a, "failed") == 0) demo_acct_state = RECOMP_LAUNCHER_ACCOUNT_FAILED;
+            else if (strcmp(a, "off") == 0) demo_acct_avail = 0;
+        }
+    }
+    demo_lobby_cb.account_available = dl_account_available;
+    demo_lobby_cb.account_login_begin = dl_account_login_begin;
+    demo_lobby_cb.account_state = dl_account_state;
+    demo_lobby_cb.account_handle = dl_account_handle;
+    demo_lobby_cb.account_username = dl_account_username;
+    demo_lobby_cb.account_error = dl_account_error;
+    demo_lobby_cb.account_sign_out = dl_account_sign_out;
+    demo_lobby_cb.account_set_handle = dl_account_set_handle;
     demo_schat_push("Sakuya", "anyone up for a set? \xF0\x9F\x94\xA5", 0);
     demo_schat_push("Reimu", "hosting now, come in", 0);
     demo_lobby_cb.leave = dl_leave;

--- a/src/recomp_flash_guard.h
+++ b/src/recomp_flash_guard.h
@@ -1,0 +1,197 @@
+#ifndef RECOMP_FLASH_GUARD_H
+#define RECOMP_FLASH_GUARD_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Presentation flash guard — cap how far the presented picture may move
+ * between one displayed frame and the next.
+ *
+ * WHAT IT IS FOR
+ * --------------
+ * Console games flash the whole screen: a super move connects, a round ends,
+ * a boss explodes, and the backdrop is slammed between two extreme colours for
+ * half a second. On the original hardware that was a design choice. For a
+ * player with photosensitive epilepsy — or with migraine, vestibular
+ * sensitivity, or simply a low tolerance for strobing — it is the reason they
+ * cannot play the game at all.
+ *
+ * The thresholds are not a matter of taste. WCAG 2.3.1 counts a *flash* as a
+ * pair of opposing changes in relative luminance of 10% or more of the range,
+ * and calls content unsafe at more than three such flashes per second over
+ * more than 25% of the visible area. The risk band runs from about 3 Hz to
+ * 60 Hz and peaks between 15 Hz and 25 Hz.
+ *
+ * MEASURED, on the sequence this was written for (Gundam Wing: Endless Duel,
+ * the end-of-fight finisher, from a player capture — see the GWED repo's
+ * docs/FLASH_GUARD.md):
+ *
+ *     backdrop alternates flat blue (mean RGB 31,26,140) and near-white
+ *     (152,153,150) — a frame-mean luminance swing of ~119/255, about 47% of
+ *     the range, over essentially the whole screen, at 15 Hz, for ~0.65 s.
+ *
+ * That is roughly five times the WCAG flash threshold, at the frequency where
+ * the risk is highest. It is not a borderline case.
+ *
+ * WHY IT IS NOT A FRAME BLEND
+ * ---------------------------
+ * recomp_frame_blend.h, next door, averages every presented frame with the one
+ * before it to reconstruct 30 Hz flicker transparency. It does not help here
+ * and cannot: the flash measured above holds each phase for TWO guest frames,
+ * so averaging adjacent frames mostly averages a frame with its own twin and
+ * both plateaus survive intact. Confirmed on the capture — with blending on
+ * (this title ships it on) the plateaus still read 42 and 161.
+ *
+ * A fixed blend is also the wrong shape for the job. It costs every frame of
+ * the game half a frame of ghosting in order to fix the one second in a match
+ * that is actually dangerous. This filter is idle — bit-identical output, no
+ * blend at all — on any frame whose step is already under the limit, which in
+ * ordinary play is all of them.
+ *
+ * WHAT IT DOES
+ * ------------
+ * One number: the largest per-channel change, frame mean to frame mean, that
+ * may reach the display in a single frame. Give it a step limit L (0..255).
+ *
+ *   - Step within L: the frame is presented exactly as drawn. Not touched,
+ *     not copied through any arithmetic, byte-identical.
+ *   - Step over L: the frame is mixed with the previously PRESENTED frame at
+ *     alpha = L/step, which by construction lands the presented step on
+ *     exactly L.
+ *
+ * Because a strobe alternates, the swing the player sees becomes about 2L
+ * instead of the source's. At L = 12 that is a ~24/255 swing — under the 10%
+ * WCAG line — in place of the measured 119.
+ *
+ * Everything the filter presents is a convex mix of two frames the game
+ * actually drew, so it cannot invent a colour, cannot clip, and cannot push
+ * anything out of gamut. That matters more than elegance for a feature whose
+ * failure mode is a seizure.
+ *
+ * CUTS ARE NOT FLASHES
+ * --------------------
+ * A round starting, a stage loading, a menu opening — each is one large step
+ * that does not come back. Limiting those would put a soft fade on every
+ * scene change in the game, which is both wrong and irritating. So the filter
+ * releases: after kReleaseFrames consecutive limited frames it lets the frame
+ * through as drawn, and a cut costs two frames of ramp (~33 ms) rather than a
+ * fade.
+ *
+ * It must NOT release during a strobe, and the release counter alone cannot
+ * tell the two apart — a slow enough strobe would out-wait any fixed count.
+ * What distinguishes them is that a strobe REVERSES. The filter watches the
+ * sign of the frame-mean step, and a reversal larger than the limit latches a
+ * hold for kHoldFrames; while that hold is live, release is disabled and the
+ * strobe stays pinned however long it runs and whatever its period.
+ *
+ * The first flash of a sequence is limited before any of this is known,
+ * because the limiter is always armed and detection only decides whether to
+ * stop releasing. A guard that waited to confirm a flash would have to let
+ * the first one through at full amplitude, and the first one is the one that
+ * is least expected.
+ *
+ * WHAT IT DOES NOT TOUCH
+ * ----------------------
+ * Pixels on their way to the screen, and nothing else. No CPU, WRAM, VRAM,
+ * OAM, CGRAM, APU or save state — so a session with this on executes the
+ * identical guest frames as one without, two netplay peers stay digest-equal
+ * whichever of them is running it, and it is not something a peer can be
+ * required to match. That independence is the point: the player who needs it
+ * is not usually the player who picked the lobby.
+ *
+ * Inert until a host creates one and calls apply; a host that never does is
+ * byte-identical to one built before this file existed. Whether it is on by
+ * default, and at what limit, is game policy decided in the game repo — this
+ * file has no default of its own.
+ */
+
+typedef struct RecompFlashGuard RecompFlashGuard;
+
+/* Presented-step limits, as the largest per-channel frame-mean change allowed
+ * per displayed frame. A strobe's visible swing settles at about twice these.
+ *
+ * kRecompFlashGuardStandard is the one to reach for: 12/255 per step is a
+ * ~9.4% swing, just inside the WCAG 2.3.1 10% flash threshold. Mild trades
+ * some of that margin for a livelier picture; Maximum is for players who want
+ * the effect gone rather than merely compliant. */
+enum {
+    kRecompFlashGuardMild     = 20,
+    kRecompFlashGuardStandard = 12,
+    kRecompFlashGuardMaximum  = 6
+};
+
+/* NULL on allocation failure. A NULL handle is legal everywhere below and
+ * makes every call a no-op, so a host may ignore the failure and present
+ * unguarded frames — the same contract as recomp_frame_blend. */
+RecompFlashGuard *recomp_flash_guard_create(void);
+void recomp_flash_guard_destroy(RecompFlashGuard *guard);
+
+/* The step limit, 1..255. Values outside the range are clamped. 0 disables
+ * the filter (apply becomes a no-op that still tracks nothing); prefer simply
+ * not calling apply. Safe to change mid-session — it takes effect on the next
+ * frame and does not disturb the kept frame. */
+void recomp_flash_guard_set_limit(RecompFlashGuard *guard, int limit);
+int recomp_flash_guard_get_limit(const RecompFlashGuard *guard);
+
+/*
+ * Forget the previous frame and drop the flash hold, so the next frame is
+ * presented as drawn. Call it wherever the frame before is not the frame the
+ * player was looking at: boot, reset, loading a save state, rewind, entering
+ * or leaving the launcher. Carrying state across such a cut would mix a stale
+ * frame into a new scene and could hold a phantom flash open.
+ *
+ * A frame size change resets automatically — the kept frame is indexed by the
+ * width it was captured at.
+ */
+void recomp_flash_guard_reset(RecompFlashGuard *guard);
+
+/*
+ * Limit `frame` (little-endian ARGB8888/BGRA, `height` rows of `width` pixels
+ * `pitch_bytes` apart) in place. Returns non-zero when the frame was actually
+ * mixed — that is, when a flash was being suppressed this frame — and zero
+ * when it passed through untouched, which is the ordinary case.
+ *
+ * `frame` MUST BE ORDINARY CACHED MEMORY, not a mapped texture, for the same
+ * measured reason recomp_frame_blend.h gives at length: this is a
+ * read-modify-write, SDL_LockTexture often hands back write-combined driver
+ * memory, and reading it is pathological on some drivers and fine on others.
+ * Blend into a staging frame, then upload it with one linear write-only copy.
+ *
+ * Only the low three bytes of each pixel are mixed. The top byte is taken
+ * from the incoming frame unchanged, because a console framebuffer's top byte
+ * is padding rather than coverage and some of them emit zero (see the GWED
+ * black-window finding) — averaging it would be arithmetic on a value that
+ * means nothing.
+ */
+int recomp_flash_guard_apply(RecompFlashGuard *guard, void *frame,
+                             int width, int height, size_t pitch_bytes);
+
+/*
+ * What the guard has actually done, for a diagnostics line or a probe.
+ *
+ * A filter whose whole job is to not be noticed is a filter that cannot be
+ * confirmed working by looking at it, so it has to be able to say. `limited`
+ * counting zero over a session where the player saw a flash is the signal
+ * that the guard is not wired into the path that presents.
+ */
+typedef struct RecompFlashGuardStats {
+    uint64_t frames;         /* frames seen by apply */
+    uint64_t limited;        /* of those, frames actually mixed */
+    uint64_t events;         /* distinct flash sequences detected */
+    int      peak_step;      /* largest per-channel source step seen, 0..255 */
+    int      holding;        /* non-zero while a detected flash is held down */
+} RecompFlashGuardStats;
+
+void recomp_flash_guard_get_stats(const RecompFlashGuard *guard,
+                                  RecompFlashGuardStats *out);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RECOMP_FLASH_GUARD_H */

--- a/src/recomp_frame_blend.h
+++ b/src/recomp_frame_blend.h
@@ -1,0 +1,95 @@
+#ifndef RECOMP_FRAME_BLEND_H
+#define RECOMP_FRAME_BLEND_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Presentation frame blending — average each presented frame with the one
+ * before it.
+ *
+ * WHY THIS IS SHARED, AND NOT IN A GAME
+ * -------------------------------------
+ * Many console games fake translucency by drawing a sprite on alternate
+ * frames only: thruster flames, explosions, shadows, HUD panels. On a CRT the
+ * phosphor persistence averages the two phases and the player sees 50%
+ * transparency. The trick relies on every guest frame being shown exactly
+ * once, whole, in order -- and a desktop display breaks that both ways. With
+ * vsync on, a 60.00 Hz panel against a 60.0988 Hz guest duplicates a frame
+ * roughly every ten seconds, showing the same flicker phase twice. With vsync
+ * off the scanout tears and splits the on-frame and the off-frame across one
+ * visible field.
+ *
+ * Averaging the presented frame with the previous one puts both phases in
+ * every displayed frame, so the flicker becomes steady translucency and stops
+ * caring about pacing at all. It costs half a frame of motion ghosting.
+ *
+ * Nothing above is specific to a console, a game, or a renderer -- it is
+ * arithmetic on two ARGB8888 buffers. It lives here, next to
+ * RecompLauncherCSettings.frame_blend and the Display row that sets it
+ * (GameInfo.has_frame_blend), so that every port gets one implementation
+ * rather than a copy per game that cannot inherit a fix. The measured
+ * write-combined-memory hazard documented under `apply` is exactly the kind
+ * of fix a copy would miss.
+ *
+ * The capability is inert until a host creates one and calls apply: a host
+ * that never does is byte-identical to one built before this file existed.
+ * Whether it is on by default is GAME policy, decided in the game repo --
+ * this file has no default of its own.
+ */
+
+typedef struct RecompFrameBlend RecompFrameBlend;
+
+/* NULL on allocation failure. A NULL handle is legal everywhere below and
+ * makes every call a no-op, so a host may ignore the failure and simply
+ * present unblended frames. */
+RecompFrameBlend *recomp_frame_blend_create(void);
+void recomp_frame_blend_destroy(RecompFrameBlend *blend);
+
+/*
+ * Forget the previous frame, so the next one is presented as drawn. Call it
+ * wherever the frame that came before is not the frame the player was just
+ * looking at: boot, reset, loading a save state, entering or leaving a mode
+ * that changes the picture wholesale. Blending across such a cut mixes one
+ * stale frame into the new scene.
+ *
+ * A frame size change resets automatically -- the kept frame is indexed by
+ * the width it was captured at, so keeping it across a resize would blend
+ * misaligned rows.
+ */
+void recomp_frame_blend_reset(RecompFrameBlend *blend);
+
+/*
+ * Blend `frame` (little-endian ARGB8888/BGRA, `height` rows of `width` pixels
+ * `pitch_bytes` apart) with the previously applied frame, in place. Returns
+ * non-zero when the frame was modified -- zero on the first frame after a
+ * reset or a size change, which is captured and presented as drawn, and zero
+ * for a NULL handle or NULL frame.
+ *
+ * `frame` MUST BE ORDINARY CACHED MEMORY, not a mapped texture. The blend is
+ * a read-modify-write, and SDL_LockTexture on a streaming texture frequently
+ * hands back write-combined, uncached driver memory: excellent for sequential
+ * writes, pathological to read, because every load is an uncached fetch.
+ * Whether the mapping is cached or write-combined depends on the backend and
+ * the driver, so blending in a locked texture is fine on one machine and
+ * ruins the frame rate on another -- the shape of a bug that never reproduces
+ * for the developer. Blend into a staging frame here, then upload it with one
+ * linear write-only copy, which is what write-combined memory is good at.
+ *
+ * All four bytes of each pixel are averaged, alpha included. Hosts whose
+ * frames carry a meaningful alpha channel should be aware that it is
+ * averaged too; a console framebuffer that leaves the top byte constant is
+ * unaffected (constant averaged with itself is itself).
+ */
+int recomp_frame_blend_apply(RecompFrameBlend *blend, void *frame,
+                             int width, int height, size_t pitch_bytes);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RECOMP_FRAME_BLEND_H */

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -682,6 +682,14 @@ typedef struct RecompLauncherCNetplayCallbacks {
     int         (*chat_report)(void* ctx, const char* const* mids, int mid_count,
                                const char* reason, const char* note);
 
+    /* Hand the backend the accounts this player has blocked, ';'-separated,
+     * replacing the whole set. The server needs them because two of a
+     * block's three effects cannot be done client-side: it must not pair the
+     * two in automatch, and the blocked player must not see or be able to
+     * join the blocker's room. A client can hide what it was sent; it cannot
+     * know it was blocked. NULL/"" clears. Appended for ABI stability. */
+    int         (*set_blocks)(void* ctx, const char* accounts);
+
     int         (*list_scope_set)(void* ctx, int scope);
 
     int         (*automatch_available)(void* ctx);
@@ -731,6 +739,8 @@ typedef struct RecompLauncherCNetplayCallbacks {
 
 /* Host may #ifdef this when wiring chat_report / filling ChatMessage.mid. */
 #define RECOMP_LAUNCHER_HAS_CHAT_REPORT 1
+/* Host may #ifdef this when wiring set_blocks. */
+#define RECOMP_LAUNCHER_HAS_SET_BLOCKS 1
 /* The categories the server matches on. Same list on every console; an
  * unrecognised one is stored as "other" rather than refused. */
 #define RECOMP_LAUNCHER_REPORT_HARASSMENT     "harassment"

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -527,7 +527,59 @@ typedef struct RecompLauncherCNetplayCallbacks {
      * matching prompt. NULL leaves the local check off and the server's
      * refusal still lands. */
     int  (*name_rejected)(void* ctx, const char* name);
+
+    /* ---- Discord account (optional, append-only) --------------------------
+     * Sign-in is OPTIONAL, always. A build with these NULL, a lobby server
+     * that offers no logins, and a player who never signs in are all ordinary
+     * supported cases: the launcher keeps its locally-typed player name and
+     * plays as a guest, which is what it has always done. Nothing in the seat
+     * table, the lobby list or the match path may be made to require an
+     * account.
+     *
+     * The host owns the HTTP: the launcher only opens a URL in a browser and
+     * asks the host how it is going. The flow, as the lobby server implements
+     * it (POST /auth/discord/start, GET /auth/discord/callback, POST
+     * /auth/discord/poll), is:
+     *
+     *   account_login_begin()  -> host asks the server to start a login, gets
+     *                             back a URL, and opens it in the player's
+     *                             browser. 0 = started; <0 = could not, and
+     *                             account_error says why.
+     *   account_state()        -> polled every frame while the modal is open.
+     *   account_handle()       -> the seat name the SERVER owns once signed in.
+     *   account_username()     -> the Discord @handle, shown as the
+     *                             disambiguator when two players present the
+     *                             same handle (Discord display names are not
+     *                             unique).
+     *   account_error()        -> one line for a human, when state is FAILED.
+     *   account_sign_out()     -> forget the stored session. Returns to guest;
+     *                             never fails in a way the player cares about.
+     *   account_set_handle()   -> ask the server to change the presentational
+     *                             handle. 0 = accepted; <0 = refused (it trips
+     *                             the word list), and the player picks another.
+     *
+     * account_available() reports whether the CONFIGURED lobby server offers
+     * logins at all -- the server answers 503 to a start when its operator has
+     * not set up Discord. Draw no sign-in affordance when this says no, rather
+     * than offering a button that cannot work. */
+    int         (*account_available)(void* ctx);
+    int         (*account_login_begin)(void* ctx);
+    int         (*account_state)(void* ctx); /* RecompLauncherCAccountState */
+    const char* (*account_handle)(void* ctx);
+    const char* (*account_username)(void* ctx);
+    const char* (*account_error)(void* ctx);
+    int         (*account_sign_out)(void* ctx);
+    int         (*account_set_handle)(void* ctx, const char* handle);
 } RecompLauncherCNetplayCallbacks;
+
+/* account_state() values. Guest is not an error and not a lesser state: it is
+ * the launcher's original behaviour, and most players will sit in it. */
+enum {
+    RECOMP_LAUNCHER_ACCOUNT_GUEST = 0,
+    RECOMP_LAUNCHER_ACCOUNT_WAITING = 1, /* browser open, polling */
+    RECOMP_LAUNCHER_ACCOUNT_SIGNED_IN = 2,
+    RECOMP_LAUNCHER_ACCOUNT_FAILED = 3   /* account_error() has one line */
+};
 
 /* ---- schema-driven mods --------------------------------------------------
  * The host owns package parsing, persistence, dependency resolution, and

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -529,6 +529,10 @@ typedef struct RecompLauncherCNetplayCallbacks {
     int  (*name_rejected)(void* ctx, const char* name);
 
     /* ---- Discord account (optional, append-only) --------------------------
+     * A host compiles against whatever recomp-ui its game pins, which may
+     * predate these fields. RECOMP_LAUNCHER_HAS_ACCOUNT (below the struct)
+     * lets a host wire them up when they exist and compile clean when they do
+     * not, so a runner and a UI can be updated in either order.
      * Sign-in is OPTIONAL, always. A build with these NULL, a lobby server
      * that offers no logins, and a player who never signs in are all ordinary
      * supported cases: the launcher keeps its locally-typed player name and
@@ -571,6 +575,11 @@ typedef struct RecompLauncherCNetplayCallbacks {
     int         (*account_sign_out)(void* ctx);
     int         (*account_set_handle)(void* ctx, const char* handle);
 } RecompLauncherCNetplayCallbacks;
+
+/* Present since the account callbacks were added. A host guards its wiring
+ * with `#ifdef RECOMP_LAUNCHER_HAS_ACCOUNT` so it builds against an older
+ * recomp-ui too -- the runner and the UI then land in either order. */
+#define RECOMP_LAUNCHER_HAS_ACCOUNT 1
 
 /* account_state() values. Guest is not an error and not a lesser state: it is
  * the launcher's original behaviour, and most players will sit in it. */

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -177,6 +177,35 @@ typedef struct RecompLauncherCNetplayLobbyMod {
 /* One lobby chat line, oldest first. Backends keep a short ring (the last
  * 64 or so); the UI redraws the whole ring every frame, so `seq` only has to
  * be monotonic so the UI can notice a new line and scroll to it. */
+/* One automatch queue type, as the server advertises it. The caps summary is
+ * a short human line the server builds ("Delay 2 - Rollback on"), NOT a
+ * parsed settings blob: the launcher shows what the player is signing up for
+ * and the server remains the only thing that writes match_caps. */
+typedef struct RecompLauncherCNetplayRuleset {
+    char id[48];
+    char label[64];
+    char caps_summary[128];
+    /* Empty when the ruleset accepts any release. */
+    char game_version[48];
+    int  max_slots;
+} RecompLauncherCNetplayRuleset;
+
+/* The opponent offered at the accept gate. */
+typedef struct RecompLauncherCNetplayFound {
+    char handle[64];
+    /* Discord @handle, shown small under the name -- display names are not
+     * unique, so this is the disambiguator. Empty when unknown. */
+    char username[64];
+    /* ISO 3166-1 alpha-2, drawn as a flag. Empty when the server has none. */
+    char country[4];
+    char ruleset_label[64];
+    /* Round-trip estimate through the relay, summed for both peers. <0 when
+     * the server did not offer one. */
+    int  est_rtt_ms;
+    /* Seconds left to answer. Counts down; 0 means it is about to lapse. */
+    int  accept_secs_left;
+} RecompLauncherCNetplayFound;
+
 typedef struct RecompLauncherCNetplayChatMessage {
     char     from[64];   /* display name; empty for a system line */
     char     text[256];
@@ -574,12 +603,60 @@ typedef struct RecompLauncherCNetplayCallbacks {
     const char* (*account_error)(void* ctx);
     int         (*account_sign_out)(void* ctx);
     int         (*account_set_handle)(void* ctx, const char* handle);
+
+    /* ---- automatch (optional, append-only) --------------------------------
+     * Server-run pairing: two players who want a match and do not care which
+     * lobby it happens in. The server creates the room, owns its match_caps
+     * (a named ruleset, not a host's settings) and is its host. Protocol:
+     * recomp-net-server `docs/AUTOMATCH.md`.
+     *
+     * automatch_available() reports whether the CONFIGURED server offers it --
+     * a deployment with no rulesets loaded has automatch off, and a signed-out
+     * player cannot queue at all, because the dodge cost the accept gate
+     * charges has to survive a reconnect and an ephemeral connection id does
+     * not. Online netplay draws the ⚡ Automatch button from this answer.
+     *
+     * The queue / accept callbacks land with the flow itself; this one is
+     * here first so the button is gated on a real capability rather than
+     * offered and then found not to work. */
+    int         (*automatch_available)(void* ctx);
+    /* The queue types this server offers for this title. Zero is a valid
+     * answer and means the same as automatch_available saying no. */
+    int         (*automatch_ruleset_count)(void* ctx);
+    int         (*automatch_ruleset_get)(void* ctx, int index,
+                                         RecompLauncherCNetplayRuleset* out);
+    /* Join the queue for `ruleset_id` (NULL / "" = the first one). 0 =
+     * queued; <0 = refused and automatch_error() has the line to show. The
+     * launcher builds the opted-in title list, not the host: standalone
+     * recomp-ui offers the running game and nothing else, and a multi-title
+     * launcher offers what the player ticked. */
+    int         (*automatch_queue)(void* ctx, const char* ruleset_id);
+    int         (*automatch_cancel)(void* ctx);
+    /* RecompLauncherCAutomatchState. Polled every frame while the page is up. */
+    int         (*automatch_state)(void* ctx);
+    /* Seconds this ticket has been waiting, and how many others are in the
+     * same bucket. The population is what makes a wait legible rather than
+     * indistinguishable from a broken feature, so show it. */
+    int         (*automatch_queued_secs)(void* ctx);
+    int         (*automatch_pool)(void* ctx);
+    /* 1 when a pair is on offer and `out` was filled. */
+    int         (*automatch_found_get)(void* ctx, RecompLauncherCNetplayFound* out);
+    /* Answer the accept gate. Declining (or letting it lapse) costs a queue
+     * cooldown that survives a reconnect, which is why automatch needs an
+     * account at all -- so the button says "Decline", not "Skip". */
+    int         (*automatch_accept)(void* ctx, int accept);
+    /* One line for a human when state is FAILED, or after a refused queue. */
+    const char* (*automatch_error)(void* ctx);
 } RecompLauncherCNetplayCallbacks;
 
 /* Present since the account callbacks were added. A host guards its wiring
  * with `#ifdef RECOMP_LAUNCHER_HAS_ACCOUNT` so it builds against an older
  * recomp-ui too -- the runner and the UI then land in either order. */
 #define RECOMP_LAUNCHER_HAS_ACCOUNT 1
+
+/* Present since automatch_available was added. Guarded the same way, for
+ * the same reason: a game pins a recomp-ui and the two move separately. */
+#define RECOMP_LAUNCHER_HAS_AUTOMATCH 1
 
 /* account_state() values. Guest is not an error and not a lesser state: it is
  * the launcher's original behaviour, and most players will sit in it. */
@@ -588,6 +665,16 @@ enum {
     RECOMP_LAUNCHER_ACCOUNT_WAITING = 1, /* browser open, polling */
     RECOMP_LAUNCHER_ACCOUNT_SIGNED_IN = 2,
     RECOMP_LAUNCHER_ACCOUNT_FAILED = 3   /* account_error() has one line */
+};
+
+/* automatch_state() values. IDLE is the resting state and covers "this build
+ * has no automatch" -- a page that never queues sits in it forever. */
+enum {
+    RECOMP_LAUNCHER_AUTOMATCH_IDLE = 0,
+    RECOMP_LAUNCHER_AUTOMATCH_QUEUED = 1,   /* waiting for a pair */
+    RECOMP_LAUNCHER_AUTOMATCH_FOUND = 2,    /* accept gate open; found_get fills */
+    RECOMP_LAUNCHER_AUTOMATCH_ACCEPTED = 3, /* answered, waiting on the peer */
+    RECOMP_LAUNCHER_AUTOMATCH_FAILED = 4    /* automatch_error() has one line */
 };
 
 /* ---- schema-driven mods --------------------------------------------------

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -106,6 +106,15 @@ typedef struct RecompLauncherCNetplayLobby {
  * browser's "players online" panel. */
 typedef struct RecompLauncherCNetplayOnlinePlayer {
     char display_name[64];
+    /* Opaque, stable id for the ACCOUNT behind this player; "" for a guest.
+     *
+     * Not a name and not a Discord identifier -- the server's own row key,
+     * published precisely so a client can keep a list that survives the other
+     * player reconnecting or renaming. Never render it; it is a key, not a
+     * label. A guest has none, so a guest can only be muted for as long as
+     * their connection lasts. */
+    char account[40];
+
     char country[4];     /* alpha-2 from the server's GeoIP; "" unknown */
     char lobby_name[64]; /* room they are in; "" while browsing */
     int  in_lobby;
@@ -116,6 +125,15 @@ typedef struct RecompLauncherCNetplayOnlinePlayer {
 typedef struct RecompLauncherCNetplayMember {
     int  slot;
     char display_name[64];
+    /* Opaque, stable id for the ACCOUNT behind this player; "" for a guest.
+     *
+     * Not a name and not a Discord identifier -- the server's own row key,
+     * published precisely so a client can keep a list that survives the other
+     * player reconnecting or renaming. Never render it; it is a key, not a
+     * label. A guest has none, so a guest can only be muted for as long as
+     * their connection lasts. */
+    char account[40];
+
     int  ready;
     int  is_host;
     /* Round-trip ms from the local peer *to* this seat; -1 unknown / self. */
@@ -210,6 +228,15 @@ typedef struct RecompLauncherCNetplayFound {
 
 typedef struct RecompLauncherCNetplayChatMessage {
     char     from[64];   /* display name; empty for a system line */
+    /* Opaque, stable id for the ACCOUNT behind this player; "" for a guest.
+     *
+     * Not a name and not a Discord identifier -- the server's own row key,
+     * published precisely so a client can keep a list that survives the other
+     * player reconnecting or renaming. Never render it; it is a key, not a
+     * label. A guest has none, so a guest can only be muted for as long as
+     * their connection lasts. */
+    char account[40];
+
     char     text[256];
     int      is_local;   /* sent by this client */
     int      is_system;  /* join/leave/notice, not a player */
@@ -675,6 +702,9 @@ typedef struct RecompLauncherCNetplayCallbacks {
 
 /* Host may #ifdef this when wiring list_scope_set. */
 #define RECOMP_LAUNCHER_HAS_LIST_SCOPE 1
+
+/* Host may #ifdef this when filling the `account` key on player rows. */
+#define RECOMP_LAUNCHER_HAS_PLAYER_ACCOUNT 1
 enum {
     RECOMP_LAUNCHER_LIST_SCOPE_ANY = 0,
     RECOMP_LAUNCHER_LIST_SCOPE_LAN = 1,

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -621,6 +621,19 @@ typedef struct RecompLauncherCNetplayCallbacks {
      * The queue / accept callbacks land with the flow itself; this one is
      * here first so the button is gated on a real capability rather than
      * offered and then found not to work. */
+    /* Which lobbies the browser should be shown: 0 = every source (the
+     * historical behaviour), 1 = LAN / Direct IP only, 2 = the lobby server
+     * only.
+     *
+     * The backend merges its LAN registry and beacon rows with the server's
+     * list, and only the UI knows which fork the player took on the way in --
+     * so the scope has to travel. Without it a player who chose "LAN / Direct
+     * IP" was shown online rooms they had no connection for, and a player who
+     * chose online was shown LAN rooms from their own machine.
+     *
+     * Appended for ABI stability; a backend without it keeps merging. */
+    int         (*list_scope_set)(void* ctx, int scope);
+
     int         (*automatch_available)(void* ctx);
     /* The queue types this server offers for this title. Zero is a valid
      * answer and means the same as automatch_available saying no. */
@@ -659,6 +672,14 @@ typedef struct RecompLauncherCNetplayCallbacks {
 /* Present since automatch_available was added. Guarded the same way, for
  * the same reason: a game pins a recomp-ui and the two move separately. */
 #define RECOMP_LAUNCHER_HAS_AUTOMATCH 1
+
+/* Host may #ifdef this when wiring list_scope_set. */
+#define RECOMP_LAUNCHER_HAS_LIST_SCOPE 1
+enum {
+    RECOMP_LAUNCHER_LIST_SCOPE_ANY = 0,
+    RECOMP_LAUNCHER_LIST_SCOPE_LAN = 1,
+    RECOMP_LAUNCHER_LIST_SCOPE_ONLINE = 2
+};
 
 /* account_state() values. Guest is not an error and not a lesser state: it is
  * the launcher's original behaviour, and most players will sit in it. */

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -228,6 +228,13 @@ typedef struct RecompLauncherCNetplayFound {
 
 typedef struct RecompLauncherCNetplayChatMessage {
     char     from[64];   /* display name; empty for a system line */
+    /* The SERVER's id for this line. A report names this and never the text:
+     * chat already passes through the server, so it has the words, and
+     * letting a report carry them would let anyone compose a message,
+     * attribute it to somebody, and have them sanctioned for words they never
+     * typed. Empty when the server predates ids -- such a line simply cannot
+     * be reported, because there is no agreed referent for it. */
+    char     mid[40];
     /* Opaque, stable id for the ACCOUNT behind this player; "" for a guest.
      *
      * Not a name and not a Discord identifier -- the server's own row key,
@@ -659,6 +666,22 @@ typedef struct RecompLauncherCNetplayCallbacks {
      * chose online was shown LAN rooms from their own machine.
      *
      * Appended for ABI stability; a backend without it keeps merging. */
+    /* Report chat lines for moderation. `mids` are RecompLauncherCNetplay-
+     * ChatMessage.mid values -- several at once, because harassment is
+     * usually a burst rather than a line, and making somebody file six
+     * reports for one incident produces six rows that each look minor.
+     *
+     * `reason` is a category string; anything unrecognised is filed as
+     * "other" rather than refused. `note` is optional.
+     *
+     * 0 means handed to the server, NOT accepted: it refuses a line that has
+     * scrolled out of its ring, one from a signed-out sender, one that is
+     * your own, and anything over the per-account rate limit.
+     *
+     * NULL hides the report affordance entirely. Appended for ABI stability. */
+    int         (*chat_report)(void* ctx, const char* const* mids, int mid_count,
+                               const char* reason, const char* note);
+
     int         (*list_scope_set)(void* ctx, int scope);
 
     int         (*automatch_available)(void* ctx);
@@ -705,6 +728,19 @@ typedef struct RecompLauncherCNetplayCallbacks {
 
 /* Host may #ifdef this when filling the `account` key on player rows. */
 #define RECOMP_LAUNCHER_HAS_PLAYER_ACCOUNT 1
+
+/* Host may #ifdef this when wiring chat_report / filling ChatMessage.mid. */
+#define RECOMP_LAUNCHER_HAS_CHAT_REPORT 1
+/* The categories the server matches on. Same list on every console; an
+ * unrecognised one is stored as "other" rather than refused. */
+#define RECOMP_LAUNCHER_REPORT_HARASSMENT     "harassment"
+#define RECOMP_LAUNCHER_REPORT_HATE_SPEECH    "hate_speech"
+#define RECOMP_LAUNCHER_REPORT_SEXUAL_CONTENT "sexual_content"
+#define RECOMP_LAUNCHER_REPORT_SPAM           "spam"
+#define RECOMP_LAUNCHER_REPORT_THREATS        "threats"
+#define RECOMP_LAUNCHER_REPORT_CHEATING       "cheating_claim"
+#define RECOMP_LAUNCHER_REPORT_OTHER          "other"
+#define RECOMP_LAUNCHER_REPORT_NOTE_MAX 500
 enum {
     RECOMP_LAUNCHER_LIST_SCOPE_ANY = 0,
     RECOMP_LAUNCHER_LIST_SCOPE_LAN = 1,

--- a/src/recomp_launcher.h
+++ b/src/recomp_launcher.h
@@ -45,6 +45,8 @@ extern "C" {
 #define RECOMP_LAUNCHER_HAS_REWIND_INTERVAL 1
 /* Host may #ifdef this when reading Settings.rewind_enabled. */
 #define RECOMP_LAUNCHER_HAS_REWIND_ENABLED 1
+/* Host may #ifdef this when reading Settings.run_ahead. */
+#define RECOMP_LAUNCHER_HAS_RUN_AHEAD 1
 /* Host may #ifdef this when reading Settings.vsync. */
 #define RECOMP_LAUNCHER_HAS_VSYNC 1
 /* Host may #ifdef this when reading Settings.virtual_stylus. */
@@ -1183,7 +1185,31 @@ struct RecompLauncherCSettings {
      * Costs half a frame of motion ghosting. 0 = off (the faithful
      * default). Appended for ABI stability. */
     int  frame_blend;
+
+    /* Run-ahead depth in frames (GameInfo.has_run_ahead consoles): how many
+     * frames the runtime speculates past the one being shown, so that the
+     * game's own internal input latency is hidden. The runtime advances the
+     * machine, snapshots, runs N more frames with the same input, presents
+     * the last one, then restores -- so the picture the player sees is the
+     * one their input will have produced N frames from now.
+     *
+     * Costs N extra emulated frames per displayed frame, and it is strictly
+     * a LOCAL prediction: a peer cannot be speculated about, so a host must
+     * refuse it during netplay regardless of this value.
+     *
+     * 0 = off, which is both "unset" and the faithful default -- a
+     * zero-initialized host predating this field gets exactly the behavior
+     * it had. RECOMP_LAUNCHER_RUN_AHEAD_MAX bounds what the UI offers.
+     * Appended for ABI stability. */
+    int  run_ahead;
 };
+
+/* Largest run-ahead depth the launcher will offer for
+ * RecompLauncherCSettings.run_ahead. Deeper than this and the cost (one full
+ * extra emulated frame each) buys latency the player cannot feel, while the
+ * mispredictions a deep speculation makes become visible. A host whose
+ * runtime clamps lower still clamps on read; the UI never offers more. */
+#define RECOMP_LAUNCHER_RUN_AHEAD_MAX 4
 
 /* Values for RecompLauncherCSettings.vsync (1-based; 0 = unset). */
 #define RECOMP_LAUNCHER_VSYNC_ON       1
@@ -1784,6 +1810,11 @@ typedef struct RecompLauncherCGameInfo {
      * so a console that leaves this unset keeps exactly today's settings
      * surface. Appended for ABI stability. */
     int has_frame_blend;
+
+    /* Display row (cycle) for Settings.run_ahead. 0 => no row drawn, so a
+     * console whose runtime cannot snapshot-and-restore a frame keeps
+     * exactly today's settings surface. Appended for ABI stability. */
+    int has_run_ahead;
 } RecompLauncherCGameInfo;
 
 /* recomp_launcher_run_window return codes */

--- a/src/recomp_moderation.h
+++ b/src/recomp_moderation.h
@@ -1,0 +1,88 @@
+#ifndef RECOMP_MODERATION_H
+#define RECOMP_MODERATION_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Per-player moderation the LOCAL player controls: who they would rather not
+ * hear from, and who they would rather not meet.
+ *
+ * WHAT THIS IS KEYED ON, AND WHY IT MATTERS
+ * -----------------------------------------
+ * An opaque account id published by the lobby server -- never a display name.
+ * A name is not an identity here: the server's own schema calls its handle
+ * "never an identity, is not unique" and player-editable. A list keyed on one
+ * blocks whoever renames INTO that name and frees whoever renames out of it,
+ * which is worse than having no list at all.
+ *
+ * A guest has no account and therefore no key. Ignoring one works for as long
+ * as their connection lasts and is not written down -- an honest nothing
+ * rather than a promise the wire cannot keep.
+ *
+ * IGNORE vs BLOCK
+ * ---------------
+ *   ignored  their chat lines are not shown. They may still share a lobby.
+ *   blocked  everything ignore does, and they are hidden from the players
+ *            list and their rooms from the browser, and the queue is asked
+ *            not to pair you.
+ *
+ * Block implies ignore; the store keeps that true so no caller has to.
+ *
+ * ONLINE ONLY. A LAN / Direct IP room has no accounts and no server to have
+ * published one, so the surface is not offered there at all.
+ */
+
+#define RECOMP_MOD_KEY_CAP  40
+#define RECOMP_MOD_NAME_CAP 64
+
+typedef enum RecompModLevel {
+    RECOMP_MOD_NONE = 0,
+    RECOMP_MOD_IGNORED = 1,
+    RECOMP_MOD_BLOCKED = 2
+} RecompModLevel;
+
+/*
+ * Load from `moderation.ini` beside the executable, creating nothing if it is
+ * absent. Safe to call more than once; a second call reloads.
+ */
+void recomp_moderation_load(const char *exe_dir);
+
+/* Written immediately on every change rather than at exit: a launcher that is
+ * killed, or a game that takes the process over, must not lose the fact that
+ * somebody was blocked. */
+int  recomp_moderation_save(void);
+
+RecompModLevel recomp_moderation_level(const char *account);
+int  recomp_moderation_is_ignored(const char *account);  /* ignored OR blocked */
+int  recomp_moderation_is_blocked(const char *account);
+
+/*
+ * `last_seen_name` is stored as a LABEL so the review list can show who an id
+ * belongs to. It is never matched on. NULL/"" keeps whatever label is there.
+ */
+void recomp_moderation_set(const char *account, const char *last_seen_name,
+                           RecompModLevel level);
+
+/* The review list, so a block can be undone without editing a file by hand. */
+int  recomp_moderation_count(void);
+int  recomp_moderation_get(int index, char *account_out, size_t account_cap,
+                           char *name_out, size_t name_cap,
+                           RecompModLevel *level_out);
+
+/*
+ * The blocked ids as one ';'-separated string, for handing to a backend that
+ * can ask the matchmaker not to pair you with them. Returns the length that
+ * WOULD be written, so truncation is detectable. Empty when nothing is
+ * blocked.
+ */
+int  recomp_moderation_blocked_list(char *out, size_t cap);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RECOMP_MODERATION_H */

--- a/tests/flash_guard_test.c
+++ b/tests/flash_guard_test.c
@@ -1,0 +1,227 @@
+/*
+ * recomp_flash_guard: does it actually flatten a strobe, and does it leave
+ * everything else alone?
+ *
+ * The second half matters as much as the first. A filter that dulled flashes
+ * by dulling the whole game would pass any test that only looked at a strobe,
+ * and would be found out by a player wondering why the game looks soft.
+ *
+ * Frames here are synthetic flat fills, because the guard's decision is taken
+ * on the frame MEAN and a flat fill is the cleanest way to set one. The
+ * amplitudes are not invented, though: FLASH_A and FLASH_B are the two
+ * measured plateaus of the Gundam Wing end-of-fight flash, mean RGB
+ * (31,26,140) and (152,153,150), a 68%-of-range step at 15 Hz.
+ */
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "recomp_flash_guard.h"
+
+#define W 64
+#define H 32
+
+static int fails;
+
+static void check(const char *what, int ok)
+{
+    printf("  %-58s %s\n", what, ok ? "ok" : "FAIL");
+    if (!ok) ++fails;
+}
+
+static void fill(uint32_t *f, int r, int g, int b)
+{
+    int i;
+    for (i = 0; i < W * H; ++i)
+        f[i] = 0xFF000000u | ((uint32_t)r << 16) | ((uint32_t)g << 8) |
+               (uint32_t)b;
+}
+
+/* Largest per-channel difference between two flat frames' first pixels. The
+ * frames the guard emits from flat inputs stay flat, so pixel 0 is the mean. */
+static int step_of(uint32_t a, uint32_t b)
+{
+    int i, mx = 0;
+    for (i = 0; i < 3; ++i) {
+        const int sa = (int)((a >> (i * 8)) & 0xFFu);
+        const int sb = (int)((b >> (i * 8)) & 0xFFu);
+        int d = sa - sb;
+        if (d < 0) d = -d;
+        if (d > mx) mx = d;
+    }
+    return mx;
+}
+
+/* The two measured plateaus, as R,G,B. */
+#define FLASH_A  31,  26, 140
+#define FLASH_B 152, 153, 150
+
+int main(void)
+{
+    static uint32_t frame[W * H];
+    RecompFlashGuard *g = recomp_flash_guard_create();
+    const size_t pitch = (size_t)W * 4u;
+    const int limit = kRecompFlashGuardStandard;
+
+    if (!g) { printf("create failed\n"); return 1; }
+    recomp_flash_guard_set_limit(g, limit);
+
+    printf("\n1. a NULL handle is legal and does nothing\n");
+    fill(frame, 10, 20, 30);
+    check("apply(NULL) returns 0",
+          recomp_flash_guard_apply(NULL, frame, W, H, pitch) == 0);
+    check("and did not touch the frame", frame[0] == (0xFF000000u | 0x0A141Eu));
+
+    printf("\n2. ordinary play passes through byte-identical\n");
+    {
+        /* Steps of 4 per frame: a scrolling background, a fading sprite --
+         * anything under the limit. Nothing may be mixed, and the pixels must
+         * come back EXACTLY, not merely close: a filter that rounds every
+         * frame of the game is a filter that degrades it. */
+        int i, mixed = 0, exact = 1;
+        recomp_flash_guard_reset(g);
+        for (i = 0; i < 40; ++i) {
+            const int v = 60 + (i * 4);
+            fill(frame, v, v, v);
+            if (recomp_flash_guard_apply(g, frame, W, H, pitch)) ++mixed;
+            if (frame[0] != (0xFF000000u | ((uint32_t)v << 16) |
+                             ((uint32_t)v << 8) | (uint32_t)v))
+                exact = 0;
+        }
+        check("no frame was mixed", mixed == 0);
+        check("every frame came back byte-identical", exact);
+    }
+
+    printf("\n3. a scene cut cuts, it does not fade\n");
+    {
+        /* One large step that does not come back. The guard is allowed to
+         * ramp briefly, but it must arrive -- a permanent soft fade on every
+         * stage load would be a worse bug than the one it fixes. */
+        int i, settled = -1;
+        recomp_flash_guard_reset(g);
+        fill(frame, 20, 20, 20);
+        recomp_flash_guard_apply(g, frame, W, H, pitch);
+        for (i = 0; i < 10; ++i) {
+            fill(frame, 220, 220, 220);
+            recomp_flash_guard_apply(g, frame, W, H, pitch);
+            if (settled < 0 && frame[0] == (0xFF000000u | 0xDCDCDCu))
+                settled = i;
+        }
+        check("reached the new scene exactly", settled >= 0);
+        check("within three frames of the cut", settled >= 0 && settled <= 2);
+    }
+
+    printf("\n4. the measured 15 Hz strobe is flattened\n");
+    {
+        /* Two guest frames per phase, which is what was measured -- and is
+         * also why frame blending does not help: it averages a frame with its
+         * own twin. */
+        int i, worst_src = 0, worst_out = 0;
+        uint32_t prev_out = 0, prev_src = 0;
+        recomp_flash_guard_reset(g);
+        for (i = 0; i < 80; ++i) {
+            const int phase = (i / 2) & 1;
+            uint32_t src;
+            if (phase) fill(frame, FLASH_B); else fill(frame, FLASH_A);
+            src = frame[0];
+            recomp_flash_guard_apply(g, frame, W, H, pitch);
+            if (i) {
+                const int ss = step_of(src, prev_src);
+                const int os = step_of(frame[0], prev_out);
+                if (ss > worst_src) worst_src = ss;
+                /* Skip the first few frames: the guard is entering the flash
+                 * and legitimately still catching up. */
+                if (i > 6 && os > worst_out) worst_out = os;
+            }
+            prev_src = src;
+            prev_out = frame[0];
+        }
+        printf("     source step %d/255, guarded step %d/255\n",
+               worst_src, worst_out);
+        check("the source really is a violent strobe (>100/255)",
+              worst_src > 100);
+        check("the guarded step never exceeds the limit",
+              worst_out <= limit);
+        check("which is under the WCAG 10% flash threshold (26/255)",
+              worst_out < 26);
+    }
+
+    printf("\n5. the guard says what it did\n");
+    {
+        RecompFlashGuardStats st;
+        recomp_flash_guard_get_stats(g, &st);
+        printf("     frames=%llu limited=%llu events=%llu peak=%d\n",
+               (unsigned long long)st.frames, (unsigned long long)st.limited,
+               (unsigned long long)st.events, st.peak_step);
+        check("it counted frames", st.frames > 0);
+        check("it counted the mixing it did", st.limited > 0);
+        check("it detected a flash event", st.events >= 1);
+        check("and reports the source amplitude it saw", st.peak_step > 100);
+    }
+
+    printf("\n6. a slower strobe is flattened too\n");
+    {
+        /* Four guest frames per phase -- 7.5 Hz, still inside the risk band.
+         * This is the case a fixed "release after N frames" rule gets wrong:
+         * the phase outlasts the release counter, so the guard would let the
+         * strobe through if the reversal hold were not what disables release.
+         */
+        int i, worst_out = 0;
+        uint32_t prev_out = 0;
+        recomp_flash_guard_reset(g);
+        for (i = 0; i < 96; ++i) {
+            const int phase = (i / 4) & 1;
+            if (phase) fill(frame, FLASH_B); else fill(frame, FLASH_A);
+            recomp_flash_guard_apply(g, frame, W, H, pitch);
+            if (i > 10) {
+                const int os = step_of(frame[0], prev_out);
+                if (os > worst_out) worst_out = os;
+            }
+            prev_out = frame[0];
+        }
+        printf("     guarded step %d/255\n", worst_out);
+        check("still never exceeds the limit", worst_out <= limit);
+    }
+
+    printf("\n7. strength changes the amplitude, and off means off\n");
+    {
+        const int limits[3] = { kRecompFlashGuardMild,
+                                kRecompFlashGuardStandard,
+                                kRecompFlashGuardMaximum };
+        int k;
+        int ok = 1;
+        for (k = 0; k < 3; ++k) {
+            int i, worst = 0;
+            uint32_t prev = 0;
+            recomp_flash_guard_reset(g);
+            recomp_flash_guard_set_limit(g, limits[k]);
+            for (i = 0; i < 60; ++i) {
+                const int phase = (i / 2) & 1;
+                if (phase) fill(frame, FLASH_B); else fill(frame, FLASH_A);
+                recomp_flash_guard_apply(g, frame, W, H, pitch);
+                if (i > 6) {
+                    const int os = step_of(frame[0], prev);
+                    if (os > worst) worst = os;
+                }
+                prev = frame[0];
+            }
+            printf("     limit %3d -> guarded step %d/255\n", limits[k], worst);
+            if (worst > limits[k]) ok = 0;
+        }
+        check("each strength honours its own limit", ok);
+
+        recomp_flash_guard_set_limit(g, 0);
+        recomp_flash_guard_reset(g);
+        fill(frame, FLASH_A);
+        recomp_flash_guard_apply(g, frame, W, H, pitch);
+        fill(frame, FLASH_B);
+        check("limit 0 leaves the frame completely alone",
+              recomp_flash_guard_apply(g, frame, W, H, pitch) == 0 &&
+              frame[0] == (0xFF000000u | 0x989996u));
+    }
+
+    recomp_flash_guard_destroy(g);
+    printf("\n%s (%d failure%s)\n", fails ? "FAILED" : "PASSED",
+           fails, fails == 1 ? "" : "s");
+    return fails ? 1 : 0;
+}

--- a/tests/launcher_video_pick_test.c
+++ b/tests/launcher_video_pick_test.c
@@ -1,0 +1,86 @@
+/* Renderer and VSync as LISTS, not cycles.
+ *
+ * These two rows were click-to-cycle buttons. With a host-supplied renderer
+ * vocabulary of five entries, reaching the last one meant four clicks and
+ * counting, so they became dropdowns -- which needs enumerate-and-set rather
+ * than next(). The risk in that change is the three-way precedence the label
+ * getter has always had (game labels, then console profile pair, then the
+ * legacy pair): a dropdown that enumerates one vocabulary while the label
+ * shows another would offer entries that do not match what is selected.
+ */
+#include "launcher_model.c"
+
+#include <stdio.h>
+#include <string.h>
+
+void launcher_binds_set_zapper(int a, int b);
+void launcher_binds_set_zapper(int a, int b) { (void)a; (void)b; }
+
+static int fails;
+static void ok(int cond, const char* what) {
+    printf("  %s  %s\n", cond ? "ok  " : "FAIL", what);
+    if (!cond) fails++;
+}
+
+int main(void) {
+    static LauncherModel m;
+    static const char* const kLabels[] = {
+        "Auto", "Direct3D 11", "Direct3D 9", "OpenGL", "Software",
+    };
+
+    /* ---- game-supplied vocabulary (the Gundam Wing case) ---------------- */
+    memset(&m, 0, sizeof(m));
+    m.has_renderer = true;
+    m.renderer_labels = kLabels;
+    m.num_renderers = 5;
+
+    ok(launcher_model_renderer_count(&m) == 5, "count follows the game's vocabulary");
+    ok(strcmp(launcher_model_renderer_label_at(&m, 0), "Auto") == 0,
+       "index 0 is Auto");
+    ok(strcmp(launcher_model_renderer_label_at(&m, 4), "Software") == 0,
+       "the last entry is reachable directly, without cycling to it");
+
+    launcher_model_set_renderer(&m, 4);
+    ok(m.s.renderer == 4, "set lands on the requested index");
+    ok(strcmp(launcher_model_renderer_label(&m), "Software") == 0,
+       "and the label the combo shows agrees with what is selected");
+
+    launcher_model_set_renderer(&m, 99);
+    ok(m.s.renderer == 4, "an out-of-range index clamps rather than wrapping to Auto");
+    launcher_model_set_renderer(&m, -1);
+    ok(m.s.renderer == 0, "and clamps at the bottom too");
+
+    /* ---- legacy pair: no game vocabulary, no profile -------------------- */
+    memset(&m, 0, sizeof(m));
+    m.has_renderer = true;
+    ok(launcher_model_renderer_count(&m) == 2, "legacy surface enumerates two");
+    ok(strcmp(launcher_model_renderer_label_at(&m, 0), "Software") == 0 &&
+       strcmp(launcher_model_renderer_label_at(&m, 1), "OpenGL") == 0,
+       "with the legacy pair, in the order the label getter uses");
+    launcher_model_set_renderer(&m, 1);
+    ok(strcmp(launcher_model_renderer_label(&m), "OpenGL") == 0,
+       "label still agrees on the legacy surface");
+
+    /* ---- vsync takes VALUES, not indices -------------------------------- */
+    memset(&m, 0, sizeof(m));
+    m.has_vsync = true;
+    launcher_model_set_vsync(&m, RECOMP_LAUNCHER_VSYNC_ADAPTIVE);
+    ok(m.s.vsync == RECOMP_LAUNCHER_VSYNC_ADAPTIVE &&
+       strcmp(launcher_model_vsync_label(&m), "Adaptive") == 0,
+       "adaptive is selectable directly");
+    launcher_model_set_vsync(&m, RECOMP_LAUNCHER_VSYNC_OFF);
+    ok(strcmp(launcher_model_vsync_label(&m), "Off") == 0, "and Off");
+    launcher_model_set_vsync(&m, 12345);
+    ok(m.s.vsync == RECOMP_LAUNCHER_VSYNC_OFF,
+       "a value outside the vocabulary is refused, not stored");
+
+    /* A host that does not offer the control must not be edited by it. */
+    memset(&m, 0, sizeof(m));
+    launcher_model_set_renderer(&m, 3);
+    launcher_model_set_vsync(&m, RECOMP_LAUNCHER_VSYNC_ON);
+    ok(m.s.renderer == 0 && m.s.vsync == 0,
+       "neither setter writes when the console does not have the control");
+
+    printf(fails ? "FAILED\n" : "PASSED\n");
+    return fails;
+}


### PR DESCRIPTION
Launcher work that accumulated on `feat/discord-login`: optional Discord sign-in, the LAN/online split, the automatch UI, and the moderation controls.

Low regression risk by construction — this is launcher UI and settings plumbing. Nothing here touches a recompiler, a runtime or a save state, and every runner-facing addition is behind a capability flag so a runner that has not opted in draws exactly what it drew before.

### Accounts and sign-in
- Optional Discord sign-in in the Player Name modal, with the device key.
- `RECOMP_LAUNCHER_HAS_ACCOUNT`, so runners can land in either order rather than needing a lockstep bump.
- Online play requires an account; LAN does not. The online name and the LAN name are two different names.
- Hold ONLINE until the quiet sign-in has answered; offer Retry when one drags; a signed-in rename reaches the lobby, and Cancel stays on the page.

### Netplay
- LAN and online fork before the lobby browser, so the two paths stop borrowing each other's state.
- Online gets an Automatch button where LAN keeps Join Direct.
- The accept gate says when it declines, and names a cooldown.

### Moderation
- Right-click a player to ignore or block them.
- **Report Message**, on chat lines only.
- The block list is pushed to the server and resent on reconnect.

### Display and binds
- Renderer and VSync are dropdowns rather than cycle buttons.
- SNES offers the Rewind bind now that there is a rewind, and the save-state menu bind is reachable in the Hotkeys panel.
- Photosensitivity flash-reduction filter (`recomp_flash_guard.{h,c}`) — a shared presentation capability, inert until a host creates one. Measured on a player capture of a 15 Hz full-screen strobe: peak frame-to-frame step 173/255 down to 13/255, and the flashes crossing the WCAG 2.3.1 threshold from nineteen to zero. Frames already changing slowly pass through byte-identical, so ordinary play is untouched. Covered by `tests/flash_guard_test.c` (CTest target `recomp-ui-flash-guard`, ROM-free).

### Notes for review
- `master` is merged in (#54), so this is mergeable with no rebase. That merge carried one real conflict, in `draw_display_controls`: `master` added a display aspect row while this branch had refactored the same function off its label-measuring pass onto right-anchored rows. Resolved to this branch's layout with the aspect row re-applied in it — `draw_aspect_row` loses its now-meaningless `col_w` and reserves the EXPERIMENTAL tag's width alongside the button's, so the tag cannot hang off the card edge on hosts that set the flag. Verified on both surfaces (GBA legacy with the flag set, PSX deep).
- `recomp_flash_guard` ships **off**. Whether a title enables it is that game's policy, decided in the game repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MoCenwWdTALkvzUtkr8coQ

